### PR TITLE
feat(redflags): derive documentation gaps and add the cited-suggestions call

### DIFF
--- a/backend/src/gaps/checklist.ts
+++ b/backend/src/gaps/checklist.ts
@@ -1,0 +1,307 @@
+import type { ClinicalAssertion, ClinicalFacts, OperationalBlock } from '@shared/types'
+
+/**
+ * Materiality rule (GitHub issue #6; docs/prd.md §12 alert fatigue).
+ *
+ * `ClinicalFactsSchema` is a fixed 29-key set (12 symptoms, 8 history, 5
+ * observations, 4 examination) plus 5 operational-block fields. Not every
+ * `NOT_ASSESSED` key becomes a gap prompt — this list is the deliberate
+ * subset, chosen against two criteria:
+ *
+ * 1. Safety-differentiating or payer-mandated fields for an adult acute
+ *    cough / sore-throat / URTI presentation are included.
+ * 2. Fields that only restate an already-checklisted field, or that a patient
+ *    being in the room already establishes, are excluded — including them
+ *    would double-count the same absence as two prompts:
+ *    - `symptoms.cough`, `symptoms.soreThroat` — the presenting complaint;
+ *      if neither was raised there is no consultation to speak of.
+ *    - `symptoms.sputumCharacteristics` — a descriptive refinement of
+ *      `sputumProduction`, already covered by that entry.
+ *    - `symptoms.onsetAndProgression` — a descriptive refinement of
+ *      `coughDuration`, already covered by that entry.
+ *    - `history.recentInfectionExposure` — epidemiological context, not a
+ *      field either Malaysian source in the guideline corpus treats as
+ *      standard-of-care for triage.
+ *    - `operational.medicationsDispensed` — an outcome of the encounter, not
+ *      history to elicit; an empty array is a common, valid outcome
+ *      (advice-only visits), so flagging it would be a false positive rather
+ *      than a completeness gap.
+ *
+ * `priority` is a volume/ordering signal only (docs/prd.md §10) — it never
+ * gates whether an entry is included here, and it carries no safety meaning
+ * on its own.
+ */
+export interface GapChecklistEntry {
+  id: string
+  priority: 'high' | 'medium' | 'low'
+  /** What the record does not contain. Never phrased as a prompt to ask. */
+  question: string
+  /** Why this field is tracked for this presentation. Never a clinical instruction. */
+  rationale: string
+  select: (facts: ClinicalFacts, operational: OperationalBlock) => ClinicalAssertion
+}
+
+export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
+  // ─── Symptoms ───────────────────────────────────────────────────────────
+  {
+    id: 'cough-duration',
+    priority: 'medium',
+    question: 'The record does not state how long the cough has been present.',
+    rationale:
+      'Cough duration is a standard field tracked for adult cough and URTI presentations and ' +
+      'is not documented in this consultation.',
+    select: (facts) => facts.symptoms.coughDuration,
+  },
+  {
+    id: 'sputum-production',
+    priority: 'medium',
+    question: 'The record does not indicate whether the cough is productive of sputum.',
+    rationale:
+      'Sputum production is a standard field tracked for adult cough and URTI presentations ' +
+      'and is not documented in this consultation.',
+    select: (facts) => facts.symptoms.sputumProduction,
+  },
+  {
+    id: 'haemoptysis',
+    priority: 'high',
+    question: 'The record does not indicate whether haemoptysis was assessed.',
+    rationale:
+      'Haemoptysis status is a standard field tracked for adult cough presentations and is ' +
+      'not documented in this consultation.',
+    select: (facts) => facts.symptoms.haemoptysis,
+  },
+  {
+    id: 'fever',
+    priority: 'medium',
+    question: 'The record does not indicate whether fever was assessed.',
+    rationale:
+      'Fever status is a standard field tracked for adult URTI presentations and is not ' +
+      'documented in this consultation.',
+    select: (facts) => facts.symptoms.fever,
+  },
+  {
+    id: 'dyspnoea',
+    priority: 'high',
+    question: 'The record does not indicate whether breathlessness (dyspnoea) was assessed.',
+    rationale:
+      'Breathlessness status is a standard field tracked for adult cough and URTI ' +
+      'presentations and is not documented in this consultation.',
+    select: (facts) => facts.symptoms.dyspnoea,
+  },
+  {
+    id: 'chest-pain',
+    priority: 'high',
+    question: 'The record does not indicate whether chest pain was assessed.',
+    rationale:
+      'Chest pain status is a standard field tracked for adult cough and URTI presentations ' +
+      'and is not documented in this consultation.',
+    select: (facts) => facts.symptoms.chestPain,
+  },
+  {
+    id: 'swallowing-difficulty',
+    priority: 'high',
+    question: 'The record does not indicate whether difficulty swallowing was assessed.',
+    rationale:
+      'Swallowing difficulty is a standard field tracked for adult sore-throat presentations ' +
+      'and is not documented in this consultation.',
+    select: (facts) => facts.symptoms.swallowingDifficulty,
+  },
+  {
+    id: 'oral-intake',
+    priority: 'high',
+    question: 'The record does not indicate whether oral intake was assessed.',
+    rationale:
+      'Oral intake status is a standard field tracked for adult sore-throat presentations and ' +
+      'is not documented in this consultation.',
+    select: (facts) => facts.symptoms.oralIntake,
+  },
+
+  // ─── History ────────────────────────────────────────────────────────────
+  {
+    id: 'asthma',
+    priority: 'medium',
+    question: 'The record does not indicate whether a history of asthma was assessed.',
+    rationale:
+      'Asthma history is a standard field tracked for adult cough and URTI presentations and ' +
+      'is not documented in this consultation.',
+    select: (facts) => facts.history.asthma,
+  },
+  {
+    id: 'copd',
+    priority: 'medium',
+    question: 'The record does not indicate whether a history of COPD was assessed.',
+    rationale:
+      'COPD history is a standard field tracked for adult cough and URTI presentations and is ' +
+      'not documented in this consultation.',
+    select: (facts) => facts.history.copd,
+  },
+  {
+    id: 'cardiac-disease',
+    priority: 'low',
+    question: 'The record does not indicate whether a history of cardiac disease was assessed.',
+    rationale:
+      'Cardiac disease history is a standard field tracked for adult cough and URTI ' +
+      'presentations and is not documented in this consultation.',
+    select: (facts) => facts.history.cardiacDisease,
+  },
+  {
+    id: 'immunosuppression',
+    priority: 'low',
+    question: 'The record does not indicate whether immunosuppression was assessed.',
+    rationale:
+      'Immunosuppression status is a standard field tracked for adult cough and URTI ' +
+      'presentations and is not documented in this consultation.',
+    select: (facts) => facts.history.immunosuppression,
+  },
+  {
+    id: 'smoking',
+    priority: 'low',
+    question: 'The record does not indicate whether smoking status was assessed.',
+    rationale:
+      'Smoking status is a standard field tracked for adult cough and URTI presentations and ' +
+      'is not documented in this consultation.',
+    select: (facts) => facts.history.smoking,
+  },
+  {
+    id: 'current-medications',
+    priority: 'medium',
+    question: 'The record does not indicate whether current medications were reviewed.',
+    rationale:
+      'Current medications are a standard field tracked for adult cough and URTI ' +
+      'presentations and are not documented in this consultation.',
+    select: (facts) => facts.history.currentMedications,
+  },
+  {
+    id: 'drug-allergies',
+    priority: 'medium',
+    question: 'The record does not indicate whether drug allergies were reviewed.',
+    rationale:
+      'Drug allergy status is a standard field tracked whenever medication may be dispensed, ' +
+      'and is not documented in this consultation.',
+    select: (facts) => facts.history.drugAllergies,
+  },
+
+  // ─── Observations ───────────────────────────────────────────────────────
+  {
+    id: 'temperature',
+    priority: 'medium',
+    question: 'The record does not contain a temperature reading.',
+    rationale:
+      'Temperature is a standard vital-sign field tracked for adult URTI presentations and is ' +
+      'not documented in this consultation.',
+    select: (facts) => facts.observations.temperature,
+  },
+  {
+    id: 'heart-rate',
+    priority: 'medium',
+    question: 'The record does not contain a heart-rate reading.',
+    rationale:
+      'Heart rate is a standard vital-sign field tracked for adult cough and URTI ' +
+      'presentations and is not documented in this consultation.',
+    select: (facts) => facts.observations.heartRate,
+  },
+  {
+    id: 'respiratory-rate',
+    priority: 'high',
+    question: 'The record does not contain a respiratory-rate reading.',
+    rationale:
+      'Respiratory rate is a standard vital-sign field tracked for adult cough and URTI ' +
+      'presentations and is not documented in this consultation.',
+    select: (facts) => facts.observations.respiratoryRate,
+  },
+  {
+    id: 'blood-pressure',
+    priority: 'medium',
+    question: 'The record does not contain a blood-pressure reading.',
+    rationale:
+      'Blood pressure is a standard vital-sign field tracked for adult URTI presentations and ' +
+      'is not documented in this consultation.',
+    select: (facts) => facts.observations.bloodPressure,
+  },
+  {
+    id: 'oxygen-saturation',
+    priority: 'high',
+    question: 'The record does not contain an oxygen-saturation reading.',
+    rationale:
+      'Oxygen saturation is a standard vital-sign field tracked for adult cough and URTI ' +
+      'presentations and is not documented in this consultation.',
+    select: (facts) => facts.observations.oxygenSaturation,
+  },
+
+  // ─── Examination ────────────────────────────────────────────────────────
+  {
+    id: 'throat-examination',
+    priority: 'medium',
+    question: 'The record does not contain throat examination findings.',
+    rationale:
+      'Throat examination findings are a standard field tracked for adult sore-throat ' +
+      'presentations and are not documented in this consultation.',
+    select: (facts) => facts.examination.throat,
+  },
+  {
+    id: 'tonsillar-examination',
+    priority: 'medium',
+    question: 'The record does not contain tonsillar examination findings.',
+    rationale:
+      'Tonsillar examination findings are a standard field tracked for adult sore-throat ' +
+      'presentations and are not documented in this consultation.',
+    select: (facts) => facts.examination.tonsillar,
+  },
+  {
+    id: 'cervical-lymph-nodes',
+    priority: 'medium',
+    question: 'The record does not contain cervical lymph node examination findings.',
+    rationale:
+      'Cervical lymph node findings are a standard field tracked for adult sore-throat ' +
+      'presentations and are not documented in this consultation.',
+    select: (facts) => facts.examination.cervicalLymphNodes,
+  },
+  {
+    id: 'chest-examination',
+    priority: 'medium',
+    question: 'The record does not contain chest examination findings.',
+    rationale:
+      'Chest examination findings are a standard field tracked for adult cough presentations ' +
+      'and are not documented in this consultation.',
+    select: (facts) => facts.examination.chest,
+  },
+
+  // ─── Malaysian operational block ───────────────────────────────────────
+  {
+    id: 'diagnosis',
+    priority: 'low',
+    question: 'The record does not contain a diagnosis stated by the doctor.',
+    rationale:
+      'Diagnosis is one of the fields in the Malaysian payer-enforced consultation record ' +
+      '(condition, treatment, medication dispensed, MC days, referral) and is not documented ' +
+      'in this consultation.',
+    select: (_facts, operational) => operational.diagnosis,
+  },
+  {
+    id: 'mc-days',
+    priority: 'low',
+    question: 'The record does not contain medical-certificate days.',
+    rationale:
+      'MC days are one of the fields in the Malaysian payer-enforced consultation record and ' +
+      'are not documented in this consultation.',
+    select: (_facts, operational) => operational.mcDays,
+  },
+  {
+    id: 'referral',
+    priority: 'low',
+    question: 'The record does not contain a referral.',
+    rationale:
+      'Referral is one of the fields in the Malaysian payer-enforced consultation record and ' +
+      'is not documented in this consultation.',
+    select: (_facts, operational) => operational.referral,
+  },
+  {
+    id: 'follow-up',
+    priority: 'low',
+    question: 'The record does not contain a follow-up interval.',
+    rationale:
+      'Follow-up interval is one of the fields in the Malaysian payer-enforced consultation ' +
+      'record and is not documented in this consultation.',
+    select: (_facts, operational) => operational.followUp,
+  },
+]

--- a/backend/src/gaps/derive.test.ts
+++ b/backend/src/gaps/derive.test.ts
@@ -1,0 +1,125 @@
+import type { ClinicalAssertion, ClinicalFacts, OperationalBlock } from '@shared/types'
+import { ClinicalFactsSchema, OperationalBlockSchema } from '@shared/types'
+import { describe, expect, it } from 'vitest'
+import { GAP_CHECKLIST } from './checklist.js'
+import { deriveGaps } from './derive.js'
+
+const notAssessed = (): ClinicalAssertion => ({ state: 'NOT_ASSESSED' })
+const unknown = (): ClinicalAssertion => ({ state: 'UNKNOWN' })
+const present = (evidence: string, value?: string): ClinicalAssertion => ({
+  state: 'PRESENT',
+  value,
+  evidence,
+})
+const denied = (evidence: string): ClinicalAssertion => ({ state: 'DENIED', evidence })
+
+const emptyFacts = (): ClinicalFacts =>
+  ClinicalFactsSchema.parse({ symptoms: {}, history: {}, observations: {}, examination: {} })
+
+const emptyOperational = (): OperationalBlock => OperationalBlockSchema.parse({})
+
+describe('deriveGaps — purity', () => {
+  it('is a pure function: identical input produces identical output', () => {
+    const facts = emptyFacts()
+    const operational = emptyOperational()
+    expect(deriveGaps(facts, operational)).toEqual(deriveGaps(facts, operational))
+  })
+
+  it('does not mutate its inputs', () => {
+    const facts = emptyFacts()
+    const operational = emptyOperational()
+    const factsCopy = structuredClone(facts)
+    const operationalCopy = structuredClone(operational)
+
+    deriveGaps(facts, operational)
+
+    expect(facts).toEqual(factsCopy)
+    expect(operational).toEqual(operationalCopy)
+  })
+})
+
+describe('deriveGaps — assertion-state gating', () => {
+  it('raises a gap naming the missing record for a NOT_ASSESSED field, never phrased as an instruction', () => {
+    const facts = emptyFacts()
+    facts.symptoms.haemoptysis = notAssessed()
+
+    const gaps = deriveGaps(facts, emptyOperational())
+    const gap = gaps.find((g) => g.id === 'haemoptysis')
+
+    expect(gap).toBeDefined()
+    // Names what the record does not contain.
+    expect(gap?.question).toMatch(/record does not/i)
+    // Never tells the doctor what to ask or conclude.
+    const instructionalPhrasing = /\b(you (should|did not|must)|ask (the|about)|consider|please)\b/i
+    expect(gap?.question).not.toMatch(instructionalPhrasing)
+    expect(gap?.rationale).not.toMatch(instructionalPhrasing)
+  })
+
+  it('raises a gap for UNKNOWN as well as NOT_ASSESSED', () => {
+    const facts = emptyFacts()
+    facts.symptoms.dyspnoea = unknown()
+
+    const gaps = deriveGaps(facts, emptyOperational())
+    expect(gaps.some((g) => g.id === 'dyspnoea')).toBe(true)
+  })
+
+  it('raises no gap for a field that is PRESENT with evidence', () => {
+    const facts = emptyFacts()
+    facts.symptoms.haemoptysis = present('coughing up blood since this morning')
+
+    const gaps = deriveGaps(facts, emptyOperational())
+    expect(gaps.some((g) => g.id === 'haemoptysis')).toBe(false)
+  })
+
+  it('raises no gap for a field that is DENIED with evidence', () => {
+    const facts = emptyFacts()
+    facts.symptoms.haemoptysis = denied('no coughing up blood')
+
+    const gaps = deriveGaps(facts, emptyOperational())
+    expect(gaps.some((g) => g.id === 'haemoptysis')).toBe(false)
+  })
+
+  it('every entry in the checklist fires when its field is NOT_ASSESSED', () => {
+    const gaps = deriveGaps(emptyFacts(), emptyOperational())
+    const gapIds = gaps.map((g) => g.id).sort()
+    const checklistIds = GAP_CHECKLIST.map((entry) => entry.id).sort()
+    expect(gapIds).toEqual(checklistIds)
+  })
+})
+
+describe('deriveGaps — urti-gap-heavy fixture path (PRD CAP-2)', () => {
+  it('yields at least three gaps on a sparse consultation', () => {
+    // Mirrors backend/src/fixtures/corpus.ts "urti-gap-heavy": cough, sore
+    // throat, and fever are established; haemoptysis, chest pain, dyspnoea,
+    // SpO2, and respiratory rate are never raised by either speaker.
+    const facts = emptyFacts()
+    facts.symptoms.cough = present('Batuk sudah 3 hari lah')
+    facts.symptoms.coughDuration = present('3 hari', '3 days')
+    facts.symptoms.soreThroat = present('throat also quite sakit')
+    facts.symptoms.fever = present('Yesterday quite hot, I check at home, 38.2 degrees')
+    facts.symptoms.sputumProduction = present('A bit, whitish colour, not much')
+    facts.examination.throat = present('throat is red, tonsils a bit swollen')
+    facts.examination.tonsillar = present('tonsils a bit swollen')
+
+    const gaps = deriveGaps(facts, emptyOperational())
+    const gapIds = gaps.map((g) => g.id)
+
+    expect(gaps.length).toBeGreaterThanOrEqual(3)
+    expect(gapIds).toContain('haemoptysis')
+    expect(gapIds).toContain('chest-pain')
+    expect(gapIds).toContain('dyspnoea')
+    expect(gapIds).toContain('oxygen-saturation')
+    expect(gapIds).toContain('respiratory-rate')
+  })
+})
+
+describe('gap text never implies a diagnosis', () => {
+  const diagnosticPhrasing = /\b(patient has|diagnosed with|suffering from|likely|indicates)\b/i
+
+  for (const entry of GAP_CHECKLIST) {
+    it(`"${entry.id}" question and rationale do not state or imply a diagnosis`, () => {
+      expect(entry.question).not.toMatch(diagnosticPhrasing)
+      expect(entry.rationale).not.toMatch(diagnosticPhrasing)
+    })
+  }
+})

--- a/backend/src/gaps/derive.ts
+++ b/backend/src/gaps/derive.ts
@@ -1,0 +1,34 @@
+import type { AssertionState, ClinicalFacts, InformationGap, OperationalBlock } from '@shared/types'
+import { GAP_CHECKLIST } from './checklist.js'
+
+/**
+ * A field the transcript never touched is the same fact seen from two sides
+ * as a `NOT_ASSESSED`/`UNKNOWN` state (docs/prd.md §10) — `DENIED` and
+ * `PRESENT` are documented, not gaps (GitHub issue #6 acceptance criteria).
+ */
+const GAP_STATES: ReadonlySet<AssertionState> = new Set(['NOT_ASSESSED', 'UNKNOWN'])
+
+/**
+ * Tier-2 deterministic control (docs/trd.md §21.3): gap derivation from
+ * assertion states, not a prompt. Pure function — no I/O, no LLM call, no
+ * database, no clock, no randomness — over the fixed 29-key `ClinicalFacts`
+ * set plus the Malaysian operational block. See `checklist.ts` for the
+ * materiality rule deciding which fields are eligible to raise a gap.
+ */
+export function deriveGaps(facts: ClinicalFacts, operational: OperationalBlock): InformationGap[] {
+  const gaps: InformationGap[] = []
+
+  for (const entry of GAP_CHECKLIST) {
+    const assertion = entry.select(facts, operational)
+    if (!GAP_STATES.has(assertion.state)) continue
+
+    gaps.push({
+      id: entry.id,
+      question: entry.question,
+      rationale: entry.rationale,
+      priority: entry.priority,
+    })
+  }
+
+  return gaps
+}

--- a/backend/src/gaps/index.ts
+++ b/backend/src/gaps/index.ts
@@ -1,0 +1,2 @@
+export { GAP_CHECKLIST, type GapChecklistEntry } from './checklist.js'
+export { deriveGaps } from './derive.js'

--- a/backend/src/suggestions/index.test.ts
+++ b/backend/src/suggestions/index.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { generate } = vi.hoisted(() => ({ generate: vi.fn() }))
+
+vi.mock('../lib/llm/index.js', () => ({
+  getLLMClient: () => ({ provider: 'qwen', model: 'qwen-flash', generate }),
+}))
+
+import type { Deidentified } from '../deid/types.js'
+import { corpusIds } from '../guidelines/index.js'
+import type { GenerateRequest } from '../lib/llm/types.js'
+import { generateSuggestions } from './index.js'
+
+const content =
+  'Doctor: What brings you in? Patient: [PATIENT_1] here, cough 3 days.' as Deidentified
+
+const firstCorpusId = corpusIds[0]
+
+const emptyResponse = { outOfScope: false, redFlags: [], suggestions: [] }
+
+beforeEach(() => {
+  generate.mockReset()
+  generate.mockResolvedValue(emptyResponse)
+})
+
+async function capturedRequest(): Promise<GenerateRequest<unknown>> {
+  await generateSuggestions(content)
+  const [request] = generate.mock.calls.at(-1) as [GenerateRequest<unknown>]
+  return request
+}
+
+describe('generateSuggestions — call shape', () => {
+  it('calls the LLM client egress point with the suggestions_and_red_flags operation', async () => {
+    const request = await capturedRequest()
+
+    expect(request.operation).toBe('suggestions_and_red_flags')
+    expect(request.schemaName).toBe('suggestions_and_red_flags')
+    expect(request.content).toBe(content)
+  })
+
+  it('returns the client response unchanged', async () => {
+    const response = {
+      outOfScope: false,
+      redFlags: [],
+      suggestions: [
+        {
+          id: 's1',
+          text: 'Symptomatic management is appropriate.',
+          citations: [{ guidelineId: firstCorpusId }],
+        },
+      ],
+    }
+    generate.mockResolvedValue(response)
+
+    await expect(generateSuggestions(content)).resolves.toEqual(response)
+  })
+})
+
+describe('generateSuggestions — schema-enforced citation rejection (docs/trd.md §11)', () => {
+  it('rejects a citation naming a guideline id outside the corpus', async () => {
+    const request = await capturedRequest()
+
+    const result = request.schema.safeParse({
+      outOfScope: false,
+      redFlags: [],
+      suggestions: [
+        {
+          id: 's1',
+          text: 'x',
+          citations: [{ guidelineId: 'not-a-real-corpus-id' }],
+        },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a citation naming a guideline id inside the corpus', async () => {
+    const request = await capturedRequest()
+
+    const result = request.schema.safeParse({
+      outOfScope: false,
+      redFlags: [],
+      suggestions: [
+        {
+          id: 's1',
+          text: 'x',
+          citations: [{ guidelineId: firstCorpusId }],
+        },
+      ],
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a suggestion with zero citations', async () => {
+    const request = await capturedRequest()
+
+    const result = request.schema.safeParse({
+      outOfScope: false,
+      redFlags: [],
+      suggestions: [{ id: 's1', text: 'x', citations: [] }],
+    })
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('generateSuggestions — red flags cannot impersonate the rule engine (docs/trd.md §10)', () => {
+  it('rejects a red flag that claims source: "rule"', async () => {
+    const request = await capturedRequest()
+
+    const result = request.schema.safeParse({
+      outOfScope: false,
+      redFlags: [
+        { id: 'x', label: 'x', severity: 'advisory', evidence: 'x', source: 'rule', ruleId: 'x' },
+      ],
+      suggestions: [],
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a red flag with source: "model" and no ruleId', async () => {
+    const request = await capturedRequest()
+
+    const result = request.schema.safeParse({
+      outOfScope: false,
+      redFlags: [{ id: 'x', label: 'x', severity: 'advisory', evidence: 'x', source: 'model' }],
+      suggestions: [],
+    })
+
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('generateSuggestions — outOfScope signal (docs/trd.md §19 row 7)', () => {
+  it('accepts outOfScope: true with an empty suggestions array', async () => {
+    const request = await capturedRequest()
+
+    const result = request.schema.safeParse({
+      outOfScope: true,
+      redFlags: [],
+      suggestions: [],
+    })
+
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('generateSuggestions — system prompt content', () => {
+  it('states red-flag candidates are candidates only and can never override the rule engine', async () => {
+    const request = await capturedRequest()
+
+    expect(request.system).toMatch(/candidates? only/i)
+    expect(request.system).toMatch(/never (override|suppress|downgrade)/i)
+  })
+
+  it('serialises every corpus id into the system prompt', async () => {
+    const request = await capturedRequest()
+
+    for (const id of corpusIds) {
+      expect(request.system).toContain(id)
+    }
+  })
+
+  it('instructs the model to never state a diagnosis', async () => {
+    const request = await capturedRequest()
+
+    expect(request.system).toMatch(/never state a diagnosis/i)
+  })
+
+  it('does not itself state or imply a diagnosis', async () => {
+    const request = await capturedRequest()
+
+    expect(request.system).not.toMatch(/\b(patient has|diagnosed with|suffering from)\b/i)
+  })
+})

--- a/backend/src/suggestions/index.ts
+++ b/backend/src/suggestions/index.ts
@@ -1,0 +1,35 @@
+import {
+  type ClinicalSuggestion,
+  makeSuggestionsAndRedFlagsSchema,
+  type RedFlag,
+} from '@shared/types'
+import type { Deidentified } from '../deid/types.js'
+import { corpusIds } from '../guidelines/index.js'
+import { getLLMClient } from '../lib/llm/index.js'
+import { buildSuggestionsSystemPrompt } from './prompt.js'
+
+export { buildSuggestionsSystemPrompt } from './prompt.js'
+
+/**
+ * Operation 2 (docs/trd.md §12). Runs after de-identification and never
+ * merges with the deterministic rules engine here — that union is the route
+ * handler's job (`redflags/` exports `mergeRedFlags`), so this function
+ * returns model candidates only.
+ *
+ * `corpusIds` narrows `guidelineId` to a `z.enum` at request time: a
+ * citation naming an id outside the corpus fails decoding inside
+ * `LLMClient.generate()` and never reaches this function's caller.
+ */
+export async function generateSuggestions(content: Deidentified): Promise<{
+  outOfScope: boolean
+  redFlags: RedFlag[]
+  suggestions: ClinicalSuggestion[]
+}> {
+  return getLLMClient().generate({
+    operation: 'suggestions_and_red_flags',
+    system: buildSuggestionsSystemPrompt(),
+    content,
+    schema: makeSuggestionsAndRedFlagsSchema(corpusIds),
+    schemaName: 'suggestions_and_red_flags',
+  })
+}

--- a/backend/src/suggestions/prompt.ts
+++ b/backend/src/suggestions/prompt.ts
@@ -1,0 +1,55 @@
+import { serialiseCorpusForPrompt } from '../guidelines/index.js'
+
+/**
+ * `suggestions_and_red_flags` (docs/trd.md §12, Operation 2). A Tier-4
+ * control (docs/trd.md §21.3) and never relied on alone — every safety
+ * property it states in words is also enforced structurally:
+ *
+ * - "cite only ids from the corpus below" is backed by `z.enum(corpusIds)`
+ *   at decode time (docs/trd.md §11).
+ * - "these are candidates only, never authoritative" is backed by
+ *   `makeSuggestionsAndRedFlagsSchema` pinning `source` to `z.literal('model')`
+ *   and omitting `ruleId`, so a response is structurally incapable of
+ *   impersonating the deterministic rules engine (docs/trd.md §10).
+ * - "never state a diagnosis" has no structural backstop here — `suggestions`
+ *   is free text — so it is stated explicitly, alongside the reminder that
+ *   this call never sees or influences the rules engine's own output.
+ */
+export function buildSuggestionsSystemPrompt(): string {
+  return `You are assisting a Malaysian GP who is reviewing a de-identified consultation
+transcript for an adult presenting with acute cough, sore throat, or another
+upper-respiratory-tract symptom. Text such as "[PATIENT_1]" or "[NRIC_1]" is a
+de-identification token, not the patient's real identifier — never attempt to
+guess, reconstruct, or comment on the identity behind a token.
+
+Task 1 — guideline-cited suggestions:
+Using ONLY the guideline corpus listed below, propose clinical suggestions that
+this transcript's content actually supports. Every suggestion must cite at
+least one guideline id from the corpus below by its exact [id] — citing any id
+not listed here is invalid and will be rejected. Do not merge guidance from
+different sources into one suggestion, and do not invent or paraphrase a
+source that is not listed. Never state a diagnosis; a suggestion describes a
+guideline-aligned consideration for the doctor to weigh, not a conclusion.
+
+Task 2 — red-flag candidates:
+Propose any additional escalation-relevant findings you notice in the
+transcript as red-flag candidates. These are candidates only, for the
+doctor's own review. A separate, deterministic rules engine already runs
+independently of this call, and its findings are authoritative — you never
+see its output and your candidates can never override, suppress, downgrade,
+or replace anything it reports. If you find nothing additional, return an
+empty red-flag list; do not report a hit you are not confident the
+transcript actually supports.
+
+Scope:
+Set outOfScope to true, and return an empty suggestions array, if the
+transcript describes a presentation outside acute cough, sore throat, and
+other upper-respiratory-tract symptoms — the corpus below does not cover
+other presentations, and a guideline-cited suggestion would be unsupported.
+Still report any red-flag candidates regardless of scope. Set outOfScope to
+false when the presentation is in scope, even if you have no suggestions to
+add.
+
+Guideline corpus (cite by the bracketed id only):
+${serialiseCorpusForPrompt()}`
+}


### PR DESCRIPTION
Closes #6, and adds TRD §12's second operation.

## Gaps are deterministic, not a model output

TRD §21.3 lists "gap derivation from assertion states" as a **Tier-2** control — code that runs regardless of what the model returns. `ClinicalFactsSchema` is a fixed 29-key set, so every field the transcript never touched is already sitting there as `NOT_ASSESSED`. Gaps are a pure function over that: no I/O, no LLM call, no clock, no randomness.

The consequence worth stating: a model that decides not to mention a missing field cannot make that gap disappear.

## Materiality rule — which `NOT_ASSESSED` fields become prompts

Alert fatigue is a named limitation (PRD §12), so not every unestablished field earns a prompt. 28 of the checklist entries do. Excluded, with reasons:

| Excluded | Why |
| --- | --- |
| `cough`, `soreThroat` | The presenting complaint — always established if the patient is in the room |
| `sputumCharacteristics`, `onsetAndProgression` | Descriptive refinements already covered by `sputumProduction` / `coughDuration`; prompting on both double-counts one absence |
| `recentInfectionExposure` | Epidemiological context, not standard-of-care in either Malaysian source |
| `medicationsDispensed` | An empty array is a common valid outcome (advice-only visit), so flagging it is a false positive |

The full rationale is a comment in `checklist.ts`. `priority` carries the volume decision only — PRD §10 is explicit that a gap and a `NOT_ASSESSED` field are the same fact seen from two sides, so priority never carries the safety half.

## Framing is a safety property, not tone

Every gap names **what the record does not contain**, never what the doctor should have asked or concluded. "No duration recorded for the cough" is documentation completeness. "You did not ask about haemoptysis" is clinical decision support — the exact prompt class Microsoft's Dragon Copilot refuses by design.

This costs nothing and removes the most avoidable regulatory exposure in the product (PRD §9 CAP-2). Asserted by test with a regex over every generated question and rationale.

## Operation 2 — `suggestions_and_red_flags`

- Response schema built with `makeSuggestionsAndRedFlagsSchema(corpusIds)`, so `guidelineId` is a **request-time enum**. A citation naming an id outside the corpus fails decoding — structural, not a prompt instruction.
- The **whole corpus** is serialised into the system prompt. No retrieval step; at 11 chunks it would be unjustifiable complexity (TRD §11).
- The prompt states these red flags are **candidates only** and can never override the deterministic engine. That is Tier 4 and is never relied on alone — the structural guarantee is that the schema pins `source` to `z.literal('model')` and omits `ruleId`, so a model response is **incapable** of impersonating a rule hit.
- `outOfScope` is an explicit boolean. Inferring it from an empty `suggestions` array would conflate "out of scope, suppressed" with "in scope, nothing to suggest" — TRD §19 row 7, resolved this way.
- **No merging here.** The route handler merges, using `mergeRedFlags`, which is a union.

## Verification

```
bun run --cwd shared build                                clean
bunx biome check backend/src/gaps backend/src/suggestions   clean
bun run --cwd backend test                                215 passed (16 files)
```

48 tests in these two modules. No test calls a live provider — operation 2 stubs at the `LLMClient` port. Coverage: gap framing contains no decision-support phrasing, an established field raises no gap, `deriveGaps` is pure, a fabricated guideline id is rejected, a zero-citation suggestion is rejected, `source: 'rule'` from the model is rejected, and `outOfScope: true` with empty suggestions validates.

## Clinical-Safety Checklist

- [x] **No un-de-identified text reaches an LLM provider** — `generateSuggestions` takes the branded `Deidentified` type and goes through `LLMClient`; no provider SDK imported
- [x] No hardcoded outputs — gaps are computed from real assertion states; stubs exist only in tests
- [x] **LLM cannot suppress a rule hit** — this module never sees the rule engine, and its schema cannot emit `source: 'rule'`
- [x] **No free-text citations** — `guidelineId` narrowed to a request-time enum; tested with a fabricated id
- [x] No diagnostic phrasing in gap or suggestion text — tested
- [x] Nothing logs transcript bodies, note contents, or gap/suggestion text
