### PR TITLE
feat(api): add authentication, RBAC and guest sign-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,17 @@ DIRECT_URL="postgresql://postgres.<ref>:<password>@aws-0-ap-southeast-1.pooler.s
 BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost:3001
 
+# ─── Demo accounts ────────────────────────────────────────────────────────────
+# Shared guest account behind "Sign in as guest". Leave both blank to disable
+# the guest route entirely — it 404s when they are unset.
+# Every guest shares this one account and therefore sees the same consultations;
+# that is a deliberate, accepted trade-off for the demo, stated in the sign-in UI.
+GUEST_EMAIL=guest@catatmd.demo
+GUEST_PASSWORD=
+
+# Password for the two seeded demo doctors, used by `bun run db:seed` only.
+SEED_DOCTOR_PASSWORD=
+
 # ─── LLM ──────────────────────────────────────────────────────────────────────
 # Which adapter LLMClient loads. One of: qwen | gemini | deepseek
 #

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,8 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.6.2",
+    "helmet": "^8.3.0",
     "openai": "^6.10.0",
     "zod": "^4.1.13"
   },

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,17 +1,51 @@
 import compression from 'compression'
 import cors from 'cors'
 import express from 'express'
+import helmet from 'helmet'
 import { env } from './config/env.js'
+import { errorHandler } from './middleware/error-handler.js'
+import { analyzeRateLimit } from './middleware/rate-limit.js'
+import { requireSession } from './middleware/require-session.js'
+import { authRouter } from './routes/auth.js'
 import { healthRouter } from './routes/health.js'
+
+/** Routes that carry clinical data. Everything here requires a session. */
+const PROTECTED_PREFIXES = ['/api/consultations', '/api/fixtures', '/api/guidelines']
 
 export function createApp() {
   const app = express()
 
+  // Render terminates TLS at its proxy, so the socket address is the proxy's.
+  // Without this, express-rate-limit buckets every caller into one buffer.
+  app.set('trust proxy', 1)
+
+  // CSP is left at helmet's default: the SPA is served by Vercel, not by this
+  // API, so this process only ever emits JSON (docs/trd.md §16).
+  app.use(helmet())
   app.use(compression())
   app.use(cors({ origin: env.CORS_ORIGIN, credentials: true }))
+
+  // Before express.json() — better-auth consumes the raw request stream.
+  app.use('/api', authRouter)
+
   app.use(express.json({ limit: '1mb' }))
 
   app.use('/api', healthRouter)
+
+  for (const prefix of PROTECTED_PREFIXES) {
+    app.use(prefix, requireSession)
+  }
+
+  // Registered ahead of the consultation routes themselves so the limiter runs
+  // whichever router later owns this path.
+  app.post('/api/consultations/:id/analyze', analyzeRateLimit)
+
+  // ── Clinical routers mount here ──────────────────────────────────────────
+  // Anything added below inherits the session guard and the analyze limiter
+  // above, and must stay above `errorHandler` — an error handler registered
+  // before a router never sees that router's errors.
+
+  app.use(errorHandler)
 
   return app
 }

--- a/backend/src/config/env.test.ts
+++ b/backend/src/config/env.test.ts
@@ -1,0 +1,80 @@
+import { execFileSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `env.ts` calls `process.exit(1)` and throws at module scope, so each case
+ * runs in a child process — importing it in-process would take the test runner
+ * down with it.
+ */
+function boot(overrides: Record<string, string>) {
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        '--no-warnings',
+        new URL('./env.ts', import.meta.url).pathname,
+      ],
+      {
+        env: { ...process.env, ...overrides },
+        stdio: 'pipe',
+        encoding: 'utf8',
+      },
+    )
+    return { ok: true, output: '' }
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string }
+    return { ok: false, output: `${e.stdout ?? ''}${e.stderr ?? ''}` }
+  }
+}
+
+describe('env fail-fast (issue #14)', () => {
+  it('boots with the repo .env as-is', () => {
+    expect(boot({}).ok).toBe(true)
+  })
+
+  it('refuses to boot when BETTER_AUTH_SECRET is absent', () => {
+    const { ok, output } = boot({ BETTER_AUTH_SECRET: '' })
+
+    expect(ok).toBe(false)
+    expect(output).toContain('Invalid environment')
+  })
+
+  it('refuses a BETTER_AUTH_SECRET shorter than 32 characters', () => {
+    const { ok } = boot({ BETTER_AUTH_SECRET: 'too-short' })
+
+    expect(ok).toBe(false)
+  })
+
+  it('refuses to boot when DATABASE_URL is absent', () => {
+    const { ok, output } = boot({ DATABASE_URL: '' })
+
+    expect(ok).toBe(false)
+    expect(output).toContain('Invalid environment')
+  })
+
+  describe('LLM provider production guards', () => {
+    it('refuses gemini in production', () => {
+      const { ok, output } = boot({ NODE_ENV: 'production', LLM_PROVIDER: 'gemini' })
+
+      expect(ok).toBe(false)
+      expect(output).toContain('local-dev-only')
+    })
+
+    // docs/trd.md §19 row 9 — DeepSeek is PRC-hosted, raising the same
+    // cross-border question Gemini was guarded for.
+    it('refuses deepseek in production', () => {
+      const { ok, output } = boot({ NODE_ENV: 'production', LLM_PROVIDER: 'deepseek' })
+
+      expect(ok).toBe(false)
+      expect(output).toContain('benchmarking-only')
+    })
+
+    it('refuses to disable the de-identification gate in production', () => {
+      const { ok, output } = boot({ NODE_ENV: 'production', DEID_FAIL_CLOSED: 'false' })
+
+      expect(ok).toBe(false)
+      expect(output).toContain('DEID_FAIL_CLOSED')
+    })
+  })
+})

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -19,6 +19,16 @@ const EnvSchema = z.object({
   BETTER_AUTH_SECRET: z.string().min(32),
   BETTER_AUTH_URL: z.string().url(),
 
+  // Shared demo account behind "Sign in as guest" (#29). Optional: absent
+  // credentials disable the guest route rather than failing boot, so a
+  // deployment that does not want a public demo simply omits them.
+  GUEST_EMAIL: z.string().email().optional(),
+  GUEST_PASSWORD: z.string().min(8).optional(),
+
+  // Password for the two seeded demo doctors. Consumed by prisma/seed.ts only;
+  // absent in normal runtime, which is why it is optional.
+  SEED_DOCTOR_PASSWORD: z.string().min(8).optional(),
+
   LLM_PROVIDER: z.enum(['qwen', 'gemini', 'deepseek']).default('qwen'),
 
   QWEN_API_KEY: z.string().optional(),
@@ -52,6 +62,15 @@ if (env.NODE_ENV === 'production' && env.LLM_PROVIDER === 'gemini') {
     'LLM_PROVIDER=gemini is local-dev-only. The free tier permits Google to use ' +
       'submitted content for product improvement and human review; it must never ' +
       'sit on a path that could carry patient-derived text.',
+  )
+}
+
+if (env.NODE_ENV === 'production' && env.LLM_PROVIDER === 'deepseek') {
+  throw new Error(
+    'LLM_PROVIDER=deepseek is benchmarking-only. The hosted API processes and ' +
+      'stores data in the PRC, which raises an unresolved PDPA 2010 s.129 ' +
+      'cross-border transfer question; it must never sit on a path that could ' +
+      'carry patient-derived text.',
   )
 }
 

--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -1,0 +1,94 @@
+import { betterAuth } from 'better-auth'
+import { prismaAdapter } from 'better-auth/adapters/prisma'
+import { env } from '../config/env.js'
+import { prisma } from './prisma.js'
+
+/**
+ * The SPA and the API sit on different registrable domains in every deployed
+ * environment (`catatmd.vercel.app` → `catatmd-api.onrender.com`), so every API
+ * call is cross-site and a `SameSite=Lax` cookie is simply never sent. The
+ * failure is deceptive: sign-in returns 200 and every subsequent request
+ * returns 401 (docs/trd.md §14).
+ *
+ * `SameSite=None` is only honoured alongside `Secure`, and browsers reject a
+ * `Secure` cookie over plain http. Deriving both from the API's own scheme
+ * keeps them in lockstep: an https deployment gets the cross-site pair, local
+ * http dev gets `Lax` (correct there anyway — both ends are `localhost`, which
+ * is same-site). There is no environment where one is set without the other.
+ */
+const isHttps = new URL(env.BETTER_AUTH_URL).protocol === 'https:'
+
+export const auth = betterAuth({
+  database: prismaAdapter(prisma, { provider: 'postgresql' }),
+  secret: env.BETTER_AUTH_SECRET,
+  baseURL: env.BETTER_AUTH_URL,
+  basePath: '/api/auth',
+
+  // The SPA origin. `baseURL`'s own origin is trusted automatically.
+  trustedOrigins: [env.CORS_ORIGIN],
+
+  emailAndPassword: {
+    enabled: true,
+    // Open self-service sign-up is in scope (docs/trd.md §14). No email
+    // verification: there is no mail provider configured, and requiring it
+    // would lock every new account out permanently.
+    requireEmailVerification: false,
+  },
+
+  session: {
+    expiresIn: 60 * 60 * 24 * 7,
+    updateAge: 60 * 60 * 24,
+  },
+
+  /**
+   * Closes docs/trd.md §19 row 4 — "confirm the default rate limiting actually
+   * covers /api/auth/sign-up/email on the installed version".
+   *
+   * Verified against better-auth 1.6.27: `getDefaultSpecialRules()` matches
+   * `path.startsWith('/sign-up')` at 10s/3, so sign-up is covered by default.
+   * Two defaults are wrong for this deployment and are overridden here:
+   *
+   *   - `enabled` defaults to `NODE_ENV === 'production'` only, which leaves
+   *     the limiter untested until it reaches production.
+   *   - `storage` defaults to in-memory, which a free-tier Render instance
+   *     wipes every time it spins down — precisely when a brute-force attempt
+   *     would resume. `database` persists the counters (`RateLimit` model).
+   */
+  rateLimit: {
+    enabled: true,
+    storage: 'database',
+    customRules: {
+      '/sign-in/email': { window: 60, max: 5 },
+      '/sign-up/email': { window: 60, max: 3 },
+      '/guest': { window: 60, max: 10 },
+    },
+  },
+
+  advanced: {
+    useSecureCookies: isHttps,
+    defaultCookieAttributes: {
+      httpOnly: true,
+      sameSite: isHttps ? 'none' : 'lax',
+      secure: isHttps,
+    },
+    // Render terminates TLS at its proxy, so the socket address is the proxy's.
+    // Without this the rate limiter buckets every caller together.
+    ipAddress: { ipAddressHeaders: ['x-forwarded-for'] },
+  },
+
+  /**
+   * Auth audit trail (issue #14). Actor id and event type only — never an
+   * email, a password, a session token, an IP, or any clinical content.
+   */
+  databaseHooks: {
+    session: {
+      create: {
+        after: async (session) => {
+          await prisma.auditEvent.create({
+            data: { action: 'auth.session.created', actorId: session.userId },
+          })
+        },
+      },
+    },
+  },
+})

--- a/backend/src/lib/authz.test.ts
+++ b/backend/src/lib/authz.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { assertOwnedConsultation } from './authz.js'
+import { HttpError } from './http-error.js'
+import { prisma } from './prisma.js'
+
+vi.mock('./prisma.js', () => ({
+  prisma: { consultation: { findFirst: vi.fn() } },
+}))
+
+/**
+ * A stand-in table rather than a canned return value: the point of these tests
+ * is that the `doctorId` filter is actually applied, and a mock that ignores
+ * the `where` clause would pass no matter what the helper did.
+ */
+const ROWS = [
+  { id: 'consult-aisyah', doctorId: 'doctor-aisyah' },
+  { id: 'consult-lim', doctorId: 'doctor-lim' },
+  { id: 'consult-guest', doctorId: 'guest' },
+]
+
+beforeEach(() => {
+  vi.mocked(prisma.consultation.findFirst).mockImplementation(
+    (async (args: { where: { id: string; doctorId: string } }) =>
+      ROWS.find((r) => r.id === args.where.id && r.doctorId === args.where.doctorId) ??
+      null) as never,
+  )
+})
+
+describe('assertOwnedConsultation', () => {
+  it('returns the consultation to its owner', async () => {
+    await expect(assertOwnedConsultation('consult-aisyah', 'doctor-aisyah')).resolves.toMatchObject(
+      { id: 'consult-aisyah' },
+    )
+  })
+
+  it('scopes the query on doctorId, not just id', async () => {
+    await assertOwnedConsultation('consult-aisyah', 'doctor-aisyah').catch(() => {})
+
+    expect(prisma.consultation.findFirst).toHaveBeenCalledWith({
+      where: { id: 'consult-aisyah', doctorId: 'doctor-aisyah' },
+    })
+  })
+
+  it('raises 404 — never 403 — when the consultation belongs to another doctor', async () => {
+    const err = await assertOwnedConsultation('consult-aisyah', 'doctor-lim').catch((e) => e)
+
+    expect(err).toBeInstanceOf(HttpError)
+    expect(err.status).toBe(404)
+    expect(err.status).not.toBe(403)
+  })
+
+  it('is indistinguishable between "not owned" and "does not exist"', async () => {
+    const notOwned = await assertOwnedConsultation('consult-aisyah', 'doctor-lim').catch((e) => e)
+    const missing = await assertOwnedConsultation('no-such-id', 'doctor-lim').catch((e) => e)
+
+    // An attacker comparing the two responses must learn nothing about whether
+    // the id is real — same status, same code, same message.
+    expect(notOwned.status).toBe(missing.status)
+    expect(notOwned.code).toBe(missing.code)
+    expect(notOwned.message).toBe(missing.message)
+  })
+
+  describe('guest isolation (#29)', () => {
+    it("hides a seeded doctor's consultation from the guest account", async () => {
+      const err = await assertOwnedConsultation('consult-aisyah', 'guest').catch((e) => e)
+
+      expect(err).toBeInstanceOf(HttpError)
+      expect(err.status).toBe(404)
+    })
+
+    it("hides the guest's consultation from a seeded doctor", async () => {
+      const err = await assertOwnedConsultation('consult-guest', 'doctor-aisyah').catch((e) => e)
+
+      expect(err).toBeInstanceOf(HttpError)
+      expect(err.status).toBe(404)
+    })
+  })
+})

--- a/backend/src/lib/authz.ts
+++ b/backend/src/lib/authz.ts
@@ -1,0 +1,25 @@
+import type { Consultation } from '@prisma/client'
+import { HttpError } from './http-error.js'
+import { prisma } from './prisma.js'
+
+/**
+ * The single ownership gate for `Consultation`. Every read and write path goes
+ * through this rather than re-implementing a `doctorId` check per route —
+ * one helper is one place to audit, and one place to get wrong.
+ *
+ * A row that exists but belongs to another doctor and a row that does not
+ * exist are deliberately indistinguishable: both raise 404, never 403. A 403
+ * would confirm the id is real, handing an unauthorised caller an existence
+ * oracle over the consultation table (docs/trd.md §13, §14).
+ */
+export async function assertOwnedConsultation(id: string, doctorId: string): Promise<Consultation> {
+  const consultation = await prisma.consultation.findFirst({
+    where: { id, doctorId },
+  })
+
+  if (!consultation) {
+    throw new HttpError(404, 'not_found', 'Consultation not found.')
+  }
+
+  return consultation
+}

--- a/backend/src/lib/http-error.ts
+++ b/backend/src/lib/http-error.ts
@@ -1,0 +1,15 @@
+/**
+ * A failure that is safe to surface to a caller. Anything thrown that is *not*
+ * an `HttpError` is treated by the error handler as unexpected and collapsed
+ * into a generic 500, so an internal message can never leak by accident.
+ */
+export class HttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'HttpError'
+  }
+}

--- a/backend/src/middleware/error-handler.test.ts
+++ b/backend/src/middleware/error-handler.test.ts
@@ -1,0 +1,83 @@
+import type { NextFunction, Request, Response } from 'express'
+import { describe, expect, it, vi } from 'vitest'
+import { HttpError } from '../lib/http-error.js'
+import { errorHandler } from './error-handler.js'
+
+function mockRes() {
+  const res = {
+    headersSent: false,
+    status: vi.fn(() => res),
+    json: vi.fn(() => res),
+  }
+  return res as unknown as Response & {
+    status: ReturnType<typeof vi.fn>
+    json: ReturnType<typeof vi.fn>
+  }
+}
+
+describe('errorHandler', () => {
+  it('passes an HttpError through with its status and code', () => {
+    const res = mockRes()
+
+    errorHandler(
+      new HttpError(404, 'not_found', 'Consultation not found.'),
+      {} as Request,
+      res,
+      vi.fn(),
+    )
+
+    expect(res.status).toHaveBeenCalledWith(404)
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'not_found', message: 'Consultation not found.' },
+    })
+  })
+
+  it('collapses an unexpected error to a generic 500, discarding its message', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = mockRes()
+    const leaky = new Error(
+      'Prisma failed at /home/app/src/db.ts:42 — transcript: patient reports chest pain',
+    )
+
+    errorHandler(leaky, {} as Request, res, vi.fn())
+
+    expect(res.status).toHaveBeenCalledWith(500)
+
+    const body = JSON.stringify(res.json.mock.calls.at(0))
+    expect(body).toContain('An unexpected error occurred.')
+    expect(body).not.toContain('chest pain')
+    expect(body).not.toContain('/home/app')
+    expect(body).not.toContain('Prisma')
+
+    spy.mockRestore()
+  })
+
+  it('never writes the error message to the log', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    errorHandler(
+      new Error('transcript: patient reports chest pain'),
+      {} as Request,
+      mockRes(),
+      vi.fn(),
+    )
+
+    const logged = spy.mock.calls.flat().join(' ')
+    expect(logged).not.toContain('chest pain')
+    expect(logged).toContain('Error')
+
+    spy.mockRestore()
+  })
+
+  it('delegates to express when headers are already sent', () => {
+    const res = mockRes()
+    res.headersSent = true
+    const next = vi.fn() as unknown as NextFunction
+    const err = new Error('boom')
+
+    errorHandler(err, {} as Request, res, next)
+
+    expect(next).toHaveBeenCalledWith(err)
+    expect(res.status).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/middleware/error-handler.ts
+++ b/backend/src/middleware/error-handler.ts
@@ -1,0 +1,33 @@
+import type { NextFunction, Request, Response } from 'express'
+import { HttpError } from '../lib/http-error.js'
+
+/**
+ * Terminal error handler. Two rules, both from issue #14's acceptance criteria:
+ *
+ *  1. Only an `HttpError` carries its message to the caller. Every other throw
+ *     collapses to a generic 500, so a Prisma message, a stack frame, a file
+ *     path, or a fragment of transcript embedded in an exception cannot reach
+ *     the client.
+ *  2. Nothing about the error is logged beyond its type. Transcript bodies and
+ *     note contents routinely appear inside thrown values on this codepath;
+ *     logging `err` would put clinical text in Render's log drain (AGENTS.md).
+ */
+export function errorHandler(err: unknown, _req: Request, res: Response, next: NextFunction) {
+  if (res.headersSent) {
+    next(err)
+    return
+  }
+
+  if (err instanceof HttpError) {
+    res.status(err.status).json({ error: { code: err.code, message: err.message } })
+    return
+  }
+
+  console.error(
+    `Unhandled error: ${err instanceof Error ? err.name : typeof err} (message withheld — may contain clinical text)`,
+  )
+
+  res.status(500).json({
+    error: { code: 'internal_error', message: 'An unexpected error occurred.' },
+  })
+}

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -1,0 +1,19 @@
+import rateLimit from 'express-rate-limit'
+
+/**
+ * Per-IP limiter for `POST /api/consultations/:id/analyze` (docs/trd.md §16) —
+ * the only route that spends an LLM call, so the only one where a loop is
+ * expensive rather than merely noisy.
+ *
+ * better-auth limits its own endpoints separately (see `lib/auth.ts`); this
+ * covers the clinical surface, which never passes through that router.
+ */
+export const analyzeRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 10,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  message: {
+    error: { code: 'rate_limited', message: 'Too many analysis requests. Please retry shortly.' },
+  },
+})

--- a/backend/src/middleware/require-session.ts
+++ b/backend/src/middleware/require-session.ts
@@ -1,0 +1,36 @@
+import { fromNodeHeaders } from 'better-auth/node'
+import type { NextFunction, Request, Response } from 'express'
+import { auth } from '../lib/auth.js'
+
+declare global {
+  namespace Express {
+    interface Request {
+      /** Populated by `requireSession`. Absent on exempt routes. */
+      doctorId?: string
+    }
+  }
+}
+
+/**
+ * Resolves the better-auth session and rejects anonymous callers with 401.
+ *
+ * Mounted per protected path prefix in `app.ts` rather than globally, so
+ * `/api/health` and `/api/auth/**` stay reachable without a session
+ * (docs/trd.md §14).
+ *
+ * On success it exposes only `doctorId` — the downstream route never sees the
+ * user record, so an email or name cannot drift into a response or a log line.
+ */
+export async function requireSession(req: Request, res: Response, next: NextFunction) {
+  const session = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) })
+
+  if (!session) {
+    res.status(401).json({
+      error: { code: 'unauthenticated', message: 'Authentication required.' },
+    })
+    return
+  }
+
+  req.doctorId = session.user.id
+  next()
+}

--- a/backend/src/routes/auth.test.ts
+++ b/backend/src/routes/auth.test.ts
@@ -1,0 +1,87 @@
+import type { Server } from 'node:http'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createApp } from '../app.js'
+
+let server: Server
+let origin: string
+
+beforeAll(async () => {
+  server = createApp().listen(0)
+  await new Promise((resolve) => server.once('listening', resolve))
+  const address = server.address()
+  if (typeof address === 'string' || address === null) throw new Error('no port')
+  origin = `http://127.0.0.1:${address.port}`
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('route protection (issue #14)', () => {
+  const protectedRoutes = [
+    ['GET', '/api/consultations'],
+    ['GET', '/api/consultations/some-id'],
+    ['POST', '/api/consultations'],
+    ['PATCH', '/api/consultations/some-id'],
+    ['POST', '/api/consultations/some-id/approve'],
+    ['GET', '/api/fixtures'],
+    ['GET', '/api/guidelines'],
+  ] as const
+
+  it.each(protectedRoutes)(
+    '%s %s rejects an unauthenticated caller with 401',
+    async (method, path) => {
+      const res = await fetch(`${origin}${path}`, { method })
+
+      expect(res.status).toBe(401)
+      expect(await res.json()).toEqual({
+        error: { code: 'unauthenticated', message: 'Authentication required.' },
+      })
+    },
+  )
+
+  it('exempts /api/health', async () => {
+    const res = await fetch(`${origin}/api/health`)
+
+    expect(res.status).not.toBe(401)
+  })
+
+  it('exempts /api/auth/** so sign-in is reachable', async () => {
+    const res = await fetch(`${origin}/api/auth/get-session`)
+
+    expect(res.status).not.toBe(401)
+  })
+
+  it('leaks no stack trace, path, or internal identifier in the 401 body', async () => {
+    const body = await (await fetch(`${origin}/api/consultations`)).text()
+
+    expect(body).not.toMatch(/at\s+\w+\s+\(/)
+    expect(body).not.toMatch(/\/home\/|node_modules|\.ts:\d+/)
+    expect(body).not.toMatch(/prisma|postgres/i)
+  })
+})
+
+describe('security headers (docs/trd.md §16)', () => {
+  it('applies helmet', async () => {
+    const res = await fetch(`${origin}/api/health`)
+
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(res.headers.get('x-frame-options')).toBeTruthy()
+    expect(res.headers.get('x-powered-by')).toBeNull()
+  })
+})
+
+describe('sign-up (docs/trd.md §14, §19 row 4)', () => {
+  it('is mounted and reachable — open self-service sign-up is in scope', async () => {
+    const res = await fetch(`${origin}/api/auth/sign-up/email`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'not-an-email', password: 'x', name: 'x' }),
+    })
+
+    // Deliberately invalid input: this asserts the route exists and validates,
+    // not that an account can be created — that would need the database.
+    expect(res.status).not.toBe(404)
+    expect(res.status).toBeGreaterThanOrEqual(400)
+  })
+})

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,64 @@
+import { toNodeHandler } from 'better-auth/node'
+import { Router } from 'express'
+import { env } from '../config/env.js'
+import { auth } from '../lib/auth.js'
+
+export const authRouter = Router()
+
+/**
+ * "Sign in as guest" (#29) — a **single shared demo account**, decided
+ * 13/08/26. Concurrent guests see each other's consultations; that risk was
+ * raised and explicitly accepted, and the sign-in screen states it.
+ *
+ * The credentials are held server-side and exchanged here rather than shipped
+ * to the SPA: a browser-side sign-in would put the demo password in the
+ * JavaScript bundle, which is not "environment configuration" in any useful
+ * sense.
+ *
+ * This is not a bypass. It calls better-auth's own `signInEmail` against a real
+ * seeded user, so the caller receives an ordinary session cookie and is subject
+ * to `requireSession` and `assertOwnedConsultation` exactly like any other
+ * doctor. Guest ownership scoping is therefore not a special case, and the
+ * seeded doctors' consultations stay invisible to it.
+ *
+ * Registered before the better-auth catch-all below so `/api/auth/guest` is
+ * not swallowed by it.
+ */
+authRouter.post('/auth/guest', async (_req, res) => {
+  if (!env.GUEST_EMAIL || !env.GUEST_PASSWORD) {
+    res.status(404).json({
+      error: { code: 'guest_disabled', message: 'Guest access is not enabled.' },
+    })
+    return
+  }
+
+  const response = await auth.api.signInEmail({
+    body: { email: env.GUEST_EMAIL, password: env.GUEST_PASSWORD },
+    asResponse: true,
+  })
+
+  for (const cookie of response.headers.getSetCookie()) {
+    res.append('Set-Cookie', cookie)
+  }
+
+  res.status(response.status === 200 ? 200 : 503).json(
+    response.status === 200
+      ? { ok: true }
+      : {
+          error: {
+            code: 'guest_unavailable',
+            message: 'The guest account is not available. It may not have been seeded.',
+          },
+        },
+  )
+})
+
+/**
+ * better-auth owns everything else under `/api/auth/**` — sign-up, sign-in,
+ * sign-out, session. Mounted, never re-implemented (docs/trd.md §13).
+ *
+ * Must be registered before `express.json()`: better-auth reads the raw request
+ * stream itself, and a body parser that has already consumed it leaves the
+ * handler waiting on a stream that will never emit.
+ */
+authRouter.all('/auth/*splat', toNodeHandler(auth))

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,8 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.6.2",
+        "helmet": "^8.3.0",
         "openai": "^6.10.0",
         "zod": "^4.1.13",
       },
@@ -75,6 +77,7 @@
       },
       "devDependencies": {
         "typescript": "^5.9.3",
+        "vitest": "^3.2.4",
       },
     },
   },
@@ -643,6 +646,8 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
+    "express-rate-limit": ["express-rate-limit@8.6.2", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A=="],
+
     "exsolve": ["exsolve@1.1.1", "", {}, "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g=="],
 
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
@@ -689,6 +694,8 @@
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
+    "helmet": ["helmet@8.3.0", "", {}, "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w=="],
+
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
@@ -706,6 +713,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev:frontend": "bun run --cwd shared build && bun run --cwd frontend dev",
     "db:migrate": "bunx prisma migrate dev --schema prisma/schema.prisma",
     "db:migrate:deploy": "bunx prisma migrate deploy --schema prisma/schema.prisma",
+    "db:seed": "bun run --cwd shared build && bunx tsx prisma/seed.ts",
     "db:studio": "bunx prisma studio --schema prisma/schema.prisma",
     "prisma:generate": "bunx prisma generate --schema prisma/schema.prisma",
     "lint": "biome check .",

--- a/prisma/migrations/20260813092610_auth_rate_limit_and_review_state/migration.sql
+++ b/prisma/migrations/20260813092610_auth_rate_limit_and_review_state/migration.sql
@@ -1,0 +1,16 @@
+-- AlterTable
+ALTER TABLE "consultation" ADD COLUMN     "acknowledgedRedFlagIds" JSONB,
+ADD COLUMN     "reviewedGapIds" JSONB;
+
+-- CreateTable
+CREATE TABLE "rate_limit" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "count" INTEGER NOT NULL,
+    "lastRequest" BIGINT NOT NULL,
+
+    CONSTRAINT "rate_limit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rate_limit_key_key" ON "rate_limit"("key");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,19 @@ model Verification {
   @@map("verification")
 }
 
+/// better-auth's rate-limit counters. Persisted rather than in-memory because
+/// the API runs on a free Render instance that spins down when idle — an
+/// in-memory limiter resets on every cold start, which is exactly when a
+/// brute-force attempt would resume.
+model RateLimit {
+  id          String @id
+  key         String @unique
+  count       Int
+  lastRequest BigInt
+
+  @@map("rate_limit")
+}
+
 // ─── Clinical domain ─────────────────────────────────────────────────────────
 
 enum ConsultationStatus {
@@ -104,6 +117,12 @@ model Consultation {
   /// Doctor's edited copy of the note. Kept separate so the AI output and the
   /// approved clinical record are never conflated.
   editedNote Json?
+
+  /// Array of `RedFlag.id` the doctor has acknowledged. Acknowledgment is
+  /// additive only — a red flag is never removed or downgraded by it.
+  acknowledgedRedFlagIds Json?
+  /// Array of `InformationGap.id` the doctor has marked as reviewed.
+  reviewedGapIds         Json?
 
   approvedAt DateTime?
   createdAt  DateTime  @default(now())

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,54 @@
+import { env } from '../backend/src/config/env.js'
+import { auth } from '../backend/src/lib/auth.js'
+import { prisma } from '../backend/src/lib/prisma.js'
+
+/**
+ * Seeds the accounts the demo depends on:
+ *
+ *  - two doctors, whose separate consultations are what the ownership-isolation
+ *    step of the Demo Script actually observes (docs/prd.md §14, step 11)
+ *  - the shared guest account behind "Sign in as guest" (#29), only when
+ *    credentials are configured
+ *
+ * Accounts are created through better-auth's own sign-up endpoint rather than
+ * by inserting rows: the password hash format is better-auth's to decide, and a
+ * hand-written `Account` row would be unverifiable at sign-in.
+ *
+ * Idempotent — an existing email is left untouched, so re-running never
+ * disturbs consultations already attached to a doctor.
+ */
+async function seedUser(email: string, password: string, name: string) {
+  const existing = await prisma.user.findUnique({ where: { email } })
+
+  if (existing) {
+    console.log(`· ${name} already present, skipped`)
+    return
+  }
+
+  await auth.api.signUpEmail({ body: { email, password, name } })
+  console.log(`✓ ${name} created`)
+}
+
+async function main() {
+  const doctorPassword = env.SEED_DOCTOR_PASSWORD
+
+  if (!doctorPassword) {
+    console.log('· SEED_DOCTOR_PASSWORD not set, skipping demo doctors')
+  } else {
+    await seedUser('dr.aisyah@catatmd.demo', doctorPassword, 'Dr Aisyah Rahman')
+    await seedUser('dr.lim@catatmd.demo', doctorPassword, 'Dr Lim Wei Jian')
+  }
+
+  if (env.GUEST_EMAIL && env.GUEST_PASSWORD) {
+    await seedUser(env.GUEST_EMAIL, env.GUEST_PASSWORD, 'Guest')
+  } else {
+    console.log('· GUEST_EMAIL/GUEST_PASSWORD not set, skipping guest account')
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error('Seed failed:', err instanceof Error ? err.message : err)
+    process.exit(1)
+  })
+  .finally(() => prisma.$disconnect())

--- a/render.yaml
+++ b/render.yaml
@@ -30,3 +30,13 @@ services:
         value: qwen-flash
       - key: DEID_FAIL_CLOSED
         value: 'true'
+      # Guest sign-in (#29). Credentials stay server-side — the /api/auth/guest
+      # route exchanges them for a real session, so the demo password is never
+      # in the SPA bundle. Without these set in the dashboard the guest button
+      # 404s in production, and the seed must be run against prod once.
+      - key: GUEST_EMAIL
+        sync: false
+      - key: GUEST_PASSWORD
+        sync: false
+      - key: SEED_DOCTOR_PASSWORD
+        sync: false


### PR DESCRIPTION
Closes #14 and #29. Also closes TRD §19 rows 4 and 9.

## The cross-site cookie, done so it cannot be got wrong

TRD §14 warns that `sameSite: 'lax'` fails deceptively here — login returns `200`, every later request `401`, and it works perfectly on `localhost` throughout.

The fix derives both attributes from the API's **own scheme** rather than from `NODE_ENV`:

```ts
const isHttps = new URL(BETTER_AUTH_URL).protocol === 'https:'
```

`sameSite` and `secure` are set together and cannot be set independently — which is the actual trap, since `SameSite=None` **without** `Secure` is silently dropped by every browser. https → `None`+`Secure`; local http → `Lax`, which is correct there because both ends are `localhost`.

Verified against a simulated production origin:

```
status: 200
Set-Cookie: __Secure-better-auth.session_token=…; Max-Age=604800; Path=/; HttpOnly; Secure; SameSite=None
```

## 404, never 403 — and byte-identical

`assertOwnedConsultation` returns `404` for both "does not exist" and "not owned". The test asserts status, code **and message** all match, because differing error text is an existence oracle just as much as a differing status code is.

## Rate limiting — storage moved to the database

better-auth's default store is in-memory, which a Render free-tier spin-down wipes — precisely when a brute-force attempt would resume. Moved to `database` (new `RateLimit` model). Also forced `enabled: true`, since the default only activates under `NODE_ENV=production` and would otherwise ship untested.

Proven end to end:

```
sign-in attempt statuses: 403, 403, 403, 403, 403, 429, 429, 429
RateLimit rows persisted: 1  |  203.0.113.9|/sign-in/email count=5
```

## TRD §19 row 4 — closed, verified against installed source

better-auth **1.6.27** is installed; `backend/package.json` pins `^1.4.4`, so there is real version drift worth tightening later. `getDefaultSpecialRules()` matches `path.startsWith('/sign-up')` at 10s/3 — so sign-up **is** covered by default. Tightened to 60s/3 for sign-up, 60s/5 for sign-in.

**No email verification.** No mail provider is configured; requiring it would lock out every new account. Stated as a scope boundary, not an oversight.

Note: the earlier "self-service sign-up was cut" comment on #14 is superseded by the Final PRD §6/§14 and TRD §14 — a correction is posted on the issue.

## TRD §19 row 9 — closed

`LLM_PROVIDER=deepseek` now throws at boot in production, symmetric with the existing Gemini guard, naming PRC hosting and the PDPA 2010 s.129 cross-border question. Asserted by test.

## Guest sign-in (#29)

A **single shared demo account**, per the decision on the issue — concurrency risk accepted, not mitigated.

The flow is `POST /api/auth/guest`, **not** a client-side `signIn.email`. Putting the demo password in the SPA bundle is not "environment configuration" in any useful sense, so credentials stay server-side and the route exchanges them for a real better-auth session — same cookie, same middleware, same `doctorId` scoping.

The shared-visibility copy is placed with the frontend work, per the decision that it must be stated in the sign-in UI:

> Guest access uses one shared demo account — everyone signed in as a guest sees the same consultations. Please don't enter anything you wouldn't want another visitor to read.

## Logging — the error handler is a PHI boundary

Only `HttpError` carries its message to the client; everything else collapses to a generic `500`, and **the thrown value is never logged**. Values on this codepath routinely contain transcript text, so logging `err` would put clinical content straight into Render's log drain.

Auth audit events record `action` + `actorId` only. `metadata` stays null — no email, no IP, no token.

## Verification

```
bun run lint        Checked 60 files. 4 warnings (console.log in prisma/seed.ts, intentional for a CLI)
bun run typecheck   clean across shared, backend, frontend
bun run --cwd backend test    98 passed (8 files)
```

Live checks against the real Supabase instance, since unit tests cannot prove the cookie or DB paths:

```
PASS  POST /api/auth/guest returns 200
PASS  guest sign-in sets a session cookie
PASS  guest cookie passes requireSession
PASS  no cookie is rejected 401
PASS  session cookie is HttpOnly
PASS  owner can read their own consultation
PASS  guest gets 404 on the doctor's consultation
PASS  auth.session.created audit event written
PASS  audit event carries no metadata payload
```

## Action required after merge

1. **The migration is already applied to the shared Supabase instance** — Prisma applies on create. The DB was ahead of `main` until this merge; it is additive (two nullable columns + one table) and low risk, but this is why the PR should not sit.
2. **Set `GUEST_EMAIL`, `GUEST_PASSWORD` and `SEED_DOCTOR_PASSWORD` in the Render dashboard**, then run the seed against production once. `render.yaml` now declares all three as `sync: false`; without them the guest button 404s in production. **#29 is not shippable until that is done** — it is a dashboard step, not a code step.
3. **Whoever mounts the consultation routes must do it inside `createApp()` above `errorHandler`** — there is a marked insertion point. A handler registered before a router never sees that router's errors, and both the analyze limiter and the session guard must sit above it.

## Note for the skills library

`better-auth-security-best-practices` is wrong for this version: it documents `databaseHooks.session.create.after` as `({ data, ctx })`; 1.6.27 uses positional `(session, context)`. The code follows the real signature.

## Clinical-Safety Checklist

- [x] No un-de-identified text reaches an LLM provider — no egress code in this diff
- [x] No hardcoded outputs — live verification above is against the real instance
- [x] LLM cannot suppress a rule hit — not applicable
- [x] No free-text citations — not applicable
- [x] **Nothing logs transcript bodies, note contents or vault entries** — the error handler explicitly never logs the thrown value; audit events carry `action` + `actorId` only
- [x] No secrets committed — `.env` gitignored; all three new vars are `sync: false` in `render.yaml`; confidentiality grep CLEAN
