### PR TITLE
fix(api): resolve the client IP behind Cloudflare so rate limiting buckets per caller

### DIFF
--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -71,9 +71,32 @@ export const auth = betterAuth({
       sameSite: isHttps ? 'none' : 'lax',
       secure: isHttps,
     },
-    // Render terminates TLS at its proxy, so the socket address is the proxy's.
-    // Without this the rate limiter buckets every caller together.
-    ipAddress: { ipAddressHeaders: ['x-forwarded-for'] },
+    /**
+     * `cf-connecting-ip` first, and that ordering is the whole fix.
+     *
+     * Render fronts every service with Cloudflare (`cf-ray` is present on all
+     * responses), so `x-forwarded-for` arrives holding a **chain** — client,
+     * then one or more proxies. better-auth 1.6.27 refuses a multi-entry
+     * `x-forwarded-for` unless `trustedProxies` is configured
+     * (`getIPFromHeader`: `if (forwardedIps.length !== 1) return null`), which
+     * is correct — an unbounded chain is trivially spoofable, so guessing which
+     * entry is the client would be worse than declining.
+     *
+     * Declining, however, means `getIp()` returns null and every caller shares
+     * one bucket per path. Observed in production as:
+     * "Rate limiting could not determine a client IP and is falling back to a
+     * single shared per-path bucket."
+     *
+     * That is worse than no limiter: one client can exhaust the bucket for
+     * everyone, turning a brute-force control into a denial-of-service vector.
+     *
+     * `cf-connecting-ip` resolves it without a proxy allow-list to maintain.
+     * Cloudflare sets it to the true client address and overwrites any
+     * client-supplied value, so it is single-valued and not spoofable — which
+     * is exactly the shape `getIPFromHeader` accepts. `x-forwarded-for` stays
+     * as the fallback for any environment without Cloudflare in front.
+     */
+    ipAddress: { ipAddressHeaders: ['cf-connecting-ip', 'x-forwarded-for'] },
   },
 
   /**

--- a/backend/src/middleware/rate-limit.test.ts
+++ b/backend/src/middleware/rate-limit.test.ts
@@ -1,0 +1,42 @@
+import type { Request } from 'express'
+import { describe, expect, it } from 'vitest'
+import { auth } from '../lib/auth.js'
+import { clientKey } from './rate-limit.js'
+
+const asRequest = (headers: Record<string, string>, ip?: string) =>
+  ({ headers, ip }) as unknown as Request
+
+/**
+ * Regression cover for a production defect: behind Render's Cloudflare edge,
+ * `x-forwarded-for` arrives as a chain, both limiters failed to resolve a
+ * client address, and every caller fell into one shared bucket — which turns a
+ * brute-force control into a denial-of-service vector.
+ */
+describe('client address resolution behind the Cloudflare edge', () => {
+  it('prefers cf-connecting-ip over a multi-entry x-forwarded-for', () => {
+    const key = clientKey(
+      asRequest({
+        'cf-connecting-ip': '203.0.113.9',
+        'x-forwarded-for': '203.0.113.9, 172.71.0.1, 10.0.0.5',
+      }),
+    )
+    expect(key).toBe('203.0.113.9')
+  })
+
+  it('does not collapse two different callers into one bucket', () => {
+    const chain = '198.51.100.7, 172.71.0.1, 10.0.0.5'
+    const a = clientKey(asRequest({ 'cf-connecting-ip': '203.0.113.9', 'x-forwarded-for': chain }))
+    const b = clientKey(asRequest({ 'cf-connecting-ip': '198.51.100.7', 'x-forwarded-for': chain }))
+    expect(a).not.toBe(b)
+  })
+
+  it('falls back to req.ip where no Cloudflare header is present', () => {
+    expect(clientKey(asRequest({}, '192.0.2.44'))).toBe('192.0.2.44')
+  })
+
+  it('keeps cf-connecting-ip ahead of x-forwarded-for in the auth config', () => {
+    // better-auth 1.6.27 rejects a multi-entry x-forwarded-for outright unless
+    // trustedProxies is set, so the ordering here is the fix, not a preference.
+    expect(auth.options.advanced?.ipAddress?.ipAddressHeaders?.[0]).toBe('cf-connecting-ip')
+  })
+})

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -1,4 +1,24 @@
-import rateLimit from 'express-rate-limit'
+import type { Request } from 'express'
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit'
+
+/**
+ * Resolves the client address behind Render's Cloudflare edge.
+ *
+ * Identical reasoning to the `ipAddress` block in `lib/auth.ts`, and it has to
+ * be repeated here because the two limiters resolve the caller independently:
+ * `x-forwarded-for` arrives as a chain, so `trust proxy` has to guess a hop
+ * count, and a wrong guess buckets every caller under a Cloudflare edge address
+ * rather than their own. `cf-connecting-ip` is single-valued, set by Cloudflare,
+ * and overwritten if a client supplies it.
+ *
+ * `ipKeyGenerator` is still used on the fallback path so IPv6 callers are
+ * bucketed by subnet rather than by a single address they can trivially vary.
+ */
+export function clientKey(req: Request): string {
+  const forwarded = req.headers['cf-connecting-ip']
+  if (typeof forwarded === 'string' && forwarded.length > 0) return forwarded
+  return ipKeyGenerator(req.ip ?? '')
+}
 
 /**
  * Per-IP limiter for `POST /api/consultations/:id/analyze` (docs/trd.md §16) —
@@ -13,6 +33,7 @@ export const analyzeRateLimit = rateLimit({
   limit: 10,
   standardHeaders: 'draft-7',
   legacyHeaders: false,
+  keyGenerator: clientKey,
   message: {
     error: { code: 'rate_limited', message: 'Too many analysis requests. Please retry shortly.' },
   },


### PR DESCRIPTION
Fixes a production defect surfaced by a Render log warning:

```
WARN [Better Auth]: Rate limiting could not determine a client IP and is falling
back to a single shared per-path bucket.
```

## Why it happened

Render fronts every service with Cloudflare — `cf-ray` is present on every response — so `x-forwarded-for` arrives holding a **chain**: client, then one or more proxies.

better-auth 1.6.27 refuses that. `getIPFromHeader` in `@better-auth/core`:

```js
if (forwardedIps.length !== 1) return null
```

Without `trustedProxies` configured it accepts `x-forwarded-for` **only when it holds exactly one address**. That is the right call, not a bug: an unbounded chain is trivially spoofable, so guessing which entry is the client would be worse than declining.

Declining, though, means `getIp()` returns `null`, and the limiter falls back to one bucket per path shared by everybody.

## Why that is worse than having no limiter

A shared bucket inverts the control. The `/sign-in/email` rule is 5 per 60s — across **all callers combined**. Any single client can spend that budget and lock every other user out of sign-in for the rest of the window. A brute-force control became a denial-of-service vector, and the same applied to `/sign-up/email` (3/60s) and `/guest` (10/60s).

It also means the per-IP protection reported as verified when #14 shipped was configured but not in force in production. Recording that plainly rather than quietly correcting it.

## The fix

Both limiters now read **`cf-connecting-ip` first**, falling back to `x-forwarded-for`.

Cloudflare sets `cf-connecting-ip` to the true client address and **overwrites any client-supplied value**, so it is single-valued and not spoofable — exactly the shape `getIPFromHeader` already accepts. No proxy allow-list to maintain, which is the alternative (`trustedProxies` would need Cloudflare's published ranges plus Render's internal range, and would silently rot as those change).

The two limiters resolve the caller independently, so the fix is applied in both places:

- `lib/auth.ts` — `advanced.ipAddress.ipAddressHeaders: ['cf-connecting-ip', 'x-forwarded-for']`
- `middleware/rate-limit.ts` — a `keyGenerator` preferring `cf-connecting-ip`, still using `ipKeyGenerator` on the fallback path so IPv6 callers bucket by subnet rather than by an address they can vary at will

`app.set('trust proxy', 1)` is left alone — with `cf-connecting-ip` doing the work it no longer has to guess a hop count correctly.

## Tests

Four regression tests, because this is a control that was reported working once already:

- `cf-connecting-ip` wins over a multi-entry `x-forwarded-for`
- two different callers sharing an identical proxy chain do **not** collapse into one bucket — the actual defect
- fallback to `req.ip` where no Cloudflare header is present
- the auth config keeps `cf-connecting-ip` first, since the ordering *is* the fix

## Verification

```
bun run lint        86 files, 4 warnings (console.log in prisma/seed.ts, intentional)
bun run typecheck   clean across shared, backend, frontend
bun run --cwd backend test    219 passed (17 files)
```

Confirmed empirically before writing the fix: `cf-ray: a2a7489e181f8066-KUL` on a live response, so Cloudflare is genuinely in the path and `cf-connecting-ip` will be populated.

## Clinical-Safety Checklist

- [x] No un-de-identified text reaches an LLM provider — no egress code in this diff
- [x] No hardcoded outputs — n/a
- [x] LLM cannot suppress a rule hit — n/a
- [x] No free-text citations — n/a
- [x] **Nothing logs transcript bodies, note contents or vault entries** — the resolved address is used as a rate-limit key only; it is never logged, and it is not written to `AuditEvent`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client IP detection behind Cloudflare and other proxies.
  * Rate limits now apply consistently to the correct client, including IPv6 connections.
  * Added fallback handling when forwarded IP information is unavailable.

* **Tests**
  * Added regression coverage for IP detection, rate-limit separation, and authentication header priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->