### PR TITLE
feat(shared): land the schema contracts that unblock both tracks

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b",
     "start": "node dist/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@prisma/client": "^6.19.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "format": "biome format --write . && prettier --write --no-error-on-unmatched-pattern '*.{md,yml,yaml}' 'docs/**/*.md'",
     "format:check": "biome format . && prettier --check --no-error-on-unmatched-pattern '*.{md,yml,yaml}' 'docs/**/*.md'",
     "typecheck": "bun run --cwd shared build && bun run --cwd backend typecheck && bun run --cwd frontend typecheck",
-    "test": "bun run --cwd shared build && bun run --cwd backend test && bun run --cwd frontend test",
+    "test": "bun run --cwd shared build && bun run --cwd shared test && bun run --cwd backend test && bun run --cwd frontend test",
     "build": "bun run --cwd shared build && bunx prisma generate --schema prisma/schema.prisma && bun run --cwd backend build && bun run --cwd frontend build",
     "start": "bun run --cwd backend start",
     "prepare": "husky"

--- a/shared/package.json
+++ b/shared/package.json
@@ -7,6 +7,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
+    "0": {
+      "types": "./dist/index.d.ts"
+    },
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
@@ -16,12 +19,14 @@
   "scripts": {
     "build": "tsc -b",
     "dev": "tsc -b --watch --preserveWatchOutput",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "zod": "^4.1.13"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/shared/src/index.test.ts
+++ b/shared/src/index.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import {
+  ClinicalAssertionSchema,
+  ClinicalFactsSchema,
+  ConsultationDetailSchema,
+  ErrorEnvelopeSchema,
+  GuidelineChunkSchema,
+  LlmClinicalAssertionSchema,
+  LlmClinicalFactsSchema,
+  makeSuggestionsAndRedFlagsSchema,
+  NoteAndGapsResponseSchema,
+  OperationalBlockSchema,
+  TranscriptSchema,
+  TranscriptSourceSchema,
+} from './index.js'
+
+describe('ClinicalAssertionSchema', () => {
+  it('rejects PRESENT without evidence', () => {
+    expect(ClinicalAssertionSchema.safeParse({ state: 'PRESENT', value: 'cough' }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects DENIED without evidence', () => {
+    expect(ClinicalAssertionSchema.safeParse({ state: 'DENIED', value: 'fever' }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects PRESENT whose evidence is whitespace only', () => {
+    const result = ClinicalAssertionSchema.safeParse({
+      state: 'PRESENT',
+      value: 'cough',
+      evidence: '   ',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts PRESENT with evidence', () => {
+    const result = ClinicalAssertionSchema.safeParse({
+      state: 'PRESENT',
+      value: 'cough',
+      evidence: 'batuk sudah 3 hari',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts NOT_ASSESSED with neither value nor evidence', () => {
+    const result = ClinicalAssertionSchema.safeParse({ state: 'NOT_ASSESSED' })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts UNKNOWN, NOT_APPLICABLE and CLINICIAN_OBSERVED without evidence', () => {
+    for (const state of ['UNKNOWN', 'NOT_APPLICABLE', 'CLINICIAN_OBSERVED'] as const) {
+      expect(ClinicalAssertionSchema.safeParse({ state }).success).toBe(true)
+    }
+  })
+
+  it('permits a normalised value against a verbatim evidence span (TRD §21.4)', () => {
+    const result = ClinicalAssertionSchema.safeParse({
+      state: 'PRESENT',
+      value: 'pharyngeal discomfort',
+      evidence: 'my throat feels scratchy',
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('the decoding schema is permissive, the persistence schema is strict', () => {
+  it('lets the model return an evidence-less DENIED, so one bad fact cannot fail the whole run', () => {
+    // Measured against qwen-flash 13/08/26: it emits exactly this shape.
+    const emitted = { state: 'DENIED', value: 'no fever' }
+    expect(LlmClinicalAssertionSchema.safeParse(emitted).success).toBe(true)
+    expect(ClinicalAssertionSchema.safeParse(emitted).success).toBe(false)
+  })
+
+  it('accepts a whole model response whose assertions carry no spans', () => {
+    const result = NoteAndGapsResponseSchema.safeParse({
+      note: { subjective: 'Cough 3 days.', objective: '', assessment: '', plan: '' },
+      clinicalFacts: {
+        symptoms: { fever: { state: 'DENIED', value: 'no fever' } },
+        history: {},
+        observations: {},
+        examination: {},
+      },
+      operational: {},
+      gaps: [],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('keeps one key list across both schemas so they cannot drift', () => {
+    const strict = ClinicalFactsSchema.parse({
+      symptoms: {},
+      history: {},
+      observations: {},
+      examination: {},
+    })
+    const permissive = LlmClinicalFactsSchema.parse({
+      symptoms: {},
+      history: {},
+      observations: {},
+      examination: {},
+    })
+    expect(Object.keys(strict.symptoms)).toEqual(Object.keys(permissive.symptoms))
+    expect(Object.keys(strict.examination)).toEqual(Object.keys(permissive.examination))
+  })
+})
+
+describe('NOT_ASSESSED is the cheapest path', () => {
+  it('makes a bare NOT_ASSESSED a complete clinical fact set', () => {
+    const result = ClinicalFactsSchema.safeParse({
+      symptoms: {},
+      history: {},
+      observations: {},
+      examination: {},
+    })
+    expect(result.success).toBe(true)
+    expect(result.data?.symptoms.haemoptysis.state).toBe('NOT_ASSESSED')
+  })
+
+  it('defaults every operational-block field to NOT_ASSESSED', () => {
+    const result = OperationalBlockSchema.safeParse({})
+    expect(result.success).toBe(true)
+    expect(result.data?.diagnosis.state).toBe('NOT_ASSESSED')
+    expect(result.data?.medicationsDispensed).toEqual([])
+  })
+
+  it('never omits a checklist key, so an untouched field cannot read as absent', () => {
+    const parsed = ClinicalFactsSchema.parse({
+      symptoms: {},
+      history: {},
+      observations: {},
+      examination: {},
+    })
+    expect(Object.keys(parsed.symptoms)).toContain('haemoptysis')
+    expect(Object.keys(parsed.observations)).toContain('oxygenSaturation')
+  })
+})
+
+describe('Transcript.source', () => {
+  it('accepts every specified provenance value', () => {
+    for (const source of ['fixture', 'paste', 'upload', 'asr_local', 'asr_hosted'] as const) {
+      expect(TranscriptSourceSchema.safeParse(source).success).toBe(true)
+    }
+  })
+
+  it('requires source on a transcript', () => {
+    const result = TranscriptSchema.safeParse({
+      turns: [{ speaker: 'doctor', text: 'What brings you in?' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a transcript carrying its source', () => {
+    const result = TranscriptSchema.safeParse({
+      source: 'fixture',
+      turns: [{ speaker: 'doctor', text: 'What brings you in?' }],
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('makeSuggestionsAndRedFlagsSchema', () => {
+  const schema = makeSuggestionsAndRedFlagsSchema(['MY-NAG-2024-A10', 'MY-DELPHI-2024-MCISAAC'])
+
+  it('rejects a citation naming an id outside the corpus', () => {
+    const result = schema.safeParse({
+      outOfScope: false,
+      redFlags: [],
+      suggestions: [
+        {
+          id: 's1',
+          text: 'Consider a throat swab.',
+          citations: [{ guidelineId: 'NICE-NG84' }],
+        },
+      ],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a citation naming a corpus id', () => {
+    const result = schema.safeParse({
+      outOfScope: false,
+      redFlags: [],
+      suggestions: [
+        {
+          id: 's1',
+          text: 'Consider a throat swab.',
+          citations: [{ guidelineId: 'MY-NAG-2024-A10' }],
+        },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a suggestion with zero citations', () => {
+    const result = schema.safeParse({
+      outOfScope: false,
+      redFlags: [],
+      suggestions: [{ id: 's1', text: 'Consider a throat swab.', citations: [] }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('forces every model-sourced red flag to source: model, with no ruleId', () => {
+    const result = schema.safeParse({
+      outOfScope: false,
+      redFlags: [
+        {
+          id: 'm1',
+          label: 'Possible peritonsillar abscess',
+          severity: 'urgent',
+          evidence: 'cannot open mouth fully',
+          source: 'rule',
+          ruleId: 'RF-001',
+        },
+      ],
+      suggestions: [],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('allows an empty suggestions array for an out-of-scope presentation', () => {
+    const result = schema.safeParse({ outOfScope: true, redFlags: [], suggestions: [] })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('LLM-facing schemas convert to JSON Schema for constrained decoding', () => {
+  it('converts note_and_gaps without throwing (TRD §6 step 2)', () => {
+    const json = z.toJSONSchema(NoteAndGapsResponseSchema, { target: 'draft-7' })
+    expect(json).toHaveProperty('properties.operational')
+    expect(json).toHaveProperty('properties.clinicalFacts')
+  })
+
+  it('converts suggestions_and_red_flags with the corpus enum intact', () => {
+    const json = z.toJSONSchema(makeSuggestionsAndRedFlagsSchema(['A', 'B']), {
+      target: 'draft-7',
+    })
+    expect(JSON.stringify(json)).toContain('"enum":["A","B"]')
+  })
+})
+
+describe('API envelope schemas', () => {
+  it('resolves ConsultationDetailSchema forward references from TRD §3', () => {
+    const result = ConsultationDetailSchema.safeParse({
+      id: 'c1',
+      status: 'awaiting_review',
+      createdAt: '2026-08-13T00:00:00.000Z',
+      updatedAt: '2026-08-13T00:00:00.000Z',
+      transcript: null,
+      analysis: null,
+      editedNote: null,
+      approvedAt: null,
+      acknowledgedRedFlagIds: [],
+      reviewedGapIds: [],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('shapes every error the same way', () => {
+    expect(
+      ErrorEnvelopeSchema.safeParse({ error: { code: 'CONFLICT', message: 'Already approved' } })
+        .success,
+    ).toBe(true)
+  })
+
+  it('rejects a guideline chunk that quotes a source forbidding verbatim reuse', () => {
+    const result = GuidelineChunkSchema.safeParse({
+      id: 'MY-NAG-2024-A10',
+      title: 'Acute pharyngitis',
+      publisher: 'Ministry of Health Malaysia',
+      year: 2024,
+      url: 'https://example.gov.my/nag',
+      summary: 'Modified Centor scoring for acute pharyngitis.',
+      sourceLicence: 'MOH-ARR',
+      verbatimAllowed: false,
+      quote: 'Antibiotics are indicated at a score of 3 or more.',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a quote on a chunk whose licence permits it', () => {
+    const result = GuidelineChunkSchema.safeParse({
+      id: 'MY-OOI-2022-URTI',
+      title: 'URTI in Malaysian primary care',
+      publisher: 'Malaysian Family Physician',
+      year: 2022,
+      url: 'https://example.org/ooi2022',
+      summary: 'Malaysian URTI epidemiology.',
+      sourceLicence: 'CC-BY-4.0',
+      verbatimAllowed: true,
+      quote: 'Respiratory complaints account for 26.8% of primary care problems.',
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -19,7 +19,24 @@ export const TranscriptTurnSchema = z.object({
   offsetSeconds: z.number().nonnegative().optional(),
 })
 
+/**
+ * How the transcript was produced. Client-asserted and unverifiable by the API
+ * (both ASR paths run in the browser), so it is an honest provenance record for
+ * a cooperating client, never a security control — nothing in the safety
+ * architecture rests on it. See docs/trd.md §3.
+ *
+ * `asr_hosted` is the only path on which audio leaves the doctor's device.
+ */
+export const TranscriptSourceSchema = z.enum([
+  'fixture',
+  'paste',
+  'upload',
+  'asr_local',
+  'asr_hosted',
+])
+
 export const TranscriptSchema = z.object({
+  source: TranscriptSourceSchema,
   turns: z.array(TranscriptTurnSchema).min(1),
 })
 
@@ -31,6 +48,162 @@ export const SoapNoteSchema = z.object({
   assessment: z.string(),
   plan: z.string(),
 })
+
+// ─── Per-field clinical assertion ────────────────────────────────────────────
+
+/**
+ * Six explicit states, so a fact the consultation never established can never
+ * be represented as denied. See docs/prd.md §10 (Unknown ≠ Negative) — the
+ * absolute half of that rule, measured failing in 5 of 5 runs without it
+ * (docs/trd.md §21.1).
+ */
+export const AssertionStateSchema = z.enum([
+  'PRESENT',
+  'DENIED',
+  'CLINICIAN_OBSERVED',
+  'NOT_ASSESSED',
+  'UNKNOWN',
+  'NOT_APPLICABLE',
+])
+
+const EVIDENCE_REQUIRED_STATES: ReadonlySet<z.infer<typeof AssertionStateSchema>> = new Set([
+  'PRESENT',
+  'DENIED',
+])
+
+const ClinicalAssertionShape = z.object({
+  state: AssertionStateSchema,
+  /** Normalised concept label. Paraphrase permitted. */
+  value: z.string().optional(),
+  /** Verbatim span from the de-identified transcript. */
+  evidence: z.string().optional(),
+})
+
+/**
+ * What the model is permitted to emit. Deliberately *not* refined.
+ *
+ * The evidence rule cannot live at the decoding boundary: measured against
+ * qwen-flash on 13/08/26, the model emits `{ state: 'DENIED', value: 'no
+ * fever' }` with no span. Enforcing the rule in `safeParse` would throw
+ * `LLMResponseError` and the doctor would get nothing at all. docs/trd.md §21.4
+ * specifies the opposite behaviour — the check runs *after* `safeParse` and
+ * downgrades the individual fact to `NOT_ASSESSED`, so one unsupported
+ * assertion costs one gap prompt rather than the whole analysis.
+ */
+export const LlmClinicalAssertionSchema = ClinicalAssertionShape
+
+/**
+ * The persisted and API-facing contract, applied *after* the §21.4 evidence
+ * check has run. By that point every surviving `PRESENT`/`DENIED` carries a
+ * span, so this schema is the loud backstop: a bug that lets an evidence-less
+ * `DENIED` through fails here rather than reaching a doctor.
+ *
+ * `NOT_ASSESSED` is the cheapest path by construction — `{ state:
+ * 'NOT_ASSESSED' }` is a complete, valid assertion costing no further tokens,
+ * and nothing here implicitly requires a field to be filled.
+ *
+ * The span requirement binds `state`, not `value` (docs/trd.md §21.4):
+ * `value` may carry a normalised concept label. Scoping it to vocabulary
+ * instead would force `NOT_ASSESSED` onto legitimate paraphrase.
+ */
+export const ClinicalAssertionSchema = ClinicalAssertionShape.refine(
+  (a) => !EVIDENCE_REQUIRED_STATES.has(a.state) || (a.evidence?.trim().length ?? 0) > 0,
+  {
+    path: ['evidence'],
+    message: 'PRESENT and DENIED each require a verbatim transcript span',
+  },
+)
+
+/**
+ * A fixed key set, not a model-chosen one. docs/prd.md §10 requires that a
+ * field the transcript never touches is never defaulted to `DENIED` *or
+ * silently omitted* — only a fixed key set can guarantee the second half, and
+ * it is what lets gaps be derived deterministically in code (a Tier-2 control)
+ * rather than asked of the model.
+ *
+ * Keys are taken verbatim from the completeness checklist in docs/prd.md §9
+ * (CAP-2). docs/trd.md §12 deferred this shape; this is it. One key list feeds
+ * both the permissive decoding schema and the strict persistence schema, so
+ * the two cannot drift.
+ */
+const buildClinicalFacts = <T extends z.ZodType>(field: T) =>
+  z.object({
+    symptoms: z.object({
+      cough: field,
+      coughDuration: field,
+      sputumProduction: field,
+      sputumCharacteristics: field,
+      haemoptysis: field,
+      soreThroat: field,
+      fever: field,
+      dyspnoea: field,
+      chestPain: field,
+      swallowingDifficulty: field,
+      oralIntake: field,
+      onsetAndProgression: field,
+    }),
+    history: z.object({
+      asthma: field,
+      copd: field,
+      cardiacDisease: field,
+      immunosuppression: field,
+      smoking: field,
+      recentInfectionExposure: field,
+      currentMedications: field,
+      drugAllergies: field,
+    }),
+    observations: z.object({
+      temperature: field,
+      heartRate: field,
+      respiratoryRate: field,
+      bloodPressure: field,
+      oxygenSaturation: field,
+    }),
+    examination: z.object({
+      throat: field,
+      tonsillar: field,
+      cervicalLymphNodes: field,
+      chest: field,
+    }),
+  })
+
+export const ClinicalFactsSchema = buildClinicalFacts(
+  ClinicalAssertionSchema.default({ state: 'NOT_ASSESSED' }),
+)
+
+export const LlmClinicalFactsSchema = buildClinicalFacts(
+  LlmClinicalAssertionSchema.default({ state: 'NOT_ASSESSED' }),
+)
+
+// ─── Malaysian operational block ─────────────────────────────────────────────
+
+/**
+ * The payer-enforced record schema — condition → treatment → itemised
+ * medication dispensed → MC days → referral (docs/prd.md §1). Two of those
+ * fields have no home in SOAP, so a SOAP-only note is incomplete against the
+ * contract the clinic signed.
+ *
+ * Every field here is extraction, never generation. `diagnosis` carries the
+ * stricter constraint: it records only an impression the doctor stated, and
+ * absent that span it resolves to `NOT_ASSESSED`. The system may not produce a
+ * diagnosis the doctor did not say (docs/prd.md §10).
+ */
+const buildOperationalBlock = <T extends z.ZodType>(field: T) =>
+  z.object({
+    diagnosis: field,
+    medicationsDispensed: z.array(field).default([]),
+    mcDays: field,
+    referral: field,
+    followUp: field,
+  })
+
+export const OperationalBlockSchema = buildOperationalBlock(
+  ClinicalAssertionSchema.default({ state: 'NOT_ASSESSED' }),
+)
+
+export const LlmOperationalBlockSchema = buildOperationalBlock(
+  LlmClinicalAssertionSchema.default({ state: 'NOT_ASSESSED' }),
+)
 
 // ─── Missing clinical information ────────────────────────────────────────────
 
@@ -111,12 +284,110 @@ export const ConsultationSchema = z.object({
   analysis: ConsultationAnalysisSchema.nullable(),
 })
 
+// ─── LLM response contracts (docs/trd.md §12) ────────────────────────────────
+
+/**
+ * Operation 1. The prompt never asks for a diagnosis, differential, or
+ * impression — only for the diagnosis the doctor stated, if any.
+ */
+export const NoteAndGapsResponseSchema = z.object({
+  note: SoapNoteSchema,
+  clinicalFacts: LlmClinicalFactsSchema,
+  operational: LlmOperationalBlockSchema,
+  gaps: z.array(InformationGapSchema),
+})
+
+/**
+ * Operation 2. `corpusIds` is the live list of guideline chunk ids at request
+ * time, which narrows `guidelineId` from a free `string` to a decoding
+ * constraint: a citation naming an id outside the corpus fails
+ * `safeParse` inside the adapter and never reaches the doctor.
+ *
+ * `outOfScope` is an explicit signal rather than an inference from an empty
+ * `suggestions` array — that inference would conflate "out of scope,
+ * suggestions suppressed" with "in scope, nothing to suggest" (docs/trd.md §19
+ * row 7).
+ *
+ * Red flags returned here are candidates only: `source` is pinned to `'model'`
+ * and `ruleId` is absent, so a model response is structurally incapable of
+ * impersonating a deterministic rule hit.
+ */
+export const makeSuggestionsAndRedFlagsSchema = (corpusIds: readonly [string, ...string[]]) =>
+  z.object({
+    outOfScope: z.boolean(),
+    redFlags: z.array(
+      RedFlagSchema.omit({ source: true, ruleId: true }).extend({
+        source: z.literal('model'),
+      }),
+    ),
+    suggestions: z.array(
+      ClinicalSuggestionSchema.extend({
+        citations: z.array(CitationSchema.extend({ guidelineId: z.enum(corpusIds) })).min(1),
+      }),
+    ),
+  })
+
+// ─── API contracts (docs/trd.md §13) ─────────────────────────────────────────
+
+export const ConsultationListItemSchema = ConsultationSchema.pick({
+  id: true,
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+})
+
+export const ConsultationDetailSchema = ConsultationSchema.extend({
+  editedNote: SoapNoteSchema.nullable(),
+  approvedAt: z.coerce.date().nullable(),
+  acknowledgedRedFlagIds: z.array(z.string()),
+  reviewedGapIds: z.array(z.string()),
+})
+
+export const ErrorEnvelopeSchema = z.object({
+  error: z.object({ code: z.string(), message: z.string() }),
+})
+
+export const FixtureSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  transcript: TranscriptSchema,
+})
+
+/**
+ * `verbatimAllowed` is legally load-bearing, not metadata: MOH NAG 2024 is
+ * all-rights-reserved and may be summarised and linked but never quoted, while
+ * the two CC-licensed sources may be. A `quote` on a chunk that forbids one is
+ * a corpus-authoring defect and fails here (docs/trd.md §11).
+ */
+export const GuidelineChunkSchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    publisher: z.string(),
+    year: z.number().int(),
+    url: z.string().url(),
+    /** Short, non-verbatim summary shown in the UI. */
+    summary: z.string(),
+    sourceLicence: z.string(),
+    verbatimAllowed: z.boolean(),
+    quote: z.string().optional(),
+  })
+  .refine((chunk) => chunk.verbatimAllowed || chunk.quote === undefined, {
+    path: ['quote'],
+    message: 'quote is not permitted on a chunk whose licence forbids verbatim reuse',
+  })
+
 // ─── Inferred types ──────────────────────────────────────────────────────────
 
 export type Speaker = z.infer<typeof SpeakerSchema>
 export type TranscriptTurn = z.infer<typeof TranscriptTurnSchema>
+export type TranscriptSource = z.infer<typeof TranscriptSourceSchema>
 export type Transcript = z.infer<typeof TranscriptSchema>
 export type SoapNote = z.infer<typeof SoapNoteSchema>
+export type AssertionState = z.infer<typeof AssertionStateSchema>
+export type ClinicalAssertion = z.infer<typeof ClinicalAssertionSchema>
+export type ClinicalFacts = z.infer<typeof ClinicalFactsSchema>
+export type OperationalBlock = z.infer<typeof OperationalBlockSchema>
 export type InformationGap = z.infer<typeof InformationGapSchema>
 export type RedFlag = z.infer<typeof RedFlagSchema>
 export type Citation = z.infer<typeof CitationSchema>
@@ -124,3 +395,12 @@ export type ClinicalSuggestion = z.infer<typeof ClinicalSuggestionSchema>
 export type ConsultationAnalysis = z.infer<typeof ConsultationAnalysisSchema>
 export type ConsultationStatus = z.infer<typeof ConsultationStatusSchema>
 export type Consultation = z.infer<typeof ConsultationSchema>
+export type NoteAndGapsResponse = z.infer<typeof NoteAndGapsResponseSchema>
+export type SuggestionsAndRedFlagsResponse = z.infer<
+  ReturnType<typeof makeSuggestionsAndRedFlagsSchema>
+>
+export type ConsultationListItem = z.infer<typeof ConsultationListItemSchema>
+export type ConsultationDetail = z.infer<typeof ConsultationDetailSchema>
+export type ErrorEnvelope = z.infer<typeof ErrorEnvelopeSchema>
+export type Fixture = z.infer<typeof FixtureSchema>
+export type GuidelineChunk = z.infer<typeof GuidelineChunkSchema>

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -6,5 +6,6 @@
     "declaration": true,
     "composite": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
Closes #31. Wave 0 — this unblocks every other issue on the board.

## What landed

All four groups from the issue, plus the TRD §13 API response schemas.

| Group | Exports |
| --- | --- |
| Assertion model | `AssertionStateSchema`, `ClinicalAssertionSchema`, `LlmClinicalAssertionSchema` |
| Clinical facts | `ClinicalFactsSchema`, `LlmClinicalFactsSchema` — fixed keys from PRD §9 CAP-2 |
| Operational block | `OperationalBlockSchema`, `LlmOperationalBlockSchema` |
| Provenance | `TranscriptSourceSchema`, `Transcript.source` (required) |
| LLM contracts (TRD §12) | `NoteAndGapsResponseSchema`, `makeSuggestionsAndRedFlagsSchema(corpusIds)` |
| API contracts (TRD §13) | `ConsultationListItemSchema`, `ConsultationDetailSchema`, `ErrorEnvelopeSchema`, `FixtureSchema`, `GuidelineChunkSchema` |

## Decision — the assertion schema is split in two

The issue asked for one `ClinicalAssertionSchema` where `PRESENT`/`DENIED` require a verbatim span. Built that way first, then measured it against the live `qwen-flash` endpoint: **the model returns `{"state":"DENIED","value":"no fever"}` with no `evidence` field.** A single refined schema therefore fails `safeParse`, `OpenAICompatibleClient.generate()` throws `LLMResponseError`, and the doctor gets nothing.

That is the opposite of what TRD §21.4 specifies — the evidence check runs *after* `safeParse` and forces the individual fact to `NOT_ASSESSED`, so one unsupported assertion costs one gap prompt, not the whole analysis.

So:

- **`LlmClinicalAssertionSchema`** — permissive, used inside `NoteAndGapsResponseSchema`. What the model is allowed to emit.
- **`ClinicalAssertionSchema`** — refined, the persisted/API contract, applied after the §21.4 check. A bug that lets an evidence-less `DENIED` through fails loudly here instead of reaching a doctor.

One key list feeds both, so they cannot drift (asserted by a test).

## Decision — `clinicalFacts` is a fixed key set

TRD §12 deferred this shape ("shapes per §3") and §3 never defined it. Keys are taken verbatim from PRD §9 CAP-2's completeness checklist — 29 assertions across symptoms / history / observations / examination.

Fixed keys are **required** by PRD §10: a field the transcript never touches must never be defaulted to `DENIED` *or silently omitted*. A model-chosen key set structurally cannot guarantee the second half. It is also what lets gaps derive deterministically in code (a Tier-2 control) rather than being asked of the model.

This is the template TRD §19 row 16 flags as the largest unvalidated assumption in the guardrail architecture. Flagged, not hidden — see the measurements below.

## Measured against the live endpoint

Synthetic transcript only — TRD §21.1's Transcript A, already published in the repo.

| Finding | Result |
| --- | --- |
| Schema accepted under `strict: true` despite optional fields | **HTTP 200** — the optional-field risk is cleared |
| `haemoptysis`, `chestPain`, `diagnosis` on the sparse transcript | **`NOT_ASSESSED`** — §21.1's 5/5 fabricated negative did **not** reproduce |
| `PRESENT`/`DENIED` assertions carrying a verbatim span | **0** — the model asserts without quoting |
| Latency, single call, one-line transcript | **9.3–10.3 s**, ~1,700 completion tokens |

Two of these need carrying forward and neither is fixed here:

- **The evidence check will downgrade nearly everything** unless the `note_and_gaps` prompt is strengthened to demand spans. That is #3/#5's problem, and it is now a known one rather than a surprise.
- **The CAP-1 30-second budget is in real doubt.** ~10 s for a *one-line* transcript, before the second call and before a 3,000-word input. This is direct evidence for TRD §19 row 8, which is a human decision.

## Scope note

The issue said "TRD §3, nothing more". I included §13's API response schemas anyway: they live in the same file, backend routes are blocked without them, and a second blocking `shared/` PR later would cost both tracks more than a slightly wider first one.

## Verification

```
bun run lint       Checked 29 files. No fixes applied.
bun run typecheck   clean across shared, backend, frontend
bun run test        27 passed (27)
```

Mutation-checked: neutering the evidence refinement fails 3 tests, so they are not vacuous.

`backend`'s test script gained `--passWithNoTests` so the root `test` script is green until #7/#9 land tests. `shared` gained vitest — it had no test runner at all.

## Clinical-Safety Checklist

- [x] No un-de-identified text reaches an LLM provider — no egress code in this diff; the probe used the already-published synthetic transcript with `[PATIENT_1]` tokens
- [x] No hardcoded outputs or stubbed model calls — measurements above are real API calls
- [x] LLM cannot suppress a rule hit — `makeSuggestionsAndRedFlagsSchema` pins `source` to `z.literal('model')` and omits `ruleId`, so a model response cannot impersonate a rule hit
- [x] No free-text citations — `guidelineId` narrowed to `z.enum(corpusIds)`; tested
- [x] `diagnosis` transcription-bound and defaults to `NOT_ASSESSED` — tested, and confirmed `NOT_ASSESSED` on a live run
- [x] Nothing logs transcript bodies, note contents, or vault entries — no logging in this diff
