### PR TITLE
feat(guidelines): seed the Malaysian MOH citation corpus

### DIFF
--- a/backend/src/guidelines/README.md
+++ b/backend/src/guidelines/README.md
@@ -1,10 +1,28 @@
 # Citation corpus
 
 Curated guideline chunks the model may cite, each with a stable ID. The model
-receives the candidate IDs and may only cite from that set; free-text references
-fail schema validation, which makes hallucinated citations structurally
-impossible rather than merely unlikely.
+receives the whole corpus (`serialiseCorpusForPrompt` in `prompt.ts` — no
+retrieval step at this size) and may only cite an ID present in it; free-text
+references fail schema validation, which makes hallucinated citations
+structurally impossible rather than merely unlikely.
 
-Sources to seed: NICE guidance on acute cough, Centre/FeverPAIN scoring for sore
-throat, Malaysian CPG for URTI, WHO. Record title, publisher, year, and URL per
-chunk so the UI can render a real reference.
+Sources (resolved 13/08/26, see `docs/trd.md` §11 — canonical):
+
+- **MOH National Antimicrobial Guideline (NAG), 4th ed., 2024** — Modified
+  Centor scoring, acute pharyngitis, acute bronchitis, uncomplicated URTI. ©
+  MOH Malaysia, all rights reserved: `sourceLicence: 'MOH-ARR'`,
+  `verbatimAllowed: false` (summarise and link, never quote).
+- **Abdullah et al. (2024)**, Malaysian sore-throat Delphi consensus,
+  _Infect Drug Resist_ — McIsaac scoring and thresholds. CC BY-NC 3.0:
+  `verbatimAllowed: true`.
+- **Ooi et al. (2022)**, _Malaysian Family Physician_ — Malaysian URTI
+  epidemiology. CC BY 4.0: `verbatimAllowed: true`.
+
+**NICE is excluded.** Its UK Open Content Licence does not cover use for
+artificial intelligence purposes; no NICE recommendation text may enter this
+corpus.
+
+One source per chunk — MOH NAG and the Delphi consensus disagree on the
+antibiotic threshold (Modified Centor ≥3 vs. McIsaac ≥4), and merging them
+into one chunk would manufacture a consensus the ID-constraint mechanism
+cannot detect, since the model would be citing a real, valid ID.

--- a/backend/src/guidelines/corpus.test.ts
+++ b/backend/src/guidelines/corpus.test.ts
@@ -1,0 +1,97 @@
+import {
+  CitationSchema,
+  GuidelineChunkSchema,
+  makeSuggestionsAndRedFlagsSchema,
+} from '@shared/types'
+import { describe, expect, it } from 'vitest'
+import { corpusIds, GUIDELINE_CORPUS } from './corpus.js'
+
+describe('guideline corpus', () => {
+  it('has 10-15 chunks scoped to adult acute cough / sore throat / URTI', () => {
+    expect(GUIDELINE_CORPUS.length).toBeGreaterThanOrEqual(10)
+    expect(GUIDELINE_CORPUS.length).toBeLessThanOrEqual(15)
+  })
+
+  it('validates every chunk against GuidelineChunkSchema', () => {
+    for (const chunk of GUIDELINE_CORPUS) {
+      expect(GuidelineChunkSchema.safeParse(chunk).success).toBe(true)
+    }
+  })
+
+  it('never puts a quote on a chunk whose licence forbids verbatim reuse', () => {
+    for (const chunk of GUIDELINE_CORPUS) {
+      if (!chunk.verbatimAllowed) {
+        expect(chunk.quote).toBeUndefined()
+      }
+    }
+  })
+
+  it('does not blend two publishers in one chunk summary (docs/trd.md §11)', () => {
+    const publishers = [...new Set(GUIDELINE_CORPUS.map((chunk) => chunk.publisher))]
+    for (const chunk of GUIDELINE_CORPUS) {
+      const otherPublishers = publishers.filter((publisher) => publisher !== chunk.publisher)
+      for (const otherPublisher of otherPublishers) {
+        expect(chunk.summary).not.toContain(otherPublisher)
+      }
+    }
+  })
+
+  it('has no duplicate ids', () => {
+    const ids = GUIDELINE_CORPUS.map((chunk) => chunk.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('rejects an adversarial response citing a guideline ID outside the corpus', () => {
+    const schema = makeSuggestionsAndRedFlagsSchema(corpusIds)
+    const adversarial = {
+      outOfScope: false,
+      redFlags: [],
+      suggestions: [
+        {
+          id: 'sugg-1',
+          text: 'Consider antibiotics per invented guidance.',
+          citations: [{ guidelineId: 'invented-guideline-id-that-does-not-exist' }],
+        },
+      ],
+    }
+
+    expect(schema.safeParse(adversarial).success).toBe(false)
+  })
+
+  it('rejects a free-text reference with no guideline ID', () => {
+    const freeText = { quote: 'According to general medical knowledge, antibiotics may help.' }
+    expect(CitationSchema.safeParse(freeText).success).toBe(false)
+
+    const schema = makeSuggestionsAndRedFlagsSchema(corpusIds)
+    const adversarial = {
+      outOfScope: false,
+      redFlags: [],
+      suggestions: [
+        {
+          id: 'sugg-1',
+          text: 'Consider antibiotics.',
+          citations: [{ quote: 'According to general medical knowledge, antibiotics may help.' }],
+        },
+      ],
+    }
+
+    expect(schema.safeParse(adversarial).success).toBe(false)
+  })
+
+  it('accepts a response citing a real corpus ID', () => {
+    const schema = makeSuggestionsAndRedFlagsSchema(corpusIds)
+    const valid = {
+      outOfScope: false,
+      redFlags: [],
+      suggestions: [
+        {
+          id: 'sugg-1',
+          text: 'Consider antibiotics per Modified Centor scoring.',
+          citations: [{ guidelineId: corpusIds[0] }],
+        },
+      ],
+    }
+
+    expect(schema.safeParse(valid).success).toBe(true)
+  })
+})

--- a/backend/src/guidelines/corpus.ts
+++ b/backend/src/guidelines/corpus.ts
@@ -1,0 +1,207 @@
+import { type GuidelineChunk, GuidelineChunkSchema } from '@shared/types'
+
+/**
+ * Bumped whenever a chunk is added, removed, or its summary/threshold
+ * changes. Recorded with every analysis (docs/trd.md §11) so a past
+ * suggestion can be traced back to the corpus state that produced it.
+ */
+export const CORPUS_VERSION = '2026-08-13'
+
+/**
+ * Source selection resolved 13/08/26 (docs/trd.md §11, §19 row 3, closed).
+ * Anchored on Malaysian sources; NICE is excluded — its UK Open Content
+ * Licence does not cover use for artificial intelligence purposes.
+ *
+ * One source per chunk, by design: MOH NAG 2024 sets the antibiotic
+ * threshold at Modified Centor >=3, while the 2024 Delphi consensus sets it
+ * at McIsaac >=4. Merging them into one "Centor threshold" chunk would
+ * manufacture a consensus that does not exist, and the ID-constrained
+ * citation mechanism cannot catch that because the model would be citing a
+ * real, valid ID. No `quote` is populated on any chunk here — this corpus
+ * was authored from the resolved TRD summary of each source rather than the
+ * primary text, so no span can honestly be marked verbatim yet; a future
+ * clinician review pass (docs/prd.md §12) is expected to add `quote`s for
+ * the CC-licensed sources where warranted.
+ */
+export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
+  // ─── MOH National Antimicrobial Guideline (NAG), 4th ed., 2024 ───────────
+  // © MOH Malaysia, all rights reserved — summarise and link, never quote.
+  {
+    id: 'moh-nag-2024-a10-modified-centor',
+    title: 'National Antimicrobial Guideline, 4th Edition — Annex A10, Modified Centor Score',
+    publisher: 'Ministry of Health Malaysia',
+    year: 2024,
+    url: 'https://www.pharmacy.gov.my/v2/en/documents/national-antimicrobial-guideline-nag.html',
+    summary:
+      'Scores four criteria in adults with sore throat — tonsillar exudate, tender anterior ' +
+      'cervical adenopathy, fever by history, and absence of cough — one point each. NAG sets ' +
+      'the antibiotic-consideration threshold at a Modified Centor score of 3 or more.',
+    sourceLicence: 'MOH-ARR',
+    verbatimAllowed: false,
+  },
+  {
+    id: 'moh-nag-2024-c1-acute-pharyngitis',
+    title:
+      'National Antimicrobial Guideline, 4th Edition — Section C1, Acute Pharyngitis/Tonsillitis',
+    publisher: 'Ministry of Health Malaysia',
+    year: 2024,
+    url: 'https://www.pharmacy.gov.my/v2/en/documents/national-antimicrobial-guideline-nag.html',
+    summary:
+      'Most adult acute pharyngitis is viral and self-limiting; antibiotics are reserved for ' +
+      'patients meeting the Modified Centor threshold (see moh-nag-2024-a10-modified-centor) ' +
+      'or with another indication for group A streptococcus coverage. Symptomatic relief is the ' +
+      'first-line management for the majority of presentations.',
+    sourceLicence: 'MOH-ARR',
+    verbatimAllowed: false,
+  },
+  {
+    id: 'moh-nag-2024-c1-viral-vs-bacterial',
+    title:
+      'National Antimicrobial Guideline, 4th Edition — Section C1, Distinguishing Viral From Bacterial Sore Throat',
+    publisher: 'Ministry of Health Malaysia',
+    year: 2024,
+    url: 'https://www.pharmacy.gov.my/v2/en/documents/national-antimicrobial-guideline-nag.html',
+    summary:
+      'Isolated sore throat with coryzal symptoms, cough, and absence of fever points away from ' +
+      'a bacterial cause and antibiotics are not indicated on presentation alone; scoring tools ' +
+      'exist because history and examination alone do not reliably separate viral from ' +
+      'bacterial pharyngitis in adults.',
+    sourceLicence: 'MOH-ARR',
+    verbatimAllowed: false,
+  },
+  {
+    id: 'moh-nag-2024-c3-acute-bronchitis',
+    title: 'National Antimicrobial Guideline, 4th Edition — Section C3, Acute Bronchitis',
+    publisher: 'Ministry of Health Malaysia',
+    year: 2024,
+    url: 'https://www.pharmacy.gov.my/v2/en/documents/national-antimicrobial-guideline-nag.html',
+    summary:
+      'Acute bronchitis in an otherwise healthy adult is usually viral. Antibiotics are not ' +
+      'routinely indicated regardless of sputum colour, and are reserved for patients with ' +
+      'significant comorbidity, prolonged symptoms, or evidence of a secondary bacterial ' +
+      'process such as pneumonia.',
+    sourceLicence: 'MOH-ARR',
+    verbatimAllowed: false,
+  },
+  {
+    id: 'moh-nag-2024-c4-uncomplicated-urti',
+    title:
+      'National Antimicrobial Guideline, 4th Edition — Section C4, Uncomplicated Upper Respiratory Tract Infection',
+    publisher: 'Ministry of Health Malaysia',
+    year: 2024,
+    url: 'https://www.pharmacy.gov.my/v2/en/documents/national-antimicrobial-guideline-nag.html',
+    summary:
+      'Uncomplicated URTI (common cold) does not warrant antibiotics; management is symptomatic ' +
+      '— analgesia, antipyretics, hydration, and rest — with safety-netting advice to return if ' +
+      'symptoms worsen, persist beyond the expected viral course, or a red-flag feature develops.',
+    sourceLicence: 'MOH-ARR',
+    verbatimAllowed: false,
+  },
+
+  // ─── Abdullah et al. (2024), Malaysian sore-throat Delphi consensus ──────
+  // Infect Drug Resist — CC BY-NC 3.0, quotable with attribution.
+  {
+    id: 'abdullah-2024-mcisaac-criteria',
+    title:
+      'Malaysian Delphi Consensus on Sore Throat Management in Primary Care — McIsaac Score Criteria',
+    publisher: 'Abdullah et al., Infectious Diseases and Therapy',
+    year: 2024,
+    url: 'https://www.dovepress.com/infection-and-drug-resistance-journal',
+    summary:
+      'Endorses the McIsaac score for adult sore throat: the four Centor criteria (tonsillar ' +
+      'exudate, tender anterior cervical adenopathy, fever by history, absence of cough) plus ' +
+      'an age adjustment of -1 for age 45 and above, reflecting the lower probability of group A ' +
+      'streptococcus in older adults.',
+    sourceLicence: 'CC-BY-NC-3.0',
+    verbatimAllowed: true,
+  },
+  {
+    id: 'abdullah-2024-mcisaac-threshold',
+    title:
+      'Malaysian Delphi Consensus on Sore Throat Management in Primary Care — Antibiotic Threshold',
+    publisher: 'Abdullah et al., Infectious Diseases and Therapy',
+    year: 2024,
+    url: 'https://www.dovepress.com/infection-and-drug-resistance-journal',
+    summary:
+      'Malaysian expert consensus recommends considering antibiotics at a McIsaac score of 4 or ' +
+      'higher, no antibiotics or further testing below a score of 2, and clinical judgement or ' +
+      'point-of-care testing at a score of 2-3.',
+    sourceLicence: 'CC-BY-NC-3.0',
+    verbatimAllowed: true,
+  },
+  {
+    id: 'abdullah-2024-safety-netting',
+    title:
+      'Malaysian Delphi Consensus on Sore Throat Management in Primary Care — Safety-Netting Advice',
+    publisher: 'Abdullah et al., Infectious Diseases and Therapy',
+    year: 2024,
+    url: 'https://www.dovepress.com/infection-and-drug-resistance-journal',
+    summary:
+      'Consensus that every adult sore-throat consultation, regardless of antibiotic decision, ' +
+      'should include explicit advice on when to seek review — worsening swallowing difficulty, ' +
+      'drooling, trismus, unilateral peritonsillar swelling, or symptoms persisting beyond the ' +
+      'expected course.',
+    sourceLicence: 'CC-BY-NC-3.0',
+    verbatimAllowed: true,
+  },
+
+  // ─── Ooi et al. (2022), Malaysian Family Physician ───────────────────────
+  // CC BY 4.0, quotable with attribution.
+  {
+    id: 'ooi-2022-urti-epidemiology',
+    title: 'Upper Respiratory Tract Infections in Malaysian Primary Care — Presentation Burden',
+    publisher: 'Ooi et al., Malaysian Family Physician',
+    year: 2022,
+    url: 'https://www.mfp.org.my/',
+    summary:
+      'URTIs (common cold, acute pharyngitis, acute bronchitis) are among the most frequent ' +
+      'reasons for a primary-care consultation in Malaysia, and the large majority are ' +
+      'viral in an otherwise healthy adult.',
+    sourceLicence: 'CC-BY-4.0',
+    verbatimAllowed: true,
+  },
+  {
+    id: 'ooi-2022-antibiotic-prescribing-patterns',
+    title: 'Upper Respiratory Tract Infections in Malaysian Primary Care — Prescribing Patterns',
+    publisher: 'Ooi et al., Malaysian Family Physician',
+    year: 2022,
+    url: 'https://www.mfp.org.my/',
+    summary:
+      'Documents antibiotic over-prescription for URTI in Malaysian primary care relative to ' +
+      'the proportion of presentations with a plausible bacterial cause, and identifies patient ' +
+      'expectation and diagnostic uncertainty as drivers — supporting structured scoring tools ' +
+      'as a stewardship intervention.',
+    sourceLicence: 'CC-BY-4.0',
+    verbatimAllowed: true,
+  },
+  {
+    id: 'ooi-2022-symptom-duration',
+    title: 'Upper Respiratory Tract Infections in Malaysian Primary Care — Expected Symptom Course',
+    publisher: 'Ooi et al., Malaysian Family Physician',
+    year: 2022,
+    url: 'https://www.mfp.org.my/',
+    summary:
+      'Uncomplicated viral URTI symptoms typically resolve within one to two weeks; cough in ' +
+      'particular can persist beyond resolution of other symptoms without indicating a ' +
+      'secondary bacterial process, which is useful context for reassurance and safety-netting.',
+    sourceLicence: 'CC-BY-4.0',
+    verbatimAllowed: true,
+  },
+]
+
+for (const chunk of GUIDELINE_CORPUS) {
+  GuidelineChunkSchema.parse(chunk)
+}
+
+/**
+ * `makeSuggestionsAndRedFlagsSchema` (docs/trd.md §12) needs a non-empty
+ * tuple type, not `string[]`, so `z.enum` can narrow `guidelineId` at the
+ * type level. The cast is checked immediately below by the length guard.
+ */
+function toCorpusIds(chunks: readonly GuidelineChunk[]): readonly [string, ...string[]] {
+  const ids = chunks.map((chunk) => chunk.id)
+  if (ids.length === 0) throw new Error('guideline corpus must not be empty')
+  return ids as [string, ...string[]]
+}
+
+export const corpusIds = toCorpusIds(GUIDELINE_CORPUS)

--- a/backend/src/guidelines/index.ts
+++ b/backend/src/guidelines/index.ts
@@ -1,0 +1,2 @@
+export { CORPUS_VERSION, corpusIds, GUIDELINE_CORPUS } from './corpus.js'
+export { serialiseCorpusForPrompt } from './prompt.js'

--- a/backend/src/guidelines/prompt.ts
+++ b/backend/src/guidelines/prompt.ts
@@ -1,0 +1,15 @@
+import type { GuidelineChunk } from '@shared/types'
+import { GUIDELINE_CORPUS } from './corpus.js'
+
+/**
+ * Serialises the whole corpus into the `suggestions_and_red_flags` system
+ * prompt (docs/trd.md §11, §12). No retrieval step — at 10-15 chunks,
+ * selecting candidate IDs before the call would be unjustifiable complexity.
+ * Only `id`, `title`, and `summary` are sent; `url`/`sourceLicence`/
+ * `verbatimAllowed` are for the review UI, not the model.
+ */
+export function serialiseCorpusForPrompt(
+  corpus: readonly GuidelineChunk[] = GUIDELINE_CORPUS,
+): string {
+  return corpus.map((chunk) => `[${chunk.id}] ${chunk.title}: ${chunk.summary}`).join('\n')
+}


### PR DESCRIPTION
Closes #8.

Eleven curated chunks scoped to adult acute cough / sore throat / URTI, plus `corpusIds` (shaped for `makeSuggestionsAndRedFlagsSchema`), `CORPUS_VERSION`, and a whole-corpus prompt serialiser.

| Source | Chunks | Licence | `verbatimAllowed` |
| --- | --- | --- | --- |
| MOH National Antimicrobial Guideline 4th ed. (§A10, C1, C3, C4) | 5 | MOH, all rights reserved | **false** |
| Abdullah et al. 2024, Malaysian sore-throat Delphi consensus | 3 | CC BY-NC 3.0 | true |
| Ooi et al. 2022, *Malaysian Family Physician* | 3 | CC BY 4.0 | true |

## Why NICE is absent

Not an oversight. The NICE UK Open Content Licence states that requests to use NICE content **for artificial intelligence purposes, UK or international, are not covered by the licence**. No NICE recommendation text enters the corpus. The issue's Scope paragraph named NICE and FeverPAIN as a fallback; TRD §11 supersedes it, and this follows the TRD.

## One source per chunk — a safety requirement, not a style rule

NAG 2024 puts the antibiotic threshold at Modified Centor **≥3**. The 2024 Delphi consensus puts it at McIsaac **≥4**. They genuinely disagree at a score of 3.

Merging them into a single "Centor threshold" chunk would manufacture a consensus that does not exist — and the ID-constraint mechanism **structurally cannot catch that**, because the model would be citing a real, valid ID. A fabricated agreement reachable through a valid ID is strictly worse than a free-text citation, because it is invisible. A test asserts no chunk's summary blends two publishers.

## Decision — no `quote` is populated on any chunk

Every chunk was authored from the TRD's resolved source summaries, not from the primary texts. Marking any span `verbatim` would have been a claim not actually verified against the source, so `quote` is left empty everywhere — including on the three CC-licensed sources where quoting is permitted.

This is consistent with TRD §11's standing open item that no clinician has reviewed any chunk in this corpus. Populating quotes is a clinician-review task, not an authoring one.

## No retrieval step

TRD §11 is explicit: the **whole corpus** is serialised into the `suggestions_and_red_flags` system prompt. A retrieval layer over 10–15 chunks is unjustifiable complexity. The issue's "select candidate chunk IDs" line is superseded; `serialiseCorpusForPrompt()` is what replaces it.

No runtime open-web call exists on the clinical suggestion path.

## Verification

```
bun run --cwd shared build                   clean
bunx biome check backend/src/guidelines/     clean, 4 files
bun run --cwd backend test                   8 passed in corpus.test.ts
```

Tests cover: every chunk validates against `GuidelineChunkSchema`; no `verbatimAllowed: false` chunk carries a quote; an adversarial response inventing a guideline ID is rejected by `makeSuggestionsAndRedFlagsSchema`; a free-text reference with no ID fails; no chunk merges two publishers; no duplicate ids.

`backend/src/guidelines/README.md` was stale — it still named NICE and Centor/FeverPAIN as sources. Updated to match the resolved TRD §11 list.

## Clinical-Safety Checklist

- [x] No un-de-identified text reaches an LLM provider — no egress code in this diff
- [x] No hardcoded outputs — this is the citable corpus, not model output
- [x] LLM cannot suppress a rule hit — not applicable; no red-flag code here
- [x] No free-text citations — `corpusIds` narrows `guidelineId` to a `z.enum`; tested with an adversarial response
- [x] Licence position recorded per chunk, and enforced: a quote on an all-rights-reserved chunk fails schema validation
- [x] Nothing logs transcript bodies or note contents — no logging in this diff
