### PR TITLE
docs: add session kickoff briefs for the parallel build tracks

### DIFF
--- a/docs/kickoff-backend-session.md
+++ b/docs/kickoff-backend-session.md
@@ -1,0 +1,129 @@
+# Kickoff — CatatMD backend session (@Andersonnn7788)
+
+> **A dated session brief, not standing policy.** Written 13/08/26 to start parallel build sessions after `docs/prd.md` and `docs/trd.md` were finalised. Committed so both collaborators' agents work from the same instructions. The canonical, durable rules live in `AGENTS.md` — where this brief and `AGENTS.md` disagree, `AGENTS.md` wins.
+
+You are working on **CatatMD** — the `catatmd` repository — on behalf of **@Andersonnn7788**. Your lane is the backend. Work from wherever your local clone lives.
+
+---
+
+## First: two things that will block you if not done
+
+1. **The repository was renamed.** If your remote still points at `ai-clinical-assistant`, fix it before anything else:
+   ```bash
+   git remote set-url origin https://github.com/AlaskanTuna/catatmd.git
+   git fetch origin && git checkout main && git pull --rebase
+   ```
+2. **You need a local `.env`.** It is gitignored and carries real secrets — `DATABASE_URL`, `DIRECT_URL`, `BETTER_AUTH_SECRET`, `QWEN_API_KEY`. `.env.example` shows the shape but not the values. **If you do not have these, stop and comment on your first assigned issue tagging @AlaskanTuna to request them.** Do not invent placeholder values and do not commit anything resembling a secret.
+
+**Read before doing anything, in this order:** `AGENTS.md` (canonical project instructions — conventions, clinical-safety do-nots, commit rules) → `docs/prd.md` → `docs/trd.md` → your assigned issues on GitHub.
+
+Both `prd.md` and `trd.md` are **Final for the MVP** as of 13/08/26 — they are the contracts. Build against them; do not redesign them.
+
+> **Note on documents you will not find.** `docs/roles.md`, `docs/plan.md`, `docs/progress.md` and `docs/decisions.md` are part of a **git-excluded private workflow layer** on @AlaskanTuna's machine. They are not missing from your clone by accident and you are not expected to have them. Everything you need is in `AGENTS.md`, the two canonical documents, and the issues. Do not create local copies of them, and do not add them to the repository.
+
+---
+
+## What CatatMD is
+
+An assistant that turns a Malaysian GP consultation transcript into a **reviewable** structured clinical note — with documentation gaps, deterministic red-flag detection, and citation-constrained clinical suggestions. Clinical scope is narrow and deliberate: **adult acute cough, sore throat, and other upper respiratory symptoms.**
+
+The product does not diagnose and does not replace clinical judgement. Every output is reviewed, edited and explicitly approved by the doctor.
+
+**The thesis you are building:** the safety properties are _architectural_, not promised. De-identification is enforced at a single egress point that refuses un-gated input. Red flags come from a deterministic rules engine the model never sees. Citations are ID-constrained so a hallucinated reference is structurally impossible. **You own almost all of that** — four of the ten sections this project is evaluated on are about the code in your lane.
+
+---
+
+## Your lane, and its hard boundaries
+
+**Yours:** `backend/`, `prisma/`, and the Supabase database.
+
+**Not yours, under any circumstances:**
+
+- **Vercel and Render.** @AlaskanTuna owns all deployment. Do not deploy, do not change platform environment variables, do not run `vercel` or `render` CLI commands. If something needs a deployment change, comment on the issue and tag him.
+- **`frontend/`** — his, and a second agent is working it.
+- **`shared/`** — his. Issue #31 defines the schema contracts you build against. **If you need a change to a shared schema, do not edit it yourself.** Comment on #31 tagging @AlaskanTuna with exactly what you need and why.
+
+### ⚠ Database migrations — you are the only one who runs them
+
+Supabase is a **single shared instance**, not per-developer. Two people running `prisma migrate dev` against it will corrupt each other's migration history. You own schema migrations. Before creating one:
+
+- `git pull --rebase` first, always.
+- Run migrations against `DIRECT_URL` (port 5432), never the pooled URL.
+- Commit the generated migration directory in the same PR as the schema change.
+- Never edit or delete a migration that already exists on `main`.
+
+---
+
+## Reporting protocol — this is how you talk to @AlaskanTuna
+
+He is away and is not watching this session. **GitHub issue comments are the only channel.**
+
+- **When you complete a task:** comment on that issue with what changed, the PR number, what you verified (with real command output), and anything you deliberately did not do. Tag **@AlaskanTuna**.
+- **When you need a decision or are blocked:** comment on the relevant issue, tag **@AlaskanTuna**, state the question in one paragraph, give your recommended default, and say what you will do if he does not reply. **Then keep working on something else** — do not idle.
+- **Batch questions.** Surface everything you can foresee in your first pass rather than drip-feeding.
+
+---
+
+## Task order
+
+### Start immediately — these do not wait on #31
+
+| Issue   | Notes                                                                                                                                                                                                         |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **#14** | Auth, RBAC, secure data handling. Read the two pinned comments first — `sameSite: 'none'` is mandatory, not `lax`, and the failure mode is deceptive.                                                         |
+| **#29** | Guest sign-in. **Decided** — read the decision comment before building. Shared account, risk accepted, and the shared-visibility behaviour must be stated in the sign-in UI copy you provide.                 |
+| **#9**  | De-identification gate. **The single most important module in this repository.** See below.                                                                                                                   |
+| **#11** | Synthetic fixtures. Malaysian register: Manglish, **MC** not "sick note", panel patients, medicine dispensed at the clinic, NRIC, RM. Design them as _gradeable_ cases — one deliberately hard, one red-flag. |
+| **#8**  | Guideline corpus. NICE is **excluded** — its licence forbids AI use. Anchor on MOH NAG 2024, Abdullah et al. 2024, Ooi et al. 2022. One source per chunk; see below.                                          |
+
+### After #31 merges — watch that issue for the announcement
+
+**#7** (deterministic red-flag rules) → **#3** and **#5** (extraction, editable note) → **#4** and **#6** (Unknown ≠ Negative, gaps engine) → **#12** (persistence) → **#16** (versioning) → **#13** (clinical-safety acceptance suite).
+
+---
+
+## The three modules where a subtle mistake is a critical defect
+
+**#9 — the de-identification gate.** This is the direct answer to "how is patient data prevented from reaching the LLM", which is a scored proposal section. `LLMClient.generate()` accepts only a branded `Deidentified` string, so a plain `string` is a compile error. Detection is `pattern + score + context-words` (TRD §9), with NRIC structural validation and a Malaysian name gazetteer. The vault is **request-scoped** — never a module-level singleton, never persisted, never logged. **@AlaskanTuna will review this PR line by line.** Write it expecting that.
+
+**#7 — the red-flag rules engine.** A pure function library: zero side effects, zero I/O, **zero tolerance for false negatives**. The model never sees its output and may only _add_ candidates. A rule without a test asserting it fires is not done. Read the `healthcare-cdss-patterns` skill before starting.
+
+**#8 — the guideline corpus.** One source per chunk, always. MOH NAG 2024 and the 2024 Malaysian consensus **disagree** at Centor/McIsaac 3 — merging them would let the model cite a manufactured consensus through a _valid_ ID, which the ID-constraint mechanism structurally cannot catch. Carry `sourceLicence` and `verbatimAllowed`; NAG is all-rights-reserved (summarise and link, never quote).
+
+---
+
+## Hard constraints — violating any of these is a critical defect, not a style issue
+
+1. **No un-de-identified text reaches any LLM provider.** Every egress goes through `backend/src/deid/` then `LLMClient`. No direct provider SDK calls anywhere else in the codebase.
+2. **No hardcoded outputs, stubbed model calls, mocked red flags, or faked latency.** If the demo shows a note, the pipeline produced it. **This does not mean removing fixtures** — synthetic fixture _inputs_ are a clinical-safety mandate; hardcoded _outputs_ are what is banned.
+3. **The LLM may never suppress, downgrade, or filter a deterministic red-flag hit.**
+4. **No free-text citations.** Guideline IDs from the supplied corpus, validated at parse time.
+5. **`diagnosis` is transcription-bound.** It records only an impression the doctor stated, carries a verbatim transcript span, and defaults to `NOT_ASSESSED`. The system may never produce a diagnosis the doctor did not say.
+6. **Never log transcript bodies, note contents, or vault entries.** IDs and event types only.
+7. **`QWEN_MODEL` stays pinned to `qwen-flash`** — the only model on the account accepting JSON-Schema-constrained decoding. Read TRD §21.2 before touching it.
+8. **Confidentiality.** The client name, any fee figure, the engagement length, and the deadline-as-commitment must never appear in a tracked file, commit message, issue, or PR. Before every push:
+   ```bash
+   git ls-files -z | xargs -0 grep -nIiE "kabel|RM ?3,?000|8-week" | grep -v "dxp\.kabel\.my/candidate/projects" || echo CLEAN
+   ```
+9. **The PR Clinical-Safety Checklist is not optional** for any diff touching `deid/`, `lib/llm/`, `redflags/`, `guidelines/`, or logging.
+
+---
+
+## Shipping
+
+Feature branch → PR → `gh pr merge --squash --delete-branch`. **One PR per issue**, never one large one — @AlaskanTuna needs to review these independently. Always `git pull --rebase` before pushing; two humans and two agents share this repository.
+
+Conventional Commits: `<type>[scope]: <description>`, imperative, no trailing period.
+
+**Verify before claiming done.** `bun run lint`, `bun run typecheck`, `bun run test`. Paste real output into the issue comment. Never assert a pass you did not observe.
+
+**Your progress log is the issue tracker**, not a markdown file — the workflow documents that would normally carry it are outside your clone (see the note above). So: the PR body records what changed and why, and the issue comment records the outcome, the verification output, and anything deliberately left undone. Between them they are the durable record of your work. If you settle a lasting technical decision — a library choice, a convention, a resolved trade-off — say so explicitly in the PR body under a **Decision** heading so @AlaskanTuna can carry it into the decision ledger on his side.
+
+---
+
+## Working expectations
+
+- **TDD on #7, #4 and #9.** Write the failing test first.
+- **Surgical changes.** Every changed line traces to the issue you are working. Do not refactor what is not broken, and do not "improve" adjacent code.
+- **Report concisely, but never let brevity hide a problem.** Blockers, failed tests and skipped work are always stated explicitly.
+- If a contract in `docs/trd.md` turns out to be wrong or unbuildable, **say so on the issue** rather than silently deviating. The document is final, not infallible.

--- a/docs/kickoff-frontend-session.md
+++ b/docs/kickoff-frontend-session.md
@@ -1,0 +1,83 @@
+# Kickoff — CatatMD frontend + shared session (@AlaskanTuna)
+
+> **A dated session brief, not standing policy.** Written 13/08/26 to start parallel build sessions after `docs/prd.md` and `docs/trd.md` were finalised. Committed so both collaborators' agents work from the same instructions. The canonical, durable rules live in `AGENTS.md` — where this brief and `AGENTS.md` disagree, `AGENTS.md` wins.
+
+Continue the **CatatMD** project — the `catatmd` repository. Work from your local clone.
+
+**Read first, in this order, before doing anything:** `docs/roles.md` → tail of `docs/progress.md` → `docs/plan.md` → `docs/prd.md` → `docs/trd.md`. Both `prd.md` and `trd.md` are **Final for the MVP** as of 13/08/26 and are the canonical contracts — build against them, do not redesign them. `docs/decisions.md` is the decision ledger; read it and append to it, never rewrite it.
+
+---
+
+## Operating mode for this session
+
+- **I am away. Run solo.** Do not block waiting for me. If you hit a genuine fork, pick the option you can best defend, state the assumption plainly, and keep going.
+- **Surface every decision you need from me in your FIRST message**, batched, before you start work. Then proceed on your stated defaults. Do not drip-feed questions across the session.
+- **Leave anything needing my visual judgement until last.** I am doing the frontend; work that requires eyeballing a rendered UI is mine, not yours.
+- **Gate 2 authorisation was granted for the dated session this brief was written for (13/08/26), and does not carry forward.** For that session only: Ship per the project's `pr-auto` mode: feature branch → PR → `gh pr merge --squash --delete-branch`. One PR per issue, not one giant PR. Small fixes may go straight to `main`. Always `git pull --rebase` before pushing — two humans share this repo.
+- **A general-purpose peer session is running in the background.** Use `ListAgents` then `SendMessage` to delegate genuinely disjoint work. Give it a self-contained brief with an explicit file scope, and tell it not to commit. Never let two agents edit the same file.
+- **Announce `shared/` the moment it lands.** A second developer (@Andersonnn7788) is blocked until then.
+
+---
+
+## ⚠ Lane discipline — a second agent is working the backend in parallel
+
+@Andersonnn7788 has his own agent session running **all backend issues** (#3, #4, #5, #6, #7, #8, #9, #11, #12, #13, #14, #16, #29). **Those are not yours. Do not touch `backend/`, `prisma/`, or any file under them.** Two agents editing the same module is how a safety-critical diff gets silently clobbered.
+
+Your lane is `shared/`, `frontend/`, and deployment configuration. Nothing else.
+
+## Task order
+
+### Wave 0 — the blocker. Ship this first, then announce it.
+
+**#31 — shared schema contracts.** `ClinicalAssertionSchema`, the Malaysian operational block, `Transcript.source`, and the two response schemas from TRD §12. Timeboxed to hours.
+
+Read the issue; the load-bearing details are safety properties, not preferences — especially that `NOT_ASSESSED` must be the cheapest, most default path, and that the verbatim-span requirement binds `state`, not `value`.
+
+**The moment it merges, comment on #31 saying so.** The backend agent is partially blocked until then and is watching that issue.
+
+### Wave 1 — yours, after #31.
+
+- **#15** — privacy-safe logging and tracing. IDs and event types only; never transcript bodies, note contents, or vault entries.
+- **Deployment configuration** — `vercel.json`, `render.yaml`, environment variables. You own Vercel and Render exclusively; the backend agent has been told not to touch either.
+
+### Wave 2 — DO NOT START. These are mine.
+
+**#2, #10, #26, #28, #30** — all frontend, all needing my eyes on a rendered screen.
+
+If you run out of lane-safe work, **stop and report** rather than reaching into `backend/` or starting UI. Writing failing tests for the frontend issues is acceptable; building screens is not.
+
+---
+
+## Hard constraints — violating any of these is a critical defect, not a style issue
+
+1. **No un-de-identified text reaches any LLM provider.** Every egress goes through `backend/src/deid/` then `LLMClient`. No direct provider SDK calls anywhere else.
+2. **No hardcoded outputs, stubbed model calls, mocked red flags, or faked latency.** If the demo shows a note, the pipeline produced it. **This does not mean removing the fixtures** — synthetic fixture _inputs_ are a clinical-safety mandate; hardcoded _outputs_ are what is banned. The distinction is load-bearing.
+3. **The LLM may never suppress, downgrade, or filter a deterministic red-flag hit.** It may only add candidates.
+4. **No free-text citations.** Guideline IDs from the supplied corpus, validated at parse time.
+5. **`diagnosis` is transcription-bound.** It records only an impression the doctor stated, carries a verbatim span, and defaults to `NOT_ASSESSED`. The system may never produce a diagnosis the doctor did not say.
+6. **Never log transcript bodies, note contents, or de-identification vault entries.** IDs and event types only.
+7. **Confidentiality.** The client name, any fee figure, the engagement length, and the deadline-as-commitment must never appear in a tracked file, commit message, issue, or PR. Before every push:
+   ```
+   git ls-files -z | xargs -0 grep -nIiE "kabel|RM ?3,?000|8-week" | grep -v "dxp\.kabel\.my/candidate/projects" || echo CLEAN
+   ```
+8. **The PR Clinical-Safety Checklist is not optional** for any diff touching `deid/`, `lib/llm/`, `redflags/`, `guidelines/`, or logging.
+
+---
+
+## Working expectations
+
+- **TDD where it matters.** #7, #4 and #9 especially: write the failing test first, then make it pass. A red-flag rule without a test asserting it fires is not done.
+- **Surgical changes.** Every changed line traces to the issue you are working. Do not refactor what is not broken.
+- **Tick `docs/plan.md`, append to `docs/progress.md`** after each task. Append one line to `docs/decisions.md` for anything that settles a lasting choice.
+- **Verify before claiming done.** `bun run lint`, `bun run typecheck`, `bun run test`. Paste real output; never assert a pass you did not observe.
+- **Report concisely.** Lead with the outcome. Blockers, failed tests and skipped work are always stated explicitly, even when everything else is compressed.
+
+---
+
+## Known-good state as of this kickoff
+
+- `main` is at the squash-merge of PR #32; working tree clean; only `main` exists on the remote.
+- Deployed and live: frontend `https://catatmd.vercel.app`, API `https://catatmd-api.onrender.com/api/health`, DB Supabase Singapore. Keep-alive pings every 10 minutes from an external scheduler.
+- `QWEN_MODEL` is pinned to `qwen-flash` — the only model on the account that accepts JSON-Schema-constrained decoding. Do not change it without re-reading TRD §21.2.
+- `graphify-out/` is refreshed by a post-commit hook; its churn is expected and not yours.
+- 24 issues open, 18 in the **MVP submission** milestone.


### PR DESCRIPTION
Commits the two agent briefs so both collaborators' sessions work from the same instructions.

Documentation only — no file under `backend/`, `frontend/`, `shared/` or `prisma/` is touched.

## Why commit them rather than paste them

The backend brief instructs @Andersonnn7788's session to read it from the repository. Left uncommitted it would never reach his clone.

Committing also fixed a defect that pasting would have hidden: the brief originally told him to read `docs/roles.md`, `docs/plan.md`, `docs/progress.md` and `docs/decisions.md`. **All four are in the git-excluded private workflow layer and have never existed in his checkout.** The reading order now references only `AGENTS.md`, `docs/prd.md`, `docs/trd.md` and the issues, and states plainly that those four are deliberately excluded rather than missing.

## Lane split

| | Owns | Explicitly excluded from |
| --- | --- | --- |
| Backend brief | `backend/`, `prisma/`, Supabase | Vercel, Render, `frontend/`, `shared/` |
| Frontend brief | `shared/`, `frontend/`, deployment config | `backend/`, `prisma/` |

Two coordination hazards are written in:

- **Migrations.** Supabase is a single shared instance. The backend brief names @Andersonnn7788 as the sole owner of `prisma migrate`; concurrent runs would corrupt migration history.
- **#31 is the only synchronisation point.** The frontend session ships the shared schemas and comments on #31; the backend session watches that issue and holds #7 onward until it lands.

## Scoping

Both files carry a header stating they are **dated session briefs, not standing policy**, and that `AGENTS.md` wins on any disagreement. The Gate 2 commit authorisation in the frontend brief is scoped to the dated session it was written for, so a future agent reading the repository does not treat it as blanket permission to commit.

## Verification

- Confidentiality grep CLEAN — the local filesystem path carrying the client name was removed from both briefs
- Every file referenced in the backend brief's reading order exists in a fresh clone
- `bunx prettier --write` clean

https://claude.ai/code/session_01QnReAqbZdxbukVcPF3o1S6