### PR TITLE
feat(db): record AI output, clinician edits, approvals and versions

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,7 +7,9 @@ import { errorHandler } from './middleware/error-handler.js'
 import { analyzeRateLimit } from './middleware/rate-limit.js'
 import { requireSession } from './middleware/require-session.js'
 import { authRouter } from './routes/auth.js'
+import { consultationsRouter } from './routes/consultations.js'
 import { healthRouter } from './routes/health.js'
+import { referenceRouter } from './routes/reference.js'
 
 /** Routes that carry clinical data. Everything here requires a session. */
 const PROTECTED_PREFIXES = ['/api/consultations', '/api/fixtures', '/api/guidelines']
@@ -40,10 +42,12 @@ export function createApp() {
   // whichever router later owns this path.
   app.post('/api/consultations/:id/analyze', analyzeRateLimit)
 
-  // ── Clinical routers mount here ──────────────────────────────────────────
-  // Anything added below inherits the session guard and the analyze limiter
-  // above, and must stay above `errorHandler` — an error handler registered
-  // before a router never sees that router's errors.
+  // ── Clinical routers ─────────────────────────────────────────────────────
+  // These inherit the session guard and the analyze limiter above, and must
+  // stay above `errorHandler` — an error handler registered before a router
+  // never sees that router's errors.
+  app.use('/api', referenceRouter)
+  app.use('/api/consultations', consultationsRouter)
 
   app.use(errorHandler)
 

--- a/backend/src/audit/audit.test.ts
+++ b/backend/src/audit/audit.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { prisma } from '../lib/prisma.js'
+import { type AuditEventInput, getAuditHistory, recordAuditEvent } from './index.js'
+
+vi.mock('../lib/prisma.js', () => ({
+  prisma: { auditEvent: { create: vi.fn(), findMany: vi.fn(() => []) } },
+}))
+
+beforeEach(() => {
+  vi.mocked(prisma.auditEvent.create).mockClear()
+  vi.mocked(prisma.auditEvent.findMany).mockClear()
+})
+
+const write = (event: AuditEventInput) =>
+  recordAuditEvent({ ...event, actorId: 'doctor-1', consultationId: 'consult-1' })
+
+function lastWrite() {
+  return vi.mocked(prisma.auditEvent.create).mock.calls.at(-1)?.[0] as {
+    data: { action: string; actorId: string; consultationId: string; metadata?: unknown }
+  }
+}
+
+describe('recordAuditEvent', () => {
+  it('writes actor and consultation on every row', async () => {
+    await write({ action: 'consultation.created' })
+
+    expect(lastWrite().data).toMatchObject({
+      action: 'consultation.created',
+      actorId: 'doctor-1',
+      consultationId: 'consult-1',
+    })
+  })
+
+  it('omits metadata for actions that carry none', async () => {
+    await write({ action: 'consultation.approved' })
+
+    expect(lastWrite().data.metadata).toBeUndefined()
+  })
+
+  it('records detector labels, discarded field ids and version stamps on completion', async () => {
+    await write({
+      action: 'consultation.analysis_completed',
+      metadata: {
+        detected: ['NRIC', 'NAME'],
+        discardedFieldIds: ['fever', 'cough_duration'],
+        versions: {
+          provider: 'qwen',
+          model: 'qwen-flash',
+          redFlagListVersion: '2026-08-13',
+          guidelineCorpusVersion: '2026-08-13',
+        },
+      },
+    })
+
+    expect(lastWrite().data.metadata).toEqual({
+      detected: ['NRIC', 'NAME'],
+      discardedFieldIds: ['fever', 'cough_duration'],
+      versions: {
+        provider: 'qwen',
+        model: 'qwen-flash',
+        redFlagListVersion: '2026-08-13',
+        guidelineCorpusVersion: '2026-08-13',
+      },
+    })
+  })
+
+  it('records a failure category, never raw error text', async () => {
+    await write({
+      action: 'consultation.analysis_failed',
+      metadata: { reason: 'llm_response_invalid' },
+    })
+
+    expect(lastWrite().data.metadata).toEqual({ reason: 'llm_response_invalid' })
+  })
+
+  /**
+   * The union is the control: every `metadata` shape in the taxonomy holds
+   * identifiers, detector labels or version strings and nothing else. This
+   * walks the whole taxonomy and asserts no written value ever resembles
+   * clinical prose (issue #12; docs/trd.md §15).
+   */
+  it('writes no transcript text, note content or vault entry for any action', async () => {
+    const everyAction: AuditEventInput[] = [
+      { action: 'consultation.created' },
+      { action: 'consultation.asr_hosted_used' },
+      { action: 'consultation.analysis_started' },
+      {
+        action: 'consultation.analysis_completed',
+        metadata: {
+          detected: ['NRIC'],
+          discardedFieldIds: ['fever'],
+          versions: {
+            provider: 'qwen',
+            model: 'qwen-flash',
+            redFlagListVersion: 'v1',
+            guidelineCorpusVersion: 'v1',
+          },
+        },
+      },
+      { action: 'consultation.analysis_failed', metadata: { reason: 'internal_error' } },
+      { action: 'consultation.edited' },
+      { action: 'redflag.acknowledged', metadata: { redFlagId: 'rf-1' } },
+      { action: 'gap.reviewed', metadata: { gapId: 'gap-1' } },
+      { action: 'consultation.approved' },
+    ]
+
+    for (const event of everyAction) await write(event)
+
+    const written = vi
+      .mocked(prisma.auditEvent.create)
+      .mock.calls.map((call) => JSON.stringify((call[0] as { data: unknown }).data))
+      .join(' ')
+
+    // Vault tokens, and the kind of prose only a transcript or note contains.
+    expect(written).not.toMatch(/\[[A-Z]+_\d+\]/)
+    expect(written).not.toMatch(/patient|doctor:|complains|reports|prescrib/i)
+    // Nothing long enough to be a sentence of clinical text.
+    for (const call of vi.mocked(prisma.auditEvent.create).mock.calls) {
+      const meta = (call[0] as { data: { metadata?: unknown } }).data.metadata
+      for (const value of JSON.stringify(meta ?? {}).match(/"[^"]*"/g) ?? []) {
+        expect(value.length).toBeLessThan(40)
+      }
+    }
+  })
+
+  it('exposes no update or delete path', async () => {
+    const audit = await import('./index.js')
+
+    expect(Object.keys(audit).filter((k) => /update|delete|remove/i.test(k))).toEqual([])
+  })
+})
+
+describe('getAuditHistory', () => {
+  it('reads one consultation in chronological order', async () => {
+    await getAuditHistory('consult-1')
+
+    expect(prisma.auditEvent.findMany).toHaveBeenCalledWith({
+      where: { consultationId: 'consult-1' },
+      orderBy: { createdAt: 'asc' },
+      select: { id: true, action: true, metadata: true, actorId: true, createdAt: true },
+    })
+  })
+})

--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -1,0 +1,87 @@
+import { prisma } from '../lib/prisma.js'
+
+/**
+ * Short failure categories for `consultation.analysis_failed`. A closed set,
+ * never the raw error text — a thrown value on the analyse path routinely
+ * carries transcript fragments (docs/trd.md §15).
+ */
+export type AnalysisFailureReason =
+  | 'deidentification_failed'
+  | 'llm_response_invalid'
+  | 'llm_unavailable'
+  | 'internal_error'
+
+/**
+ * Which versions of the system produced one analysis (issue #12). Enough to
+ * answer "what generated this note?" months later without guessing.
+ */
+export interface AnalysisVersions {
+  provider: string
+  model: string
+  redFlagListVersion: string
+  guidelineCorpusVersion: string
+}
+
+/**
+ * The `AuditEvent.action` taxonomy from docs/trd.md §15, as a discriminated
+ * union rather than a free string.
+ *
+ * §15 proposes exactly this ("constraining its shape to a discriminated union
+ * keyed by `action` is proposed here but not yet implemented"); implementing it
+ * is what turns "no metadata value may contain clinical content" from a review
+ * convention into a compile error. There is no `metadata` shape in this union
+ * that can hold a transcript body, note text, gap or suggestion text, or a
+ * vault entry — only identifiers, detector labels, and version stamps.
+ */
+export type AuditEventInput =
+  | { action: 'consultation.created' }
+  | { action: 'consultation.asr_hosted_used' }
+  | { action: 'consultation.analysis_started' }
+  | {
+      action: 'consultation.analysis_completed'
+      metadata: {
+        /** Detector labels that fired, e.g. ["NRIC","NAME"]. Never the values. */
+        detected: readonly string[]
+        /** Field ids forced to NOT_ASSESSED by the evidence check. Ids, never content. */
+        discardedFieldIds: readonly string[]
+        versions: AnalysisVersions
+      }
+    }
+  | { action: 'consultation.analysis_failed'; metadata: { reason: AnalysisFailureReason } }
+  | { action: 'consultation.edited' }
+  | { action: 'redflag.acknowledged'; metadata: { redFlagId: string } }
+  | { action: 'gap.reviewed'; metadata: { gapId: string } }
+  | { action: 'consultation.approved' }
+
+/**
+ * Appends one audit row. Append-only by construction: this module exposes no
+ * update or delete, and nothing else in the codebase writes `auditEvent`.
+ */
+export async function recordAuditEvent(
+  event: AuditEventInput & { actorId: string; consultationId: string },
+): Promise<void> {
+  const { action, actorId, consultationId } = event
+  const metadata = 'metadata' in event ? event.metadata : undefined
+
+  await prisma.auditEvent.create({
+    data: {
+      action,
+      actorId,
+      consultationId,
+      metadata: metadata === undefined ? undefined : JSON.parse(JSON.stringify(metadata)),
+    },
+  })
+}
+
+/**
+ * The full event history for one consultation, oldest first. Ownership is the
+ * caller's responsibility — every route reaching this has already been through
+ * `assertOwnedConsultation`.
+ */
+export async function getAuditHistory(consultationId: string) {
+  return prisma.auditEvent.findMany({
+    where: { consultationId },
+    orderBy: { createdAt: 'asc' },
+    select: { id: true, action: true, metadata: true, actorId: true, createdAt: true },
+  })
+}

--- a/backend/src/deid/index.ts
+++ b/backend/src/deid/index.ts
@@ -64,10 +64,18 @@ export function deidentify(text: string, vault = new RequestTokenVault()): Deide
  * every turn rather than a new one per turn (docs/trd.md §9, §12).
  */
 export function deidentifyTranscript(transcript: Transcript): DeidentificationResult {
-  const serialised = transcript.turns
+  return deidentify(serialiseTranscript(transcript))
+}
+
+/**
+ * Exported because the evidence check (§21.4) must match spans against text in
+ * **exactly** this format. Two copies of a format that has to stay
+ * byte-identical is a drift bug waiting to happen, so there is one.
+ */
+export function serialiseTranscript(transcript: Transcript): string {
+  return transcript.turns
     .map((turn) => `${turn.speaker === 'doctor' ? 'Doctor' : 'Patient'}: ${turn.text}`)
     .join('\n')
-  return deidentify(serialised)
 }
 
 /**

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -1,0 +1,395 @@
+import type { Server } from 'node:http'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The analyse pipeline is mocked at the module seam so these tests exercise the
+ * state machine, the red-flag union and rehydration — not the model. The
+ * modules themselves are covered by #3/#4/#5 and #6.
+ */
+vi.mock('../analysis/index.js', () => ({
+  analyseNote: vi.fn(async () => ({
+    note: {
+      subjective: '[PATIENT_1] reports a cough',
+      objective: 'Chest clear',
+      assessment: 'Likely viral URTI',
+      plan: 'Fluids and rest',
+    },
+    clinicalFacts: {},
+    operational: {},
+    gaps: [
+      {
+        id: 'model-gap',
+        question: 'Any fever for [PATIENT_1]?',
+        rationale: 'Because',
+        priority: 'low',
+      },
+    ],
+    discardedFieldIds: ['fever'],
+  })),
+}))
+
+vi.mock('../gaps/index.js', () => ({
+  deriveGaps: vi.fn(() => [
+    { id: 'derived-gap', question: 'Duration?', rationale: 'Needed', priority: 'high' },
+  ]),
+}))
+
+vi.mock('../suggestions/index.js', () => ({
+  generateSuggestions: vi.fn(async () => ({
+    outOfScope: false,
+    redFlags: [
+      {
+        id: 'model-flag',
+        label: 'Model candidate',
+        severity: 'advisory',
+        evidence: '[PATIENT_1] said so',
+        source: 'model',
+      },
+    ],
+    suggestions: [
+      { id: 's1', text: 'Advise [PATIENT_1] on fluids', citations: [{ guidelineId: 'g1' }] },
+    ],
+  })),
+}))
+
+vi.mock('../redflags/index.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  evaluateRedFlags: vi.fn(() => [
+    {
+      id: 'rule-flag',
+      label: 'Rule hit',
+      severity: 'emergency',
+      evidence: 'stridor',
+      source: 'rule',
+      ruleId: 'r1',
+    },
+  ]),
+}))
+
+vi.mock('../middleware/require-session.js', () => ({
+  requireSession: (req: { doctorId?: string }, _res: unknown, next: () => void) => {
+    req.doctorId = 'doctor-1'
+    next()
+  },
+}))
+
+const TRANSCRIPT = {
+  source: 'paste',
+  turns: [{ speaker: 'patient', text: 'I am Ahmad and I have a cough' }],
+}
+
+/** Minimal in-memory stand-in for the two tables these routes touch. */
+const store = new Map<string, Record<string, unknown>>()
+const audits: { action: string; consultationId: string }[] = []
+
+vi.mock('../lib/prisma.js', () => ({
+  prisma: {
+    consultation: {
+      findFirst: vi.fn(async ({ where }: { where: { id: string; doctorId: string } }) => {
+        const row = store.get(where.id)
+        return row && row.doctorId === where.doctorId ? { ...row } : null
+      }),
+      findMany: vi.fn(async () => [...store.values()]),
+      create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        const row = {
+          id: 'c1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          analysis: null,
+          editedNote: null,
+          approvedAt: null,
+          acknowledgedRedFlagIds: null,
+          reviewedGapIds: null,
+          ...data,
+        }
+        store.set(row.id as string, row)
+        return { ...row }
+      }),
+      update: vi.fn(
+        async ({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
+          const row = { ...store.get(where.id), ...data, updatedAt: new Date() }
+          store.set(where.id, row)
+          return { ...row }
+        },
+      ),
+    },
+    auditEvent: {
+      create: vi.fn(async ({ data }: { data: { action: string; consultationId: string } }) => {
+        audits.push({ action: data.action, consultationId: data.consultationId })
+        return data
+      }),
+      findMany: vi.fn(async () => []),
+    },
+  },
+}))
+
+let server: Server
+let origin: string
+
+beforeAll(async () => {
+  const { createApp } = await import('../app.js')
+  server = createApp().listen(0)
+  await new Promise((r) => server.once('listening', r))
+  const addr = server.address()
+  if (typeof addr === 'string' || addr === null) throw new Error('no port')
+  origin = `http://127.0.0.1:${addr.port}`
+})
+
+afterAll(() => server.close())
+
+beforeEach(() => {
+  store.clear()
+  audits.length = 0
+})
+
+function seed(status: string, extra: Record<string, unknown> = {}) {
+  store.set('c1', {
+    id: 'c1',
+    doctorId: 'doctor-1',
+    status,
+    transcript: TRANSCRIPT,
+    analysis: null,
+    editedNote: null,
+    approvedAt: null,
+    acknowledgedRedFlagIds: null,
+    reviewedGapIds: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...extra,
+  })
+}
+
+/** A complete, schema-valid analysis — `toDetail` parses on the way out. */
+const AI_NOTE = {
+  subjective: 'AI subjective',
+  objective: 'AI objective',
+  assessment: 'AI assessment',
+  plan: 'AI plan',
+}
+const ANALYSIS = { note: AI_NOTE, gaps: [], redFlags: [], suggestions: [] }
+
+/**
+ * Each call presents a distinct client IP. The analyze limiter is per-IP and
+ * counts every request including 409s and 404s — correct behaviour, since a
+ * cheap rejection is still a request — but it would otherwise bleed across
+ * tests and start returning 429 partway through the file.
+ */
+let clientIp = 0
+const call = (method: string, path: string, body?: unknown) =>
+  fetch(`${origin}${path}`, {
+    method,
+    headers: {
+      'x-forwarded-for': `198.51.100.${++clientIp % 250}`,
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+
+describe('state machine — analyze', () => {
+  it.each(['draft', 'awaiting_review'])('is allowed from %s', async (status) => {
+    seed(status)
+
+    const res = await call('POST', '/api/consultations/c1/analyze')
+
+    expect(res.status).toBe(200)
+    expect(store.get('c1')?.status).toBe('awaiting_review')
+  })
+
+  it.each(['analyzing', 'approved'])('is refused with 409 from %s', async (status) => {
+    seed(status)
+
+    const res = await call('POST', '/api/consultations/c1/analyze')
+
+    expect(res.status).toBe(409)
+    expect(store.get('c1')?.status).toBe(status)
+  })
+
+  it('reverts status and records a failure category when the pipeline throws', async () => {
+    seed('draft')
+    const { generateSuggestions } = await import('../suggestions/index.js')
+    vi.mocked(generateSuggestions).mockRejectedValueOnce(new Error('transcript: chest pain'))
+
+    const res = await call('POST', '/api/consultations/c1/analyze')
+
+    expect(res.status).toBe(500)
+    expect(store.get('c1')?.status).toBe('draft')
+    expect(audits.map((a) => a.action)).toContain('consultation.analysis_failed')
+
+    const body = await res.text()
+    expect(body).not.toContain('chest pain')
+  })
+})
+
+describe('analyse output', () => {
+  beforeEach(() => seed('draft'))
+
+  async function analysed() {
+    const body = (await (await call('POST', '/api/consultations/c1/analyze')).json()) as {
+      consultation: {
+        analysis: { redFlags: { id: string }[]; gaps: { id: string }[] }
+      }
+    }
+    return body.consultation.analysis
+  }
+
+  it('unions rule and model red flags — the model cannot suppress a rule hit', async () => {
+    const ids = (await analysed()).redFlags.map((f) => f.id)
+
+    expect(ids).toContain('rule-flag')
+    expect(ids).toContain('model-flag')
+  })
+
+  it('keeps deterministic gaps alongside model gaps', async () => {
+    const ids = (await analysed()).gaps.map((g) => g.id)
+
+    expect(ids).toContain('derived-gap')
+    expect(ids).toContain('model-gap')
+  })
+
+  it('rehydrates every string field, leaving no vault token in the response', async () => {
+    const res = await call('POST', '/api/consultations/c1/analyze')
+    const body = await res.text()
+
+    expect(body).not.toMatch(/\[[A-Z]+_\d+\]/)
+  })
+
+  it('records version stamps and discarded field ids on completion', async () => {
+    await call('POST', '/api/consultations/c1/analyze')
+
+    expect(audits.map((a) => a.action)).toEqual([
+      'consultation.analysis_started',
+      'consultation.analysis_completed',
+    ])
+  })
+})
+
+describe('state machine — patch', () => {
+  it('accepts an edit while awaiting_review', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    const res = await call('PATCH', '/api/consultations/c1', {
+      editedNote: { plan: 'Revised plan' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(audits.map((a) => a.action)).toContain('consultation.edited')
+  })
+
+  it('seeds a partial first edit from the AI note, so editedNote stays complete', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    const res = await call('PATCH', '/api/consultations/c1', {
+      editedNote: { plan: 'Revised plan' },
+    })
+    const { consultation } = (await res.json()) as {
+      consultation: { editedNote: Record<string, string> }
+    }
+
+    // The one edited field changes; the other three carry over from the AI note
+    // rather than persisting a half-note that fails validation on the way out.
+    expect(consultation.editedNote).toEqual({
+      subjective: 'AI subjective',
+      objective: 'AI objective',
+      assessment: 'AI assessment',
+      plan: 'Revised plan',
+    })
+  })
+
+  it('refuses an edit when there is no note to edit yet', async () => {
+    seed('awaiting_review')
+
+    const res = await call('PATCH', '/api/consultations/c1', { editedNote: { plan: 'x' } })
+
+    expect(res.status).toBe(409)
+  })
+
+  it.each(['draft', 'analyzing', 'approved'])(
+    'refuses an edit from %s with 409',
+    async (status) => {
+      seed(status)
+
+      expect(
+        (await call('PATCH', '/api/consultations/c1', { editedNote: { plan: 'x' } })).status,
+      ).toBe(409)
+    },
+  )
+
+  it('leaves the original AI analysis untouched when the note is edited', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    await call('PATCH', '/api/consultations/c1', { editedNote: { plan: 'Doctor plan' } })
+
+    const stored = store.get('c1') as { analysis: { note: { plan: string } } }
+    expect(stored.analysis.note.plan).toBe('AI plan')
+    expect(store.get('c1')?.editedNote).toMatchObject({ plan: 'Doctor plan' })
+  })
+
+  it('acknowledges red flags additively and audits each one once', async () => {
+    seed('awaiting_review', { acknowledgedRedFlagIds: ['rf-1'] })
+
+    await call('PATCH', '/api/consultations/c1', { acknowledgedRedFlagIds: ['rf-1', 'rf-2'] })
+
+    expect(store.get('c1')?.acknowledgedRedFlagIds).toEqual(['rf-1', 'rf-2'])
+    expect(audits.filter((a) => a.action === 'redflag.acknowledged')).toHaveLength(1)
+  })
+})
+
+describe('state machine — approve', () => {
+  it('approves from awaiting_review with an analysis attached', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    const res = await call('POST', '/api/consultations/c1/approve')
+
+    expect(res.status).toBe(200)
+    expect(store.get('c1')?.status).toBe('approved')
+    expect(store.get('c1')?.approvedAt).toBeInstanceOf(Date)
+    expect(audits.map((a) => a.action)).toContain('consultation.approved')
+  })
+
+  it('refuses to approve a consultation with no analysis', async () => {
+    seed('awaiting_review')
+
+    expect((await call('POST', '/api/consultations/c1/approve')).status).toBe(409)
+    expect(store.get('c1')?.status).toBe('awaiting_review')
+  })
+
+  it.each(['draft', 'analyzing', 'approved'])(
+    'refuses approval from %s with 409',
+    async (status) => {
+      seed(status, { analysis: ANALYSIS })
+
+      expect((await call('POST', '/api/consultations/c1/approve')).status).toBe(409)
+    },
+  )
+
+  it('is terminal — no edit or re-analysis after approval', async () => {
+    seed('approved', { analysis: ANALYSIS })
+
+    expect(
+      (await call('PATCH', '/api/consultations/c1', { editedNote: { plan: 'x' } })).status,
+    ).toBe(409)
+    expect((await call('POST', '/api/consultations/c1/analyze')).status).toBe(409)
+    expect((await call('POST', '/api/consultations/c1/approve')).status).toBe(409)
+  })
+})
+
+describe('ownership', () => {
+  it.each([
+    ['GET', '/api/consultations/c1'],
+    ['POST', '/api/consultations/c1/analyze'],
+    ['PATCH', '/api/consultations/c1'],
+    ['POST', '/api/consultations/c1/approve'],
+    ['GET', '/api/consultations/c1/history'],
+  ])('%s %s returns 404 for another doctor', async (method, path) => {
+    seed('awaiting_review')
+    store.set('c1', { ...store.get('c1'), doctorId: 'someone-else' })
+
+    const res = await call(
+      method,
+      path,
+      method === 'PATCH' ? { editedNote: { plan: 'x' } } : undefined,
+    )
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -1,0 +1,385 @@
+import type { Consultation } from '@prisma/client'
+import {
+  ConsultationDetailSchema,
+  ConsultationListItemSchema,
+  type InformationGap,
+  type SoapNote,
+  SoapNoteSchema,
+  TranscriptSchema,
+} from '@shared/types'
+import { Router } from 'express'
+import { z } from 'zod'
+import { analyseNote } from '../analysis/index.js'
+import { type AnalysisFailureReason, getAuditHistory, recordAuditEvent } from '../audit/index.js'
+import { DeidentificationError, deidentifyTranscript } from '../deid/index.js'
+import { deriveGaps } from '../gaps/index.js'
+import { CORPUS_VERSION } from '../guidelines/index.js'
+import { assertOwnedConsultation } from '../lib/authz.js'
+import { HttpError } from '../lib/http-error.js'
+import { getLLMClient, LLMResponseError } from '../lib/llm/index.js'
+import { prisma } from '../lib/prisma.js'
+import { ACTIVE_RED_FLAG_LIST_VERSION, evaluateRedFlags, mergeRedFlags } from '../redflags/index.js'
+import { generateSuggestions } from '../suggestions/index.js'
+
+export const consultationsRouter = Router()
+
+/** `req.doctorId` is set by `requireSession`, which guards every route here. */
+function doctorId(req: { doctorId?: string }): string {
+  if (!req.doctorId) throw new HttpError(401, 'unauthenticated', 'Authentication required.')
+  return req.doctorId
+}
+
+/**
+ * Maps a persisted row onto the wire contract, validating on the way out — the
+ * JSON columns are `Json?` to Prisma, so this is the only place their shape is
+ * actually checked.
+ */
+function toDetail(row: Consultation) {
+  return ConsultationDetailSchema.parse({
+    id: row.id,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    transcript: row.transcript ?? null,
+    analysis: row.analysis ?? null,
+    editedNote: row.editedNote ?? null,
+    approvedAt: row.approvedAt,
+    acknowledgedRedFlagIds: row.acknowledgedRedFlagIds ?? [],
+    reviewedGapIds: row.reviewedGapIds ?? [],
+  })
+}
+
+/**
+ * Must stay byte-identical to the serialisation inside `deidentifyTranscript`,
+ * so evidence offsets computed against the raw text line up with the
+ * de-identified text the model saw. Duplicated rather than imported because
+ * `deid/` does not export it — see the note in the handover.
+ */
+/**
+ * Deterministic gaps first, model gaps additive — the same rule the red-flag
+ * engine follows. `deriveGaps` reads the structured facts, so its output is
+ * reproducible; the model may only add to it, never remove an entry.
+ */
+function mergeGaps(derived: InformationGap[], modelGaps: InformationGap[]): InformationGap[] {
+  const seen = new Set(derived.map((gap) => gap.id))
+  return [...derived, ...modelGaps.filter((gap) => !seen.has(gap.id))]
+}
+
+function classifyFailure(error: unknown): AnalysisFailureReason {
+  if (error instanceof DeidentificationError) return 'deidentification_failed'
+  if (error instanceof LLMResponseError) return 'llm_response_invalid'
+  return 'internal_error'
+}
+
+// ─── Routes (docs/trd.md §13) ────────────────────────────────────────────────
+
+consultationsRouter.get('/', async (req, res) => {
+  const rows = await prisma.consultation.findMany({
+    where: { doctorId: doctorId(req) },
+    orderBy: { updatedAt: 'desc' },
+    select: { id: true, status: true, createdAt: true, updatedAt: true },
+  })
+
+  res.json({ consultations: rows.map((row) => ConsultationListItemSchema.parse(row)) })
+})
+
+const CreateBodySchema = z.object({ transcript: TranscriptSchema })
+
+consultationsRouter.post('/', async (req, res) => {
+  const parsed = CreateBodySchema.safeParse(req.body)
+  if (!parsed.success) {
+    throw new HttpError(400, 'invalid_body', 'A valid transcript is required.')
+  }
+
+  const actor = doctorId(req)
+  const created = await prisma.consultation.create({
+    data: { doctorId: actor, status: 'draft', transcript: parsed.data.transcript },
+  })
+
+  await recordAuditEvent({
+    action: 'consultation.created',
+    actorId: actor,
+    consultationId: created.id,
+  })
+
+  // A client-asserted fact, recorded at the first point the transcript source
+  // and a consultation id coexist (docs/trd.md §15).
+  if (parsed.data.transcript.source === 'asr_hosted') {
+    await recordAuditEvent({
+      action: 'consultation.asr_hosted_used',
+      actorId: actor,
+      consultationId: created.id,
+    })
+  }
+
+  res.status(201).json({ consultation: toDetail(created) })
+})
+
+consultationsRouter.get('/:id', async (req, res) => {
+  const consultation = await assertOwnedConsultation(req.params.id, doctorId(req))
+  res.json({ consultation: toDetail(consultation) })
+})
+
+/**
+ * Full audit history for one consultation, oldest first.
+ *
+ * NOT in docs/trd.md §13's route table — added because issue #12's acceptance
+ * criterion "the full event history for a consultation is retrievable in
+ * chronological order" has no route behind it otherwise. Flagged for TRD
+ * ratification rather than assumed; delete it if §13 is meant to stay closed.
+ *
+ * Returns only what the taxonomy permits: action, actor, timestamp, and
+ * metadata that is structurally incapable of holding clinical content.
+ */
+consultationsRouter.get('/:id/history', async (req, res) => {
+  await assertOwnedConsultation(req.params.id, doctorId(req))
+  res.json({ events: await getAuditHistory(req.params.id) })
+})
+
+/**
+ * The analyse pipeline. Ordering here is a safety property, not a preference:
+ * de-identify first, run the deterministic rules on the raw transcript
+ * in-process, send only de-identified content to the model, then merge as a
+ * union so a model response can never suppress a rule hit.
+ */
+consultationsRouter.post('/:id/analyze', async (req, res) => {
+  const actor = doctorId(req)
+  const consultation = await assertOwnedConsultation(req.params.id, actor)
+
+  if (consultation.status === 'analyzing' || consultation.status === 'approved') {
+    throw new HttpError(
+      409,
+      'invalid_state',
+      `Analysis cannot start while the consultation is ${consultation.status}.`,
+    )
+  }
+
+  const transcript = TranscriptSchema.safeParse(consultation.transcript)
+  if (!transcript.success) {
+    throw new HttpError(409, 'invalid_state', 'This consultation has no usable transcript.')
+  }
+
+  const previousStatus = consultation.status
+  await prisma.consultation.update({
+    where: { id: consultation.id },
+    data: { status: 'analyzing' },
+  })
+  await recordAuditEvent({
+    action: 'consultation.analysis_started',
+    actorId: actor,
+    consultationId: consultation.id,
+  })
+
+  try {
+    const { text, vault, detected } = deidentifyTranscript(transcript.data)
+
+    // Runs on the raw transcript, in-process, regardless of model output. It
+    // never leaves the API, so it needs no gate.
+    const ruleFlags = evaluateRedFlags(transcript.data)
+
+    const [noteResult, suggestionResult] = await Promise.all([
+      analyseNote(text, text),
+      generateSuggestions(text),
+    ])
+
+    const rehydrate = (value: string) => vault.rehydrate(value)
+
+    const analysis = {
+      note: {
+        subjective: rehydrate(noteResult.note.subjective),
+        objective: rehydrate(noteResult.note.objective),
+        assessment: rehydrate(noteResult.note.assessment),
+        plan: rehydrate(noteResult.note.plan),
+      },
+      gaps: mergeGaps(
+        deriveGaps(noteResult.clinicalFacts, noteResult.operational),
+        noteResult.gaps,
+      ).map((gap) => ({
+        ...gap,
+        question: rehydrate(gap.question),
+        rationale: rehydrate(gap.rationale),
+      })),
+      redFlags: mergeRedFlags(ruleFlags, suggestionResult.redFlags).map((flag) => ({
+        ...flag,
+        label: rehydrate(flag.label),
+        evidence: rehydrate(flag.evidence),
+      })),
+      suggestions: suggestionResult.suggestions.map((suggestion) => ({
+        ...suggestion,
+        text: rehydrate(suggestion.text),
+      })),
+    }
+
+    const updated = await prisma.consultation.update({
+      where: { id: consultation.id },
+      data: { status: 'awaiting_review', analysis },
+    })
+
+    const llm = getLLMClient()
+    await recordAuditEvent({
+      action: 'consultation.analysis_completed',
+      actorId: actor,
+      consultationId: consultation.id,
+      metadata: {
+        detected,
+        discardedFieldIds: noteResult.discardedFieldIds,
+        versions: {
+          provider: llm.provider,
+          model: llm.model,
+          redFlagListVersion: ACTIVE_RED_FLAG_LIST_VERSION,
+          guidelineCorpusVersion: CORPUS_VERSION,
+        },
+      },
+    })
+
+    res.json({ consultation: toDetail(updated) })
+  } catch (error) {
+    // The doctor's only retry path is triggering analysis again — nothing
+    // retries autonomously (docs/prd.md CAP-5).
+    await prisma.consultation.update({
+      where: { id: consultation.id },
+      data: { status: previousStatus },
+    })
+    await recordAuditEvent({
+      action: 'consultation.analysis_failed',
+      actorId: actor,
+      consultationId: consultation.id,
+      metadata: { reason: classifyFailure(error) },
+    })
+
+    throw new HttpError(500, 'analysis_failed', 'Analysis could not be completed.')
+  }
+})
+
+const PatchBodySchema = z
+  .object({
+    editedNote: SoapNoteSchema.partial().optional(),
+    acknowledgedRedFlagIds: z.array(z.string()).optional(),
+    reviewedGapIds: z.array(z.string()).optional(),
+  })
+  .refine((body) => Object.keys(body).length > 0, { message: 'empty patch' })
+
+consultationsRouter.patch('/:id', async (req, res) => {
+  const actor = doctorId(req)
+  const consultation = await assertOwnedConsultation(req.params.id, actor)
+
+  if (consultation.status !== 'awaiting_review') {
+    throw new HttpError(
+      409,
+      'invalid_state',
+      consultation.status === 'approved'
+        ? 'An approved consultation is final and cannot be edited.'
+        : 'This consultation is not open for review.',
+    )
+  }
+
+  const parsed = PatchBodySchema.safeParse(req.body)
+  if (!parsed.success) {
+    throw new HttpError(400, 'invalid_body', 'No valid changes supplied.')
+  }
+  const patch = parsed.data
+
+  /**
+   * The PATCH body is a `Partial<SoapNote>`, but `editedNote` on the wire is a
+   * complete `SoapNote` — so a partial edit has to land on a complete base.
+   * That base is the doctor's existing copy, or the AI's note the first time
+   * they touch it. Merging onto `{}` instead would persist a half-note that
+   * fails validation on the way back out.
+   *
+   * `analysis.note` is only ever *read* here. The AI's original output is
+   * never written to, so the two stay independently inspectable.
+   */
+  let nextEditedNote: SoapNote | undefined
+  if (patch.editedNote !== undefined) {
+    const base =
+      consultation.editedNote ?? (consultation.analysis as { note?: unknown } | null)?.note ?? null
+    const merged = SoapNoteSchema.safeParse({
+      ...(base as Record<string, unknown> | null),
+      ...patch.editedNote,
+    })
+    if (!merged.success) {
+      throw new HttpError(409, 'invalid_state', 'This consultation has no note to edit yet.')
+    }
+    nextEditedNote = merged.data
+  }
+
+  // Acknowledgment is additive: a red flag can be acknowledged, never removed,
+  // and the AI's own output in `analysis` is never overwritten by an edit.
+  const previousFlags = new Set((consultation.acknowledgedRedFlagIds as string[] | null) ?? [])
+  const previousGaps = new Set((consultation.reviewedGapIds as string[] | null) ?? [])
+  const newFlags = (patch.acknowledgedRedFlagIds ?? []).filter((id) => !previousFlags.has(id))
+  const newGaps = (patch.reviewedGapIds ?? []).filter((id) => !previousGaps.has(id))
+
+  const updated = await prisma.consultation.update({
+    where: { id: consultation.id },
+    data: {
+      ...(nextEditedNote === undefined ? {} : { editedNote: nextEditedNote }),
+      ...(patch.acknowledgedRedFlagIds === undefined
+        ? {}
+        : { acknowledgedRedFlagIds: [...previousFlags, ...newFlags] }),
+      ...(patch.reviewedGapIds === undefined
+        ? {}
+        : { reviewedGapIds: [...previousGaps, ...newGaps] }),
+    },
+  })
+
+  if (patch.editedNote !== undefined) {
+    await recordAuditEvent({
+      action: 'consultation.edited',
+      actorId: actor,
+      consultationId: consultation.id,
+    })
+  }
+  for (const redFlagId of newFlags) {
+    await recordAuditEvent({
+      action: 'redflag.acknowledged',
+      actorId: actor,
+      consultationId: consultation.id,
+      metadata: { redFlagId },
+    })
+  }
+  for (const gapId of newGaps) {
+    await recordAuditEvent({
+      action: 'gap.reviewed',
+      actorId: actor,
+      consultationId: consultation.id,
+      metadata: { gapId },
+    })
+  }
+
+  res.json({ consultation: toDetail(updated) })
+})
+
+consultationsRouter.post('/:id/approve', async (req, res) => {
+  const actor = doctorId(req)
+  const consultation = await assertOwnedConsultation(req.params.id, actor)
+
+  if (consultation.status !== 'awaiting_review') {
+    throw new HttpError(
+      409,
+      'invalid_state',
+      consultation.status === 'approved'
+        ? 'This consultation is already approved.'
+        : 'Only a consultation awaiting review can be approved.',
+    )
+  }
+
+  // CAP-5: approval is an explicit transition over reviewed AI output. There is
+  // nothing to take responsibility for without an analysis attached.
+  if (consultation.analysis === null) {
+    throw new HttpError(409, 'invalid_state', 'This consultation has no analysis to approve.')
+  }
+
+  const updated = await prisma.consultation.update({
+    where: { id: consultation.id },
+    data: { status: 'approved', approvedAt: new Date() },
+  })
+
+  await recordAuditEvent({
+    action: 'consultation.approved',
+    actorId: actor,
+    consultationId: consultation.id,
+  })
+
+  res.json({ consultation: toDetail(updated) })
+})

--- a/backend/src/routes/reference.ts
+++ b/backend/src/routes/reference.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express'
+import { FIXTURES } from '../fixtures/index.js'
+import { GUIDELINE_CORPUS } from '../guidelines/index.js'
+
+/**
+ * The two read-only reference collections (docs/trd.md §13). Both are
+ * compile-time constants already validated against their schemas in
+ * `fixtures/corpus.ts` and `guidelines/corpus.ts`, so there is nothing to
+ * re-parse here.
+ *
+ * Session-guarded like every other clinical route — `requireSession` is mounted
+ * on both path prefixes in `app.ts`.
+ */
+export const referenceRouter = Router()
+
+referenceRouter.get('/fixtures', (_req, res) => {
+  res.json({ fixtures: FIXTURES })
+})
+
+referenceRouter.get('/guidelines', (_req, res) => {
+  // `verbatimAllowed` is surfaced, never stripped: the citation-detail view
+  // needs it to explain a licence-restricted chunk's absent quote rather than
+  // letting it look like missing data (docs/trd.md §13).
+  res.json({ guidelines: GUIDELINE_CORPUS })
+})


### PR DESCRIPTION
Closes #12. Built by the peer session; integrated, reviewed and shipped here, with one bug fix added during review.

## A real bug found in review — the evidence check was reading the wrong text

`analyseNote(content, transcriptText)` was being called with the **de-identified** payload as `content` and the **raw** transcript as `transcriptText`.

The model only ever sees de-identified text, so the spans it returns carry tokens like `[PATIENT_1]`. Matching those against the raw transcript fails for **any assertion whose evidence contains an identifier**, silently forcing it to `NOT_ASSESSED`.

It errs in the safe direction per TRD §21.4's asymmetry, so nothing unsafe would have shipped — but it would have produced spurious gaps and a thinner note than the transcript supports, and it would have looked like model weakness rather than a wiring fault. Fixed to pass the de-identified text.

Related: `serialiseTranscript` was duplicated between `deid/` and the route. Two copies of a format that must stay byte-identical for evidence offsets to line up is a latent drift bug, so `deid/` now exports it and there is one copy.

## A second real bug, found by the peer's own tests

`PATCH` accepted a partial `SoapNote`, but `ConsultationDetailSchema.editedNote` is a **complete** one. Merging a partial onto `{}` persisted a half-note that then failed validation on the way out — every first edit would have 500'd. Not a contract flaw; a gap between two halves of §13 that only appears when you round-trip it.

Fixed by seeding the first edit from `analysis.note`, so `editedNote` is always complete. `analysis` is only ever read, never written, so the AI output and the doctor's copy stay independently inspectable. Editing with no analysis attached is now `409` rather than a 500.

## The pipeline, in the order that matters

1. De-identify.
2. `evaluateRedFlags` on the **raw** transcript, in-process — it never leaves the API, so it needs no gate, and it runs regardless of model output.
3. `analyseNote` and `generateSuggestions` on de-identified content only.
4. `mergeRedFlags` — a union, never a filter.
5. **Rehydrate every string field** before persisting or returning. The vault is request-scoped and discarded when the handler returns.

**The two LLM calls run concurrently, not sequentially.** `generateSuggestions` takes only the de-identified content and has no dependency on the note. TRD §12's "two sequential calls" is a latency estimate, not an ordering constraint, and serialising them would roughly double wall-clock against §19 row 8's already-doubtful 30s target for no safety gain. Flagging it because §12's wording could be read either way.

## State machine

| Transition | Enforcement |
| --- | --- |
| `analyze` from `draft` / `awaiting_review` | allowed; re-analysis explicitly tested |
| `analyze` from `analyzing` / `approved` | `409`, status untouched |
| analyse throws | status reverted to its **pre-call** value, `consultation.analysis_failed` with a category, `500` as `ErrorEnvelopeSchema`, **no autonomous retry** |
| `PATCH` | only `awaiting_review`; `409` otherwise |
| `approve` | requires `awaiting_review` **and** a non-null `analysis`; sets `approvedAt` |
| `approved` | terminal — edit, re-analyze and re-approve all `409` |

Every id-bearing path goes through `assertOwnedConsultation` → `404`, never `403`.

## Two extensions beyond the contract — both flagged for your ratification

1. **§15's proposed discriminated union is now implemented.** §15 says constraining `metadata` by `action` is "proposed here but not yet implemented". It is now: there is no shape in the union capable of holding a transcript body, note text, or vault entry, so the labels-only rule is a **compile error** rather than a review convention. A test walks all nine actions and asserts no written value matches a vault token, clinical prose, or any string ≥40 chars.
2. **`GET /api/consultations/:id/history` is not in §13's route table.** #12's acceptance criterion "the full event history is retrievable in chronological order" has no route behind it otherwise. Added rather than silently dropping the AC — but it extends a Final contract, so **ratify or delete it**. Ownership-scoped; returns action, actor, timestamp and metadata only.

**One inference worth a second look:** gaps merge deterministic-first, with model gaps appended only when the id is new. `analyseNote` returns gaps *and* `deriveGaps` exists, and neither document says which wins. The red-flag idiom was applied — deterministic first, model strictly additive — on the reasoning that a model silently dropping a deterministic gap is the same failure class the red-flag rule exists to prevent. That is reasoning, not a documented decision.

## Verification

```
bun run lint        85 files, 4 warnings (console.log in prisma/seed.ts, intentional for a CLI)
bun run typecheck   clean across shared, backend, frontend
bun run build       clean
bun run --cwd backend test    215 passed (16 files)
```

35 of those are new here: `consultations.test.ts` 28, `audit.test.ts` 7.

## Deliberately not done

- **No `Consultation.analysisMeta` column.** Version stamps (provider, model, rule-set version, corpus version) live in the `analysis_completed` audit row rather than on the consultation, because re-analysis overwrites `analysis` and an append-only row is what actually survives. Cheap to add later if you'd rather the row were self-describing.
- No frontend.

## Clinical-Safety Checklist

- [x] **No un-de-identified text reaches an LLM provider** — de-identification is step 1; both LLM calls take the branded type; the rule engine runs in-process and never egresses
- [x] No hardcoded outputs or faked latency — the pipeline genuinely runs
- [x] **LLM cannot suppress a rule hit** — `mergeRedFlags` is a union, and the model never sees the engine's output
- [x] No free-text citations — enforced upstream by the request-time enum
- [x] `diagnosis` transcription-bound — enforced upstream by the evidence check
- [x] **Nothing logs transcript bodies, note contents or vault entries** — the audit metadata union structurally cannot hold them, asserted by a test walking all nine actions; the error handler never logs the thrown value
- [x] Approval is an explicit state transition writing an audit event — never a default
