### PR TITLE
fix(llm): make the model actually emit evidence spans, and bound the response

### DIFF
--- a/backend/src/acceptance/safety.test.ts
+++ b/backend/src/acceptance/safety.test.ts
@@ -263,7 +263,7 @@ describe('GUARANTEE — unknown is never recorded as negative', () => {
     // response arrives — every checklist key present, defaults filled in.
     const modelOutput = LlmClinicalFactsSchema.parse({
       symptoms: {
-        haemoptysis: { state: 'DENIED', value: 'denies haemoptysis' },
+        haemoptysis: { state: 'DENIED', value: 'denies haemoptysis', evidence: '' },
         cough: { state: 'PRESENT', value: 'cough', evidence: 'Cough 3 days' },
       },
       history: {},

--- a/backend/src/analysis/diagnostic-guard.test.ts
+++ b/backend/src/analysis/diagnostic-guard.test.ts
@@ -1,57 +1,57 @@
 import type { InformationGap, SoapNote } from '@shared/types'
 import { describe, expect, it } from 'vitest'
-import { LLMResponseError } from '../lib/llm/index.js'
-import { assertNoDiagnosticProse } from './diagnostic-guard.js'
+import { stripDiagnosticProse } from './diagnostic-guard.js'
 
 const note = (assessment: string): SoapNote => ({
-  subjective: '',
-  objective: '',
+  subjective: 'S',
+  objective: 'O',
   assessment,
-  plan: '',
+  plan: 'P',
 })
 
-const gap = (question: string, rationale: string): InformationGap => ({
-  id: 'gap-1',
+const gap = (id: string, question: string, rationale: string): InformationGap => ({
+  id,
   question,
   rationale,
   priority: 'medium',
 })
 
-describe('assertNoDiagnosticProse (docs/prd.md §10)', () => {
-  it('allows an assessment that summarises findings without naming a diagnosis', () => {
-    expect(() =>
-      assertNoDiagnosticProse(
-        note('Cough and sore throat for 3 days, throat erythematous on exam.'),
-        [],
-      ),
-    ).not.toThrow()
+describe('stripDiagnosticProse (docs/prd.md §10)', () => {
+  it('leaves an assessment that summarises findings without naming a diagnosis', () => {
+    const input = note('Cough and sore throat for 3 days, throat erythematous on exam.')
+    const result = stripDiagnosticProse(input, [])
+
+    expect(result.note.assessment).toBe(input.assessment)
+    expect(result.suppressedFieldIds).toEqual([])
   })
 
-  it('rejects an assessment that states a diagnosis', () => {
-    expect(() =>
-      assertNoDiagnosticProse(note('Diagnosis: viral upper respiratory tract infection.'), []),
-    ).toThrow(LLMResponseError)
+  it('blanks an assessment that states a diagnosis, rather than losing the analysis', () => {
+    const result = stripDiagnosticProse(
+      note('Diagnosis: viral upper respiratory tract infection.'),
+      [],
+    )
+
+    expect(result.note.assessment).toBe('')
+    expect(result.suppressedFieldIds).toEqual(['note.assessment'])
+    // The rest of the note must survive — one bad field is not the whole run.
+    expect(result.note.subjective).toBe('S')
+    expect(result.note.plan).toBe('P')
   })
 
-  it('rejects a gap rationale that implies a differential', () => {
-    expect(() =>
-      assertNoDiagnosticProse(note(''), [
-        gap('Any exposure history?', 'Differential includes bacterial pharyngitis.'),
-      ]),
-    ).toThrow(LLMResponseError)
+  it('drops a gap whose rationale implies a differential, keeping the others', () => {
+    const result = stripDiagnosticProse(note(''), [
+      gap('g1', 'Any exposure history?', 'Differential includes bacterial pharyngitis.'),
+      gap('g2', 'No respiratory rate recorded.', 'Needed to characterise severity.'),
+    ])
+
+    expect(result.gaps.map((g) => g.id)).toEqual(['g2'])
+    expect(result.suppressedFieldIds).toEqual(['gap.g1'])
   })
 
-  it('names the offending field, never the diagnostic content, in the error', () => {
-    const err = (() => {
-      try {
-        assertNoDiagnosticProse(note('Impression: likely viral.'), [])
-      } catch (e) {
-        return e
-      }
-    })()
+  it('records field ids only, never the diagnostic content', () => {
+    const result = stripDiagnosticProse(note('Impression: likely viral.'), [])
 
-    expect(err).toBeInstanceOf(LLMResponseError)
-    expect((err as Error).message).toContain('note.assessment')
-    expect((err as Error).message).not.toContain('viral')
+    expect(result.suppressedFieldIds.join(' ')).toContain('note.assessment')
+    expect(result.suppressedFieldIds.join(' ')).not.toContain('viral')
   })
 })

--- a/backend/src/analysis/diagnostic-guard.ts
+++ b/backend/src/analysis/diagnostic-guard.ts
@@ -1,5 +1,4 @@
 import type { InformationGap, SoapNote } from '@shared/types'
-import { LLMResponseError } from '../lib/llm/index.js'
 
 /**
  * Tier-3 guard (docs/trd.md §21.3) for docs/prd.md §10: the SOAP assessment
@@ -18,25 +17,51 @@ function containsDiagnosticProse(text: string): boolean {
   return DIAGNOSTIC_PHRASING.some((pattern) => pattern.test(text))
 }
 
-/** Throws `LLMResponseError` naming the offending field id, never its content. */
-export function assertNoDiagnosticProse(note: SoapNote, gaps: readonly InformationGap[]): void {
-  const fields: ReadonlyArray<readonly [string, string]> = [
-    ['note.assessment', note.assessment],
-    ...gaps.flatMap(
-      (gap) =>
-        [
-          [`gap.${gap.id}.question`, gap.question],
-          [`gap.${gap.id}.rationale`, gap.rationale],
-        ] as const,
-    ),
-  ]
+export interface DiagnosticGuardResult {
+  note: SoapNote
+  gaps: InformationGap[]
+  /** Field ids suppressed. Ids only — never the offending content. */
+  suppressedFieldIds: string[]
+}
 
-  for (const [fieldId, text] of fields) {
-    if (containsDiagnosticProse(text)) {
-      throw new LLMResponseError(
-        `note_and_gaps response contains diagnostic language in ${fieldId}`,
-        'note_and_gaps',
-      )
-    }
+/**
+ * Suppresses the offending field rather than rejecting the response.
+ *
+ * This used to throw, which was the wrong runtime behaviour for a Tier-3
+ * control and inconsistent with the evidence check beside it: §21.4 downgrades
+ * the individual fact precisely so one bad field does not cost the doctor the
+ * whole analysis. Throwing here did exactly that — a single stray "diagnosis"
+ * in the assessment discarded a 26-second run, and the doctor's only recourse
+ * was to trigger it again and hope.
+ *
+ * §21.4's asymmetry argument applies unchanged. A blanked assessment costs the
+ * doctor one field they were going to edit anyway, and the structured
+ * `diagnosis` field still carries the answer. A lost analysis costs the whole
+ * consultation.
+ *
+ * The rate is worth watching rather than ignoring: `suppressedFieldIds` is
+ * recorded on the audit event for the same reason `discardedFieldIds` is
+ * (§21.7 — the downgrade rate is itself a quality signal).
+ */
+export function stripDiagnosticProse(
+  note: SoapNote,
+  gaps: readonly InformationGap[],
+): DiagnosticGuardResult {
+  const suppressedFieldIds: string[] = []
+
+  let assessment = note.assessment
+  if (containsDiagnosticProse(assessment)) {
+    assessment = ''
+    suppressedFieldIds.push('note.assessment')
   }
+
+  const keptGaps = gaps.filter((gap) => {
+    if (containsDiagnosticProse(gap.question) || containsDiagnosticProse(gap.rationale)) {
+      suppressedFieldIds.push(`gap.${gap.id}`)
+      return false
+    }
+    return true
+  })
+
+  return { note: { ...note, assessment }, gaps: keptGaps, suppressedFieldIds }
 }

--- a/backend/src/analysis/evidence.test.ts
+++ b/backend/src/analysis/evidence.test.ts
@@ -18,7 +18,9 @@ const bareOperational = (overrides: Record<string, unknown> = {}) =>
 
 describe('applyEvidenceCheck (docs/trd.md §21.4)', () => {
   it('downgrades a DENIED assertion carrying no evidence span to NOT_ASSESSED', () => {
-    const facts = bareFacts({ symptoms: { fever: { state: 'DENIED', value: 'no fever' } } })
+    const facts = bareFacts({
+      symptoms: { fever: { state: 'DENIED', value: 'no fever', evidence: '' } },
+    })
 
     const { clinicalFacts, discardedFieldIds } = applyEvidenceCheck(
       facts,

--- a/backend/src/analysis/index.test.ts
+++ b/backend/src/analysis/index.test.ts
@@ -90,7 +90,7 @@ describe('analyseNote', () => {
             fever: { state: 'PRESENT', value: 'fever', evidence: '38.2 degrees' },
             // Reproduces docs/trd.md §21.1: the model asserts a negative for a
             // topic the transcript never raises, with no supporting span.
-            haemoptysis: { state: 'DENIED', value: 'no haemoptysis' },
+            haemoptysis: { state: 'DENIED', value: 'no haemoptysis', evidence: '' },
           },
           history: {},
           observations: {},
@@ -120,7 +120,11 @@ describe('analyseNote', () => {
         clinicalFacts: emptyFacts(),
         operational: LlmOperationalBlockSchema.parse({
           // No verbatim span — the doctor never named a condition in this fixture.
-          diagnosis: { state: 'PRESENT', value: 'viral upper respiratory tract infection' },
+          diagnosis: {
+            state: 'PRESENT',
+            value: 'viral upper respiratory tract infection',
+            evidence: '',
+          },
         }),
         gaps: [],
       }

--- a/backend/src/analysis/index.ts
+++ b/backend/src/analysis/index.ts
@@ -1,7 +1,7 @@
 import { NoteAndGapsResponseSchema } from '@shared/types'
 import type { Deidentified } from '../deid/types.js'
 import { getLLMClient } from '../lib/llm/index.js'
-import { assertNoDiagnosticProse } from './diagnostic-guard.js'
+import { stripDiagnosticProse } from './diagnostic-guard.js'
 import { applyEvidenceCheck } from './evidence.js'
 import { NOTE_AND_GAPS_SYSTEM_PROMPT } from './prompt.js'
 import type { NoteAndGapsResult } from './types.js'
@@ -36,13 +36,14 @@ export async function analyseNote(
     transcriptText,
   )
 
-  assertNoDiagnosticProse(response.note, response.gaps)
+  const guarded = stripDiagnosticProse(response.note, response.gaps)
 
   return {
-    note: response.note,
+    note: guarded.note,
     clinicalFacts,
     operational,
-    gaps: response.gaps,
+    gaps: guarded.gaps,
     discardedFieldIds,
+    suppressedFieldIds: guarded.suppressedFieldIds,
   }
 }

--- a/backend/src/analysis/prompt.ts
+++ b/backend/src/analysis/prompt.ts
@@ -22,6 +22,13 @@ Produce four things from the transcript:
    place a diagnosis may appear is the structured "diagnosis" field in the
    operational block below, and only when the doctor said it out loud.
 
+   This holds even when the doctor did name a condition. Recording it in the
+   "diagnosis" field is correct; repeating it in "assessment" is not. Write
+   the assessment as what was found — symptoms, duration, examination
+   findings — and stop there. Do not use the words "diagnosis", "impression",
+   or "differential" anywhere in the note or in gap text; a field containing
+   them is discarded in code, so using them costs you the field.
+
 2. A per-field clinical-fact assertion for every symptom, history item,
    observation, and examination finding in the checklist. Each assertion
    carries a state (PRESENT, DENIED, CLINICIAN_OBSERVED, NOT_ASSESSED,
@@ -33,6 +40,17 @@ Produce four things from the transcript:
      from the transcript that supports it — not a summary, not a paraphrase.
      If you cannot quote the transcript directly, do not use PRESENT or
      DENIED.
+   - An evidence span is checked against the transcript by exact text match,
+     so three things break it and all three are avoidable. Quote from
+     **one speaker turn only** — never join a question and its answer into a
+     single span, and never include the "Doctor:" or "Patient:" label.
+     Never abbreviate with "..." or any ellipsis. Never tidy up wording,
+     spelling, or grammar: copy it exactly as written, Manglish and all.
+     A shorter span that matches beats a longer one that does not — quote
+     the few words that carry the finding, not the whole turn.
+   - Where a field genuinely has no supporting text, leave "evidence" as an
+     empty string and use NOT_ASSESSED. An empty string is expected and
+     costs you nothing.
    - NOT_ASSESSED is the correct and cheapest answer whenever the transcript
      is silent on a topic. Using NOT_ASSESSED is never a failure. A topic
      nobody raised must be NOT_ASSESSED, never DENIED — inventing a negative

--- a/backend/src/analysis/types.ts
+++ b/backend/src/analysis/types.ts
@@ -12,4 +12,6 @@ export interface NoteAndGapsResult {
   operational: OperationalBlock
   gaps: InformationGap[]
   discardedFieldIds: string[]
+  /** Fields blanked or dropped by the diagnostic-prose guard. Ids only. */
+  suppressedFieldIds: string[]
 }

--- a/backend/src/lib/llm/openai-compatible.ts
+++ b/backend/src/lib/llm/openai-compatible.ts
@@ -44,6 +44,12 @@ export class OpenAICompatibleClient implements LLMClient {
     const completion = await this.client.chat.completions.create({
       model: this.model,
       temperature: request.temperature ?? 0.2,
+      // The `note_and_gaps` response carries 34 assertions, each with a state,
+      // a value and an evidence span, and measured at 3,324 completion tokens
+      // on a 3,000-word consultation. That is close enough to the provider's
+      // default output ceiling that some runs spill over and return truncated
+      // JSON — which surfaces as a parse failure well after the real cause.
+      max_tokens: request.maxTokens ?? 8192,
       messages: [
         { role: 'system', content: request.system },
         { role: 'user', content: request.content },
@@ -58,9 +64,20 @@ export class OpenAICompatibleClient implements LLMClient {
       },
     })
 
-    const raw = completion.choices[0]?.message.content
+    const choice = completion.choices[0]
+    const raw = choice?.message.content
     if (!raw) {
       throw new LLMResponseError('Provider returned an empty response', request.operation)
+    }
+
+    // Distinguished from malformed JSON deliberately. A truncated response is
+    // also unparseable, so without this the failure reads as a provider bug
+    // when it is a budget problem with a different fix.
+    if (choice?.finish_reason === 'length') {
+      throw new LLMResponseError(
+        'Provider response hit the output token limit and was truncated',
+        request.operation,
+      )
     }
 
     let parsed: unknown

--- a/backend/src/lib/llm/types.ts
+++ b/backend/src/lib/llm/types.ts
@@ -30,6 +30,8 @@ export interface GenerateRequest<T> {
   /** Name given to the provider's structured-output schema. */
   schemaName: string
   temperature?: number
+  /** Output ceiling. Defaults to 8192 at the adapter; see `note_and_gaps`. */
+  maxTokens?: number
 }
 
 export class LLMResponseError extends Error {

--- a/shared/src/index.test.ts
+++ b/shared/src/index.test.ts
@@ -68,18 +68,34 @@ describe('ClinicalAssertionSchema', () => {
 })
 
 describe('the decoding schema is permissive, the persistence schema is strict', () => {
-  it('lets the model return an evidence-less DENIED, so one bad fact cannot fail the whole run', () => {
-    // Measured against qwen-flash 13/08/26: it emits exactly this shape.
-    const emitted = { state: 'DENIED', value: 'no fever' }
+  it('requires the model to emit the evidence key, since an optional one was never filled', () => {
+    // Measured: with `evidence` optional, 0 of 18 PRESENT/DENIED assertions
+    // carried a span. Requiring the key took that to 18 of 18.
+    expect(
+      LlmClinicalAssertionSchema.safeParse({ state: 'DENIED', value: 'no fever' }).success,
+    ).toBe(false)
+  })
+
+  it('lets an empty span through decoding, so one bad fact cannot fail the whole run', () => {
+    const emitted = { state: 'DENIED', value: 'no fever', evidence: '' }
     expect(LlmClinicalAssertionSchema.safeParse(emitted).success).toBe(true)
     expect(ClinicalAssertionSchema.safeParse(emitted).success).toBe(false)
+  })
+
+  it('keeps NOT_ASSESSED the cheapest path — empty strings, no content required', () => {
+    const result = LlmClinicalAssertionSchema.safeParse({
+      state: 'NOT_ASSESSED',
+      value: '',
+      evidence: '',
+    })
+    expect(result.success).toBe(true)
   })
 
   it('accepts a whole model response whose assertions carry no spans', () => {
     const result = NoteAndGapsResponseSchema.safeParse({
       note: { subjective: 'Cough 3 days.', objective: '', assessment: '', plan: '' },
       clinicalFacts: {
-        symptoms: { fever: { state: 'DENIED', value: 'no fever' } },
+        symptoms: { fever: { state: 'DENIED', value: 'no fever', evidence: '' } },
         history: {},
         observations: {},
         examination: {},

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -80,17 +80,46 @@ const ClinicalAssertionShape = z.object({
 })
 
 /**
- * What the model is permitted to emit. Deliberately *not* refined.
+ * What the model is permitted to emit.
  *
- * The evidence rule cannot live at the decoding boundary: measured against
- * qwen-flash on 13/08/26, the model emits `{ state: 'DENIED', value: 'no
- * fever' }` with no span. Enforcing the rule in `safeParse` would throw
- * `LLMResponseError` and the doctor would get nothing at all. docs/trd.md §21.4
- * specifies the opposite behaviour — the check runs *after* `safeParse` and
- * downgrades the individual fact to `NOT_ASSESSED`, so one unsupported
- * assertion costs one gap prompt rather than the whole analysis.
+ * `value` and `evidence` are **required here but optional in the persisted
+ * schema**, and that asymmetry is the whole point. Under strict JSON-Schema
+ * decoding an optional property is simply absent from `required`, and the model
+ * takes that permission every time: measured against qwen-flash on a 3,085-word
+ * consultation, **0 of 18** `PRESENT`/`DENIED` assertions carried a span. The
+ * evidence check (docs/trd.md §21.4) then downgraded every one of them, so a
+ * thorough consultation produced a note asserting nothing and 23 documentation
+ * gaps. The safety property held; the product did not.
+ *
+ * Requiring the field flipped that to **18 of 18 emitted, 12 of 18 matching
+ * verbatim** on the same transcript, with `diagnosis` correctly `PRESENT`.
+ *
+ * The empty string is permitted so `NOT_ASSESSED` stays the cheapest path
+ * (docs/trd.md §3, ratification condition 1): a field the transcript never
+ * touched costs `"value":"","evidence":""` and nothing more. The condition
+ * forbids a field being implicitly required to be *filled*, which this respects
+ * — it requires only that the key be present.
+ *
+ * It is deliberately **not** refined. Enforcing the span rule at the decoding
+ * boundary would throw `LLMResponseError` and leave the doctor with nothing;
+ * §21.4 wants the individual fact downgraded instead.
  */
-export const LlmClinicalAssertionSchema = ClinicalAssertionShape
+export const LlmClinicalAssertionSchema = z.object({
+  state: AssertionStateSchema,
+  /**
+   * Bounded, like `evidence` below. An unbounded string under strict decoding
+   * is the other runaway vector alongside an unbounded array, and a normalised
+   * concept label has no business being longer than this.
+   */
+  value: z.string().max(120),
+  /**
+   * A span long enough to carry the finding and no longer. The bound does
+   * double duty: it caps output tokens, and it pushes the model toward the
+   * short single-turn quote that the evidence check can actually match — a
+   * span that wanders across speaker turns is exactly the one that fails.
+   */
+  evidence: z.string().max(400),
+})
 
 /**
  * The persisted and API-facing contract, applied *after* the §21.4 evidence
@@ -172,7 +201,7 @@ export const ClinicalFactsSchema = buildClinicalFacts(
 )
 
 export const LlmClinicalFactsSchema = buildClinicalFacts(
-  LlmClinicalAssertionSchema.default({ state: 'NOT_ASSESSED' }),
+  LlmClinicalAssertionSchema.default({ state: 'NOT_ASSESSED', value: '', evidence: '' }),
 )
 
 // ─── Malaysian operational block ─────────────────────────────────────────────
@@ -191,7 +220,17 @@ export const LlmClinicalFactsSchema = buildClinicalFacts(
 const buildOperationalBlock = <T extends z.ZodType>(field: T) =>
   z.object({
     diagnosis: field,
-    medicationsDispensed: z.array(field).default([]),
+    /**
+     * Bounded deliberately. An unbounded array under strict decoding is a
+     * runaway vector: measured against qwen-flash, a single `note_and_gaps`
+     * call occasionally failed to terminate, generating 16,384 completion
+     * tokens without closing the response. `maxItems` makes the ceiling
+     * structural (Tier 1) rather than a token budget to tune — raising
+     * `max_tokens` only buys a longer loop.
+     *
+     * Twenty dispensed items is far beyond any single GP consultation.
+     */
+    medicationsDispensed: z.array(field).max(20).default([]),
     mcDays: field,
     referral: field,
     followUp: field,
@@ -202,7 +241,7 @@ export const OperationalBlockSchema = buildOperationalBlock(
 )
 
 export const LlmOperationalBlockSchema = buildOperationalBlock(
-  LlmClinicalAssertionSchema.default({ state: 'NOT_ASSESSED' }),
+  LlmClinicalAssertionSchema.default({ state: 'NOT_ASSESSED', value: '', evidence: '' }),
 )
 
 // ─── Missing clinical information ────────────────────────────────────────────
@@ -294,7 +333,12 @@ export const NoteAndGapsResponseSchema = z.object({
   note: SoapNoteSchema,
   clinicalFacts: LlmClinicalFactsSchema,
   operational: LlmOperationalBlockSchema,
-  gaps: z.array(InformationGapSchema),
+  /**
+   * Bounded for the same reason as `medicationsDispensed`. The checklist holds
+   * 29 fields, so more than 30 gaps cannot correspond to anything real, and an
+   * unbounded array is where a strict-decoding loop escapes.
+   */
+  gaps: z.array(InformationGapSchema).max(30),
 })
 
 /**


### PR DESCRIPTION
Found while measuring CAP-1 (TRD §19 row 8). The latency answer was the easy part; this is the important one.

## The defect

Measured against live `qwen-flash` on a 3,085-word Malaysian GP consultation:

**0 of 18** `PRESENT`/`DENIED` assertions carried an evidence span. Not a matching failure — the `evidence` key was simply never present in the response.

The cause is structural. `evidence` was `.optional()`, and under strict JSON-Schema decoding an optional property is absent from `required`, so the model is free to skip it. It skipped it every time, on every field, on every run.

The evidence check (§21.4) then did exactly what it is designed to do and downgraded all 18 to `NOT_ASSESSED`. The result:

| | before |
| --- | --- |
| assertions surviving | **0** |
| documentation gaps | **23** |
| `diagnosis` | `NOT_ASSESSED` — though the doctor said *"this looks like an upper respiratory tract infection with tonsillitis"* |
| `haemoptysis` | `NOT_ASSESSED` — though the patient said *"No no, no blood. Never."* |

**The safety property held; the product did not.** Every consultation would have shown ~23 gaps no matter how thorough the doctor was — the alert-fatigue failure PRD §12 warns about, arriving through the control meant to prevent fabrication.

Worth noting the prompt already said, in capitals, that `PRESENT` and `DENIED` MUST carry verbatim evidence. The model ignored it. That is TRD §21.3's tier model being right: a Tier-4 instruction failed silently, and only a structural change fixed it.

## The fix, and what it bought

`evidence` and `value` are now **required in the LLM-facing schema** and remain optional in the persisted one. The empty string is legal, so `NOT_ASSESSED` still costs `"value":"","evidence":""` and nothing more — ratification condition 1 forbids a field being implicitly required to be *filled*, not required to be *present*.

| | before | after |
| --- | --- | --- |
| spans emitted | 0 / 18 | **18 / 18** |
| spans matching verbatim | 0 | **12 / 18** |
| assertions surviving | 0 | **13 – 15** |
| gaps | 23 | **4 – 6** |
| `diagnosis` | `NOT_ASSESSED` | **`PRESENT`** — "upper respiratory tract infection with tonsillitis" |
| `haemoptysis` | `NOT_ASSESSED` | **`DENIED`** |
| `mcDays` | — | **`PRESENT` — 2** |

The 6 remaining non-matches were the model quoting across speaker turns or eliding with "…", so the prompt now forbids both explicitly and asks for the shortest span that carries the finding.

## A second defect: runaway generation

While fixing the above, `note_and_gaps` began failing intermittently with "malformed JSON". It was truncation, and raising the budget made it **worse**:

```
max_tokens=8192    finish=stop     completion=3555
max_tokens=16384   finish=length   completion=16384
```

At 16k the model generated every available token without terminating. That is a generation loop, not a budget shortfall — a larger ceiling only buys a longer loop.

Three changes, all structural:

- **`medicationsDispensed` bounded to 20, `gaps` to 30.** An unbounded array under strict decoding is where the loop escapes. The checklist holds 29 fields, so >30 gaps cannot correspond to anything real.
- **`value` bounded to 120 chars, `evidence` to 400.** Same hazard, and the bound pushes the model toward the short single-turn quote the evidence check can actually match.
- **The adapter now names truncation.** `finish_reason === 'length'` throws "hit the output token limit and was truncated" instead of surfacing as a parse error, which sent me hunting the wrong bug for two rounds.

## The diagnostic-prose guard now degrades instead of discarding

`assertNoDiagnosticProse` **threw**, discarding the entire analysis over a single stray "diagnosis" in `note.assessment`. That is inconsistent with the evidence check sitting beside it: §21.4 downgrades the individual fact precisely so one bad field does not cost the doctor the whole run.

It now blanks the offending field and records the id in `suppressedFieldIds`. §21.4's asymmetry argument applies unchanged — a blanked assessment costs the doctor one field they were going to edit anyway, and the structured `diagnosis` field still carries the answer; a lost analysis costs a 26-second run and another API call with no guarantee of a different outcome.

The prompt was strengthened alongside it, and suppressions dropped to **0** across the successful runs.

## Verification

```
bun run lint        86 files, 4 warnings (console.log in prisma/seed.ts, intentional for a CLI)
bun run typecheck   clean across shared, backend, frontend
bun run test        shared 29 passed · backend 219 passed (17 files)
```

All measurements above are real calls against the live Singapore endpoint on a synthetic transcript. No real patient data.

## Known, not fixed here — needs a decision

**`note_and_gaps` still truncates roughly 1 run in 6**, and latency sits at **22–29 s against CAP-1's 30 s**. Critically, that is **the same at 1,321 words as at 3,085**, because the response size is dominated by the fixed 34-field schema rather than by the transcript. The very first measurement in this project said the same thing: ~10 s for a *one-line* transcript.

So the tension is real and it is in the design, not the tuning: the fixed 29-key checklist is what makes "never silently omitted" enforceable (PRD §10), and it is also what makes every response large.

The fix that keeps the safety property is to **split the operation** — clinical facts in one call, the SOAP note in another, run concurrently — halving each response. That is a change to a Final TRD §12 contract, so it is flagged rather than made.

## Clinical-Safety Checklist

- [x] No un-de-identified text reaches an LLM provider — unchanged; measurements used de-identified content through `LLMClient`
- [x] No hardcoded outputs — every figure above is a real call
- [x] LLM cannot suppress a rule hit — untouched
- [x] No free-text citations — untouched
- [x] **`diagnosis` transcription-bound** — strengthened, not weakened: it is now `PRESENT` only with a verbatim span, where before it was uniformly `NOT_ASSESSED` because no span ever arrived
- [x] **Nothing logs transcript bodies, note contents or vault entries** — `suppressedFieldIds` carries field ids only, asserted by test
