### PR TITLE
chore: rename product to CatatMD and record live deployment URLs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,24 @@
-# AI Clinical Assistant
+# CatatMD
 
 An assistant that turns a GP consultation transcript into a **reviewable** structured clinical note — with missing-information prompts, red-flag detection, and clinical suggestions carrying real citations.
+
+_Catat_ — Malay, "to note down". The product documents; the doctor decides.
 
 > **The doctor decides.** This system does not diagnose and does not replace clinical judgement. Every output is reviewed, edited, and explicitly approved by the clinician, who remains fully responsible for all medical decisions. All consultation data in this repository is **simulated**.
 
 **Clinical scope:** adult GP consultations for acute cough, sore throat, and other upper respiratory symptoms.
+
+---
+
+## Live
+
+| Component    | URL                                                      | Host                |
+| ------------ | -------------------------------------------------------- | ------------------- |
+| **Frontend** | https://catatmd.vercel.app                               | Vercel              |
+| **API**      | https://catatmd-api.onrender.com · health: `/api/health` | Render, Singapore   |
+| **Database** | not publicly reachable — API-only access                 | Supabase, Singapore |
+
+Both are on free tiers by design. Render free instances spin down when idle, so a first request after a quiet period may take up to a minute to answer while the instance wakes — see `docs/trd.md` §17.
 
 ---
 
@@ -98,6 +112,8 @@ bun run test                  # vitest
 ```
 
 `BETTER_AUTH_SECRET` — generate with `openssl rand -base64 32`.
+
+`PORT` defaults to `3001`, which is commonly taken (Grafana, other dev servers). Set `PORT` and `BETTER_AUTH_URL` together in `.env` if you move it — better-auth's URL must match the origin the API actually serves on.
 
 ---
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI Clinical Assistant</title>
+    <title>CatatMD</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 export function App() {
   return (
     <main className="grid min-h-dvh place-items-center">
-      <p className="text-sm text-neutral-500">AI Clinical Assistant — scaffold</p>
+      <p className="text-sm text-neutral-500">CatatMD — scaffold</p>
     </main>
   )
 }

--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: web
-    name: ai-clinical-assistant-api
+    name: catatmd-api
     runtime: node
     region: singapore
     plan: free


### PR DESCRIPTION
## Summary

Product name settled as **CatatMD**, applied across every surface, plus the first deployment of both tiers.

`Catat` is Malay for "to note down" — it names the documentation function rather than a diagnostic one. That distinction is load-bearing, not aesthetic: `docs/prd.md`'s regulatory positioning under Medical Device Act 737 rests on the system not diagnosing, so a name implying diagnosis would argue against our own compliance section.

## ⚠️ Action required for @Andersonnn7788

**The repository has been renamed** — `ai-clinical-assistant` → `catatmd`. GitHub redirects the old path, but update your remote:

```
git remote set-url origin https://github.com/AlaskanTuna/catatmd.git
```

## Live

| Component | URL | Host |
| --- | --- | --- |
| Frontend | https://catatmd.vercel.app | Vercel |
| API | https://catatmd-api.onrender.com/api/health | Render, Singapore |
| Database | API-only | Supabase, Singapore |

Both verified publicly reachable and talking to each other — CORS scoped to the Vercel origin with credentials, API answering `200 {"status":"ok","provider":"qwen"}` against live Supabase Singapore.

## Rename mechanics worth knowing

- **Render's `onrender.com` subdomain is immutable.** Renaming the service kept the old URL, so the service was recreated to claim `catatmd-api`.
- **Vercel's `.vercel.app` alias does not follow a project rename** either; `catatmd.vercel.app` was claimed explicitly.
- **Vercel SSO protection was on** (`all_except_custom_domains`), so every deployment URL served a login wall instead of the app. Disabled — this is a public demo with synthetic data and no clinical code yet.
- **Supabase keeps its permanent project ref**, so its rename is cosmetic and connection strings are unaffected.

## Changes

- `docs/README.md` — title, Live section with both URLs, and a note that `PORT`'s 3001 default is commonly taken and must move together with `BETTER_AUTH_URL`
- `render.yaml` — service name
- `frontend/index.html`, `frontend/src/App.tsx` — title and scaffold text

## Clinical-Safety Checklist

- [x] No change to `deid/`, `lib/llm/`, `redflags/`, `guidelines/`, or logging
- [x] No transcript, note, or vault content logged
- [x] No real patient data; no fixtures added