### PR TITLE
feat(llm): build the note_and_gaps pipeline with evidence-bound assertion

### DIFF
--- a/backend/src/analysis/diagnostic-guard.test.ts
+++ b/backend/src/analysis/diagnostic-guard.test.ts
@@ -1,0 +1,57 @@
+import type { InformationGap, SoapNote } from '@shared/types'
+import { describe, expect, it } from 'vitest'
+import { LLMResponseError } from '../lib/llm/index.js'
+import { assertNoDiagnosticProse } from './diagnostic-guard.js'
+
+const note = (assessment: string): SoapNote => ({
+  subjective: '',
+  objective: '',
+  assessment,
+  plan: '',
+})
+
+const gap = (question: string, rationale: string): InformationGap => ({
+  id: 'gap-1',
+  question,
+  rationale,
+  priority: 'medium',
+})
+
+describe('assertNoDiagnosticProse (docs/prd.md §10)', () => {
+  it('allows an assessment that summarises findings without naming a diagnosis', () => {
+    expect(() =>
+      assertNoDiagnosticProse(
+        note('Cough and sore throat for 3 days, throat erythematous on exam.'),
+        [],
+      ),
+    ).not.toThrow()
+  })
+
+  it('rejects an assessment that states a diagnosis', () => {
+    expect(() =>
+      assertNoDiagnosticProse(note('Diagnosis: viral upper respiratory tract infection.'), []),
+    ).toThrow(LLMResponseError)
+  })
+
+  it('rejects a gap rationale that implies a differential', () => {
+    expect(() =>
+      assertNoDiagnosticProse(note(''), [
+        gap('Any exposure history?', 'Differential includes bacterial pharyngitis.'),
+      ]),
+    ).toThrow(LLMResponseError)
+  })
+
+  it('names the offending field, never the diagnostic content, in the error', () => {
+    const err = (() => {
+      try {
+        assertNoDiagnosticProse(note('Impression: likely viral.'), [])
+      } catch (e) {
+        return e
+      }
+    })()
+
+    expect(err).toBeInstanceOf(LLMResponseError)
+    expect((err as Error).message).toContain('note.assessment')
+    expect((err as Error).message).not.toContain('viral')
+  })
+})

--- a/backend/src/analysis/diagnostic-guard.ts
+++ b/backend/src/analysis/diagnostic-guard.ts
@@ -1,0 +1,42 @@
+import type { InformationGap, SoapNote } from '@shared/types'
+import { LLMResponseError } from '../lib/llm/index.js'
+
+/**
+ * Tier-3 guard (docs/trd.md §21.3) for docs/prd.md §10: the SOAP assessment
+ * and gap text must never state or imply a diagnosis. The structured
+ * `operational.diagnosis` field is the only place a diagnosis may appear,
+ * and it is bound by the evidence check (§21.4), not by this pattern match.
+ */
+const DIAGNOSTIC_PHRASING: readonly RegExp[] = [
+  /\bdiagnos(is|ed|es|ing)\b/i,
+  /\bimpression\s*:/i,
+  /\bdifferential\b/i,
+  /\bconsistent with a diagnosis\b/i,
+]
+
+function containsDiagnosticProse(text: string): boolean {
+  return DIAGNOSTIC_PHRASING.some((pattern) => pattern.test(text))
+}
+
+/** Throws `LLMResponseError` naming the offending field id, never its content. */
+export function assertNoDiagnosticProse(note: SoapNote, gaps: readonly InformationGap[]): void {
+  const fields: ReadonlyArray<readonly [string, string]> = [
+    ['note.assessment', note.assessment],
+    ...gaps.flatMap(
+      (gap) =>
+        [
+          [`gap.${gap.id}.question`, gap.question],
+          [`gap.${gap.id}.rationale`, gap.rationale],
+        ] as const,
+    ),
+  ]
+
+  for (const [fieldId, text] of fields) {
+    if (containsDiagnosticProse(text)) {
+      throw new LLMResponseError(
+        `note_and_gaps response contains diagnostic language in ${fieldId}`,
+        'note_and_gaps',
+      )
+    }
+  }
+}

--- a/backend/src/analysis/evidence.test.ts
+++ b/backend/src/analysis/evidence.test.ts
@@ -1,0 +1,103 @@
+import { LlmClinicalFactsSchema, LlmOperationalBlockSchema } from '@shared/types'
+import { describe, expect, it } from 'vitest'
+import { applyEvidenceCheck } from './evidence.js'
+
+const TRANSCRIPT_TEXT = 'Doctor: Any fever?\nPatient: No fever, but I do have a cough for 3 days.'
+
+const bareFacts = (overrides: Record<string, unknown> = {}) =>
+  LlmClinicalFactsSchema.parse({
+    symptoms: {},
+    history: {},
+    observations: {},
+    examination: {},
+    ...overrides,
+  })
+
+const bareOperational = (overrides: Record<string, unknown> = {}) =>
+  LlmOperationalBlockSchema.parse(overrides)
+
+describe('applyEvidenceCheck (docs/trd.md §21.4)', () => {
+  it('downgrades a DENIED assertion carrying no evidence span to NOT_ASSESSED', () => {
+    const facts = bareFacts({ symptoms: { fever: { state: 'DENIED', value: 'no fever' } } })
+
+    const { clinicalFacts, discardedFieldIds } = applyEvidenceCheck(
+      facts,
+      bareOperational(),
+      TRANSCRIPT_TEXT,
+    )
+
+    expect(clinicalFacts.symptoms.fever.state).toBe('NOT_ASSESSED')
+    expect(clinicalFacts.symptoms.fever.state).not.toBe('DENIED')
+    expect(discardedFieldIds).toContain('clinicalFacts.symptoms.fever')
+  })
+
+  it('downgrades an assertion whose evidence span is fabricated, not present in the transcript', () => {
+    const facts = bareFacts({
+      symptoms: {
+        haemoptysis: {
+          state: 'DENIED',
+          value: 'no haemoptysis',
+          evidence: 'denies coughing up blood',
+        },
+      },
+    })
+
+    const { clinicalFacts, discardedFieldIds } = applyEvidenceCheck(
+      facts,
+      bareOperational(),
+      TRANSCRIPT_TEXT,
+    )
+
+    expect(clinicalFacts.symptoms.haemoptysis.state).toBe('NOT_ASSESSED')
+    expect(discardedFieldIds).toContain('clinicalFacts.symptoms.haemoptysis')
+  })
+
+  it('keeps a paraphrased value when its evidence span is verbatim in the transcript', () => {
+    const facts = bareFacts({
+      symptoms: { fever: { state: 'DENIED', value: 'afebrile', evidence: 'No fever' } },
+    })
+
+    const { clinicalFacts, discardedFieldIds } = applyEvidenceCheck(
+      facts,
+      bareOperational(),
+      TRANSCRIPT_TEXT,
+    )
+
+    expect(clinicalFacts.symptoms.fever.state).toBe('DENIED')
+    expect(clinicalFacts.symptoms.fever.value).toBe('afebrile')
+    expect(discardedFieldIds).not.toContain('clinicalFacts.symptoms.fever')
+  })
+
+  it('resolves every field the model omitted to NOT_ASSESSED, never DENIED', () => {
+    const { clinicalFacts, discardedFieldIds } = applyEvidenceCheck(
+      bareFacts(),
+      bareOperational(),
+      TRANSCRIPT_TEXT,
+    )
+
+    expect(clinicalFacts.symptoms.haemoptysis.state).toBe('NOT_ASSESSED')
+    expect(clinicalFacts.symptoms.haemoptysis.state).not.toBe('DENIED')
+    expect(clinicalFacts.observations.oxygenSaturation.state).toBe('NOT_ASSESSED')
+    expect(discardedFieldIds).toEqual([])
+  })
+
+  it('applies the same rule to the operational block, including medicationsDispensed entries', () => {
+    const operational = bareOperational({
+      diagnosis: { state: 'PRESENT', value: 'viral URTI', evidence: 'never actually said' },
+      medicationsDispensed: [
+        { state: 'PRESENT', value: 'Paracetamol', evidence: 'Paracetamol 500mg' },
+      ],
+    })
+
+    const { operational: checked, discardedFieldIds } = applyEvidenceCheck(
+      bareFacts(),
+      operational,
+      TRANSCRIPT_TEXT,
+    )
+
+    expect(checked.diagnosis.state).toBe('NOT_ASSESSED')
+    expect(discardedFieldIds).toContain('operational.diagnosis')
+    expect(checked.medicationsDispensed[0]?.state).toBe('NOT_ASSESSED')
+    expect(discardedFieldIds).toContain('operational.medicationsDispensed[0]')
+  })
+})

--- a/backend/src/analysis/evidence.ts
+++ b/backend/src/analysis/evidence.ts
@@ -1,0 +1,135 @@
+import {
+  type ClinicalAssertion,
+  type ClinicalFacts,
+  ClinicalFactsSchema,
+  type LlmClinicalFactsSchema,
+  type LlmOperationalBlockSchema,
+  type OperationalBlock,
+  OperationalBlockSchema,
+} from '@shared/types'
+import type { z } from 'zod'
+
+type LlmClinicalFacts = z.infer<typeof LlmClinicalFactsSchema>
+type LlmOperationalBlock = z.infer<typeof LlmOperationalBlockSchema>
+
+export interface EvidenceCheckResult {
+  clinicalFacts: ClinicalFacts
+  operational: OperationalBlock
+  discardedFieldIds: string[]
+}
+
+/** Only these two states assert something happened or did not — docs/trd.md §21.4. */
+const EVIDENCE_REQUIRED_STATES = new Set(['PRESENT', 'DENIED'])
+
+const normalise = (text: string): string => text.toLowerCase().replace(/\s+/g, ' ').trim()
+
+function hasVerbatimEvidence(assertion: ClinicalAssertion, transcriptText: string): boolean {
+  if (!EVIDENCE_REQUIRED_STATES.has(assertion.state)) return true
+  const evidence = assertion.evidence?.trim()
+  if (!evidence) return false
+  return normalise(transcriptText).includes(normalise(evidence))
+}
+
+/**
+ * The primary control (docs/trd.md §21.4). Scoped to `state`, not `value` —
+ * a paraphrased `value` paired with a genuine `evidence` span survives; only
+ * a `state` with no matching span is downgraded. Strict matching biases every
+ * error toward the safe direction (§21.4's asymmetry table): a false
+ * `NOT_ASSESSED` costs one dismissed gap prompt, a false `DENIED` is the harm
+ * this system exists to prevent.
+ */
+function checkAssertion(
+  assertion: ClinicalAssertion,
+  fieldId: string,
+  transcriptText: string,
+  discarded: string[],
+): ClinicalAssertion {
+  if (hasVerbatimEvidence(assertion, transcriptText)) return assertion
+  discarded.push(fieldId)
+  return { state: 'NOT_ASSESSED' }
+}
+
+function checkGroup<T extends Record<string, ClinicalAssertion>>(
+  group: T,
+  prefix: string,
+  transcriptText: string,
+  discarded: string[],
+): T {
+  const entries = Object.entries(group).map(
+    ([key, assertion]) =>
+      [key, checkAssertion(assertion, `${prefix}.${key}`, transcriptText, discarded)] as const,
+  )
+  return Object.fromEntries(entries) as T
+}
+
+/**
+ * Runs the evidence check over every field in `clinicalFacts` and
+ * `operational`, then re-parses the result against the strict schemas as a
+ * backstop: those schemas refuse an evidence-less `PRESENT`/`DENIED`, so a
+ * bug in the check above fails loudly here rather than reaching a doctor.
+ */
+export function applyEvidenceCheck(
+  clinicalFacts: LlmClinicalFacts,
+  operational: LlmOperationalBlock,
+  transcriptText: string,
+): EvidenceCheckResult {
+  const discarded: string[] = []
+
+  const checkedFacts = {
+    symptoms: checkGroup(
+      clinicalFacts.symptoms,
+      'clinicalFacts.symptoms',
+      transcriptText,
+      discarded,
+    ),
+    history: checkGroup(clinicalFacts.history, 'clinicalFacts.history', transcriptText, discarded),
+    observations: checkGroup(
+      clinicalFacts.observations,
+      'clinicalFacts.observations',
+      transcriptText,
+      discarded,
+    ),
+    examination: checkGroup(
+      clinicalFacts.examination,
+      'clinicalFacts.examination',
+      transcriptText,
+      discarded,
+    ),
+  }
+
+  const checkedOperational = {
+    diagnosis: checkAssertion(
+      operational.diagnosis,
+      'operational.diagnosis',
+      transcriptText,
+      discarded,
+    ),
+    medicationsDispensed: operational.medicationsDispensed.map((medication, index) =>
+      checkAssertion(
+        medication,
+        `operational.medicationsDispensed[${index}]`,
+        transcriptText,
+        discarded,
+      ),
+    ),
+    mcDays: checkAssertion(operational.mcDays, 'operational.mcDays', transcriptText, discarded),
+    referral: checkAssertion(
+      operational.referral,
+      'operational.referral',
+      transcriptText,
+      discarded,
+    ),
+    followUp: checkAssertion(
+      operational.followUp,
+      'operational.followUp',
+      transcriptText,
+      discarded,
+    ),
+  }
+
+  return {
+    clinicalFacts: ClinicalFactsSchema.parse(checkedFacts),
+    operational: OperationalBlockSchema.parse(checkedOperational),
+    discardedFieldIds: discarded,
+  }
+}

--- a/backend/src/analysis/index.test.ts
+++ b/backend/src/analysis/index.test.ts
@@ -1,0 +1,147 @@
+import {
+  LlmClinicalFactsSchema,
+  LlmOperationalBlockSchema,
+  type NoteAndGapsResponse,
+} from '@shared/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { deidentify, deidentifyTranscript } from '../deid/index.js'
+import { FIXTURES } from '../fixtures/index.js'
+import { getLLMClient, LLMResponseError } from '../lib/llm/index.js'
+import { analyseNote } from './index.js'
+
+vi.mock('../lib/llm/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/llm/index.js')>()
+  return { ...actual, getLLMClient: vi.fn() }
+})
+
+const stubClient = (generate: (...args: unknown[]) => Promise<unknown>) => {
+  vi.mocked(getLLMClient).mockReturnValue({
+    provider: 'qwen',
+    model: 'test-model',
+    generate: vi.fn(generate),
+  } as never)
+}
+
+const fixtureById = (id: string) => {
+  const fixture = FIXTURES.find((f) => f.id === id)
+  if (!fixture) throw new Error(`fixture "${id}" not found`)
+  return fixture
+}
+
+const emptyFacts = () =>
+  LlmClinicalFactsSchema.parse({ symptoms: {}, history: {}, observations: {}, examination: {} })
+
+beforeEach(() => {
+  vi.mocked(getLLMClient).mockReset()
+})
+
+describe('analyseNote', () => {
+  it('returns the model output unchanged when every PRESENT/DENIED assertion carries real evidence', async () => {
+    const fixture = fixtureById('urti-gap-heavy')
+    const { text: content } = deidentifyTranscript(fixture.transcript)
+
+    const response: NoteAndGapsResponse = {
+      note: {
+        subjective: 'Cough 3 days, sore throat.',
+        objective: 'Throat red, tonsils swollen.',
+        assessment: 'Findings support a viral upper respiratory illness.',
+        plan: 'Symptomatic treatment, 2 days MC.',
+      },
+      clinicalFacts: LlmClinicalFactsSchema.parse({
+        symptoms: {
+          cough: { state: 'PRESENT', value: 'cough', evidence: 'Batuk sudah 3 hari' },
+        },
+        history: {},
+        observations: {},
+        examination: {},
+      }),
+      operational: LlmOperationalBlockSchema.parse({}),
+      gaps: [],
+    }
+
+    stubClient(async () => response)
+
+    const result = await analyseNote(content, content)
+
+    expect(result.discardedFieldIds).toEqual([])
+    expect(result.clinicalFacts.symptoms.cough.state).toBe('PRESENT')
+  })
+
+  describe('the haemoptysis test (docs/prd.md §10, docs/trd.md §21.1)', () => {
+    it('never lets a fabricated haemoptysis negative survive analysis', async () => {
+      const fixture = fixtureById('urti-gap-heavy')
+      const { text: content } = deidentifyTranscript(fixture.transcript)
+
+      const response: NoteAndGapsResponse = {
+        note: {
+          subjective: 'Cough 3 days, sore throat, fever yesterday.',
+          objective: 'Throat red, tonsils swollen.',
+          assessment: 'Findings support a viral upper respiratory illness.',
+          plan: 'Symptomatic treatment, 2 days MC.',
+        },
+        clinicalFacts: LlmClinicalFactsSchema.parse({
+          symptoms: {
+            cough: { state: 'PRESENT', value: 'cough', evidence: 'Batuk sudah 3 hari' },
+            soreThroat: {
+              state: 'PRESENT',
+              value: 'sore throat',
+              evidence: 'throat also quite sakit',
+            },
+            fever: { state: 'PRESENT', value: 'fever', evidence: '38.2 degrees' },
+            // Reproduces docs/trd.md §21.1: the model asserts a negative for a
+            // topic the transcript never raises, with no supporting span.
+            haemoptysis: { state: 'DENIED', value: 'no haemoptysis' },
+          },
+          history: {},
+          observations: {},
+          examination: {},
+        }),
+        operational: LlmOperationalBlockSchema.parse({}),
+        gaps: [],
+      }
+
+      stubClient(async () => response)
+
+      const result = await analyseNote(content, content)
+
+      expect(result.clinicalFacts.symptoms.haemoptysis.state).toBe('NOT_ASSESSED')
+      expect(result.clinicalFacts.symptoms.haemoptysis.state).not.toBe('DENIED')
+      expect(result.discardedFieldIds).toContain('clinicalFacts.symptoms.haemoptysis')
+    })
+  })
+
+  describe('the diagnosis test (docs/prd.md §10, docs/trd.md §3)', () => {
+    it('resolves an inferred diagnosis with no supporting doctor statement to NOT_ASSESSED', async () => {
+      const fixture = fixtureById('urti-diagnosis-not-assessed')
+      const { text: content } = deidentifyTranscript(fixture.transcript)
+
+      const response: NoteAndGapsResponse = {
+        note: { subjective: '', objective: '', assessment: '', plan: '' },
+        clinicalFacts: emptyFacts(),
+        operational: LlmOperationalBlockSchema.parse({
+          // No verbatim span — the doctor never named a condition in this fixture.
+          diagnosis: { state: 'PRESENT', value: 'viral upper respiratory tract infection' },
+        }),
+        gaps: [],
+      }
+
+      stubClient(async () => response)
+
+      const result = await analyseNote(content, content)
+
+      expect(result.operational.diagnosis.state).toBe('NOT_ASSESSED')
+    })
+  })
+
+  describe('malformed model responses', () => {
+    it('propagates the adapter error rather than returning a partial result', async () => {
+      const { text: content } = deidentify('Doctor: what brings you in today?')
+
+      stubClient(async () => {
+        throw new LLMResponseError('Provider response failed schema validation', 'note_and_gaps')
+      })
+
+      await expect(analyseNote(content, content)).rejects.toBeInstanceOf(LLMResponseError)
+    })
+  })
+})

--- a/backend/src/analysis/index.ts
+++ b/backend/src/analysis/index.ts
@@ -1,0 +1,48 @@
+import { NoteAndGapsResponseSchema } from '@shared/types'
+import type { Deidentified } from '../deid/types.js'
+import { getLLMClient } from '../lib/llm/index.js'
+import { assertNoDiagnosticProse } from './diagnostic-guard.js'
+import { applyEvidenceCheck } from './evidence.js'
+import { NOTE_AND_GAPS_SYSTEM_PROMPT } from './prompt.js'
+import type { NoteAndGapsResult } from './types.js'
+
+export { buildEvidenceLinks, type EvidenceLink } from './note.js'
+export type { NoteAndGapsResult } from './types.js'
+
+/**
+ * Operation 1 (docs/trd.md §12) — the single call that produces the SOAP
+ * scaffold, the per-field clinical assertions, the operational block, and
+ * information gaps. There is no separate extract-then-generate pipeline.
+ *
+ * `content` and `transcriptText` carry the same de-identified transcript:
+ * `content` as the branded type the LLM port requires, `transcriptText` as a
+ * plain string for the evidence check (§21.4) to match spans against.
+ */
+export async function analyseNote(
+  content: Deidentified,
+  transcriptText: string,
+): Promise<NoteAndGapsResult> {
+  const response = await getLLMClient().generate({
+    operation: 'note_and_gaps',
+    system: NOTE_AND_GAPS_SYSTEM_PROMPT,
+    content,
+    schema: NoteAndGapsResponseSchema,
+    schemaName: 'note_and_gaps',
+  })
+
+  const { clinicalFacts, operational, discardedFieldIds } = applyEvidenceCheck(
+    response.clinicalFacts,
+    response.operational,
+    transcriptText,
+  )
+
+  assertNoDiagnosticProse(response.note, response.gaps)
+
+  return {
+    note: response.note,
+    clinicalFacts,
+    operational,
+    gaps: response.gaps,
+    discardedFieldIds,
+  }
+}

--- a/backend/src/analysis/note.ts
+++ b/backend/src/analysis/note.ts
@@ -1,0 +1,50 @@
+import type {
+  AssertionState,
+  ClinicalAssertion,
+  ClinicalFacts,
+  OperationalBlock,
+} from '@shared/types'
+
+/**
+ * Issue #5 — maps each supported clinical fact to the verbatim transcript
+ * span behind it, keyed by field id. This is a by-product of the evidence
+ * check (docs/trd.md §21.4): every link here already carries a span the
+ * check matched against the de-identified transcript, so there is no
+ * separate "note statement" to trace — the note itself is generated prose
+ * (§12), not composed from these facts. Data only; docs/trd.md §21.4's Open
+ * item (§19 row 17) scopes surfacing this as clickable UI out for now.
+ */
+export interface EvidenceLink {
+  fieldId: string
+  state: AssertionState
+  evidence: string
+}
+
+function linkFor(fieldId: string, assertion: ClinicalAssertion): EvidenceLink[] {
+  return assertion.evidence
+    ? [{ fieldId, state: assertion.state, evidence: assertion.evidence }]
+    : []
+}
+
+function linksForGroup(prefix: string, group: Record<string, ClinicalAssertion>): EvidenceLink[] {
+  return Object.entries(group).flatMap(([key, assertion]) => linkFor(`${prefix}.${key}`, assertion))
+}
+
+export function buildEvidenceLinks(
+  clinicalFacts: ClinicalFacts,
+  operational: OperationalBlock,
+): EvidenceLink[] {
+  return [
+    ...linksForGroup('clinicalFacts.symptoms', clinicalFacts.symptoms),
+    ...linksForGroup('clinicalFacts.history', clinicalFacts.history),
+    ...linksForGroup('clinicalFacts.observations', clinicalFacts.observations),
+    ...linksForGroup('clinicalFacts.examination', clinicalFacts.examination),
+    ...linkFor('operational.diagnosis', operational.diagnosis),
+    ...operational.medicationsDispensed.flatMap((medication, index) =>
+      linkFor(`operational.medicationsDispensed[${index}]`, medication),
+    ),
+    ...linkFor('operational.mcDays', operational.mcDays),
+    ...linkFor('operational.referral', operational.referral),
+    ...linkFor('operational.followUp', operational.followUp),
+  ]
+}

--- a/backend/src/analysis/prompt.ts
+++ b/backend/src/analysis/prompt.ts
@@ -1,0 +1,60 @@
+/**
+ * System prompt for the `note_and_gaps` operation (docs/trd.md §12).
+ *
+ * This is a Tier-4 control (§21.3) and is never relied on alone — the
+ * `NOT_ASSESSED` default is enforced structurally by the schema (Tier 1) and
+ * the span requirement is enforced in code by `evidence.ts` (Tier 3).
+ * §21.1 measured this exact class of instruction failing silently: 5 of 5
+ * runs fabricated "denies fever, ... hemoptysis, ..." on a sparse transcript
+ * despite an instruction not to state a diagnosis.
+ */
+export const NOTE_AND_GAPS_SYSTEM_PROMPT = `You are extracting structured clinical information from a de-identified GP
+consultation transcript for adult upper-respiratory presentations (cough,
+sore throat, and related URTI symptoms). You do not diagnose and you do not
+replace clinical judgement — every output you produce is reviewed and edited
+by the treating doctor before it is used.
+
+Produce four things from the transcript:
+
+1. A SOAP note (subjective, objective, assessment, plan). The "assessment"
+   section is a synthesis of the findings recorded — it must never state,
+   imply, or name a diagnosis, differential, or clinical impression. The only
+   place a diagnosis may appear is the structured "diagnosis" field in the
+   operational block below, and only when the doctor said it out loud.
+
+2. A per-field clinical-fact assertion for every symptom, history item,
+   observation, and examination finding in the checklist. Each assertion
+   carries a state (PRESENT, DENIED, CLINICIAN_OBSERVED, NOT_ASSESSED,
+   UNKNOWN, or NOT_APPLICABLE), an optional normalised value, and an optional
+   evidence span.
+
+   - PRESENT and DENIED each assert that something happened or did not
+     happen, and each MUST carry "evidence": the exact, verbatim wording
+     from the transcript that supports it — not a summary, not a paraphrase.
+     If you cannot quote the transcript directly, do not use PRESENT or
+     DENIED.
+   - NOT_ASSESSED is the correct and cheapest answer whenever the transcript
+     is silent on a topic. Using NOT_ASSESSED is never a failure. A topic
+     nobody raised must be NOT_ASSESSED, never DENIED — inventing a negative
+     finding for something nobody discussed (for example "denies
+     haemoptysis" when haemoptysis was never mentioned) is the single most
+     dangerous error you can make, and it is checked in code, not just here.
+   - "value" may use your own clinical wording to normalise what was said
+     (for example "pharyngeal discomfort" for "throat feels irritated") —
+     paraphrase is fine for "value". "evidence" must still be the patient's
+     or doctor's own words, quoted verbatim.
+
+3. The operational block (diagnosis, medicationsDispensed, mcDays, referral,
+   followUp). Every field here is extraction, never generation — record only
+   what the doctor explicitly stated. "diagnosis" in particular must be the
+   condition the doctor named out loud, if any, never your own inference
+   from the symptoms. If the doctor examined and treated the patient without
+   ever naming a condition, "diagnosis" is NOT_ASSESSED. This is the most
+   important rule in this prompt: this system does not diagnose.
+
+4. Information gaps — clinically relevant questions the transcript leaves
+   unanswered, each with a rationale and a priority. Gap text must describe
+   what is missing; it must never assert or suggest a diagnosis.
+
+Do not produce a differential diagnosis, a clinical impression, or a
+probability statement anywhere in your output.`

--- a/backend/src/analysis/types.ts
+++ b/backend/src/analysis/types.ts
@@ -1,0 +1,15 @@
+import type { ClinicalFacts, InformationGap, OperationalBlock, SoapNote } from '@shared/types'
+
+/**
+ * Result of the `note_and_gaps` operation (docs/trd.md §12), after the
+ * evidence-bound assertion check (§21.4) has run. `discardedFieldIds` names
+ * every field the check forced to `NOT_ASSESSED` — field ids only, never the
+ * discarded content (AGENTS.md — no assertion values in logs or errors).
+ */
+export interface NoteAndGapsResult {
+  note: SoapNote
+  clinicalFacts: ClinicalFacts
+  operational: OperationalBlock
+  gaps: InformationGap[]
+  discardedFieldIds: string[]
+}


### PR DESCRIPTION
Closes #3, #4 and #5. They are one code path — see the reconciliation below.

## Reconciliation — the issues predate the finalised TRD

Three places where the issue text was superseded, all resolved toward the TRD:

1. **No extract-then-generate split.** #3 and #5 describe extracting facts and then generating a note from them in a second call. TRD §12 specifies **one** call, `note_and_gaps`, returning note, facts, operational block and gaps together. Built as one call. #5's intent — no finding without a supporting fact — is preserved by the §21.4 evidence check rather than by a second prompt.
2. **The schema names in the issues do not exist.** There is no `ClinicalFactSchema` or `ClinicalStatusSchema`; #31 shipped `ClinicalAssertionSchema` with a `state` field. Used as shipped; `shared/` untouched.
3. **No `confidence` field.** PRD §6 puts confidence display explicitly out of scope — "it would invite misplaced trust in an unvalidated prototype".

## The evidence-bound assertion check (#4) — the primary control

After `safeParse`, before assembly, every `PRESENT`/`DENIED` assertion is checked for a verbatim span in the de-identified transcript under whitespace-and-case normalisation. **A fact whose evidence does not match is forced to `NOT_ASSESSED`** — not rejected, not left alone — and its dot-path field id (`clinicalFacts.symptoms.haemoptysis`) is recorded in `discardedFieldIds`. **Never the content.**

The result is then re-parsed through the strict `ClinicalFactsSchema`/`OperationalBlockSchema` as a backstop, so a bug in the downgrade path fails loudly rather than reaching a doctor.

**The span requirement binds `state`, not `value`.** A normalised concept label is permitted with the transcript's own words as evidence — "throat irritation" may become `pharyngeal discomfort`. Applying this to vocabulary instead would force `NOT_ASSESSED` onto legitimate paraphrase; a vendor study measured a 35% → 9% swing in apparent hallucination rate purely from that judging distinction.

Strict matching first, per TRD §21.4's asymmetry: a false `NOT_ASSESSED` costs one dismissed prompt; a false `DENIED` is the harm the system exists to prevent.

## Why this matters more than it looks

TRD §21.1 measured `qwen-flash` fabricating "denies haemoptysis" on a sparse transcript in **5 of 5 runs**, with a Tier-4 "never state a diagnosis" instruction already in place. That is the failure this check exists to catch, and it is why the control is code rather than prompt wording.

A second measured fact shapes the implementation: on live probing, **none** of the model's `PRESENT`/`DENIED` assertions carried a verbatim span. The prompt pushes hard for spans, but the check has to handle their absence gracefully — downgrading the field — rather than throwing. That is why `NoteAndGapsResponseSchema` uses the permissive assertion schema.

## Also in this diff

- **`assertNoDiagnosticProse`** — PRD §10 forbids diagnostic phrasing in `note.assessment` and gap text. Guarded and tested. Suggestion text belongs to operation 2 and is out of scope here.
- **`buildEvidenceLinks`** — #5's evidence-provenance data, exported but deliberately not wired into UI. TRD §19 row 17 leaves surfacing it as an open scope call.
- The prompt **never requests a diagnosis, differential or impression** — only the diagnosis the doctor stated, if any. That is PRD §10's hinge and a CAP-1 acceptance criterion.

## Verification

```
bun run --cwd shared build           clean
bun run --cwd backend typecheck      clean
bunx biome check backend/src/analysis  clean
bun run --cwd backend test           215 passed (16 files)
```

13 tests in this module, all stubbing `getLLMClient` via `vi.mock` — **no test calls a live provider.** Coverage includes: an unsupported `DENIED` downgraded to `NOT_ASSESSED` (asserted explicitly *not* `DENIED`), a fabricated span downgraded, a legitimate paraphrase surviving (the false-downgrade guard), omitted fields resolving to `NOT_ASSESSED`, the haemoptysis test against `urti-gap-heavy`, the `diagnosis: NOT_ASSESSED` test against `urti-diagnosis-not-assessed`, and a malformed response rejected loudly.

## Deliberate simplification

`buildEvidenceLinks` is a separate exported utility rather than embedded in `NoteAndGapsResult`: the note is generated prose from the same call, not composed sentence-by-sentence from facts, so a per-sentence mapping would be inferred rather than known. Stated as a choice, not an omission.

## Clinical-Safety Checklist

- [x] **No un-de-identified text reaches an LLM provider** — `analyseNote` takes the branded `Deidentified` type; the call goes through `LLMClient`; no provider SDK imported
- [x] No hardcoded outputs or stubbed model calls **in the shipped path** — stubs exist only in tests, at the port
- [x] LLM cannot suppress a rule hit — this module never sees the rule engine
- [x] No free-text citations — not applicable to operation 1
- [x] **`diagnosis` transcription-bound** — the prompt never asks for one, and the evidence check forces `NOT_ASSESSED` absent a stated span. Tested against the fixture where the doctor never names a condition
- [x] **Nothing logs transcript bodies, note contents, assertion values or vault entries** — `discardedFieldIds` carries dot-path ids only, asserted by test
