### PR TITLE
fix(config): resolve the env.ts child-process path with fileURLToPath

### DIFF
--- a/backend/src/config/env.test.ts
+++ b/backend/src/config/env.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 /**
@@ -13,7 +14,7 @@ function boot(overrides: Record<string, string>) {
       [
         '--experimental-strip-types',
         '--no-warnings',
-        new URL('./env.ts', import.meta.url).pathname,
+        fileURLToPath(new URL('./env.ts', import.meta.url)),
       ],
       {
         env: { ...process.env, ...overrides },


### PR DESCRIPTION
## What Changed

`backend/src/config/env.test.ts` builds the child-process path with `fileURLToPath()` instead of `new URL(...).pathname`. The env fail-fast suite runs on a Windows checkout again: 7 of 7 pass, where 6 were failing.

## Why

The suite spawns `env.ts` in a child process because it calls `process.exit(1)` at module scope. It built that path with `new URL('./env.ts', import.meta.url).pathname`, which on Windows yields `/C:/Users/...`. Node resolves that against the drive root as `C:\C:\Users\...`, so every case died with `MODULE_NOT_FOUND` before `env.ts` ever loaded, and the six cases that assert on the child's output failed.

CI is `ubuntu-latest`, where `.pathname` already returned a usable path, so this was invisible in CI and is a no-op there. `fileURLToPath` is also percent-decoded, so a checkout path containing a space no longer breaks the suite on any platform.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manually exercised the affected flow

`env.test.ts` 7/7 (was 1/7). Full suite 219/219 across 17 files. Also booted `bun run dev:backend` to confirm the guards still fire in a real process.

## Notes For The Reviewer

The Clinical-Safety Checklist section is deleted deliberately: the diff touches one test file and none of `deid/`, `lib/llm/`, `redflags/`, `guidelines/`, or logging.

Worth knowing that the six restored cases include all three production guards, namely gemini refused in production, deepseek refused in production, and `DEID_FAIL_CLOSED` required true in production. On a Windows checkout those were not being exercised at all. The single case that did report green, `refuses a BETTER_AUTH_SECRET shorter than 32 characters`, was passing spuriously: it only asserts the child exited non-zero, and the child was exiting on `MODULE_NOT_FOUND`.

Unrelated, not fixed here: `bun run lint` fails wholesale on a Windows checkout. Git for Windows sets `core.autocrlf=true` at system level and the repo has no `.gitattributes`, so the working tree is CRLF while Biome expects LF. The committed blobs are all LF, so CI and non-Windows collaborators are unaffected. Setting `core.autocrlf=input` locally clears it. A tracked `.gitattributes` carrying `* text=auto eol=lf` would fix it for everyone, but it triggers a one-time renormalization touching every file, so it is flagged here rather than bundled in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment validation tests to run reliably across filesystem path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->