### PR TITLE
feat(guidelines): version the clinical checklist and safety rules

### DIFF
--- a/backend/src/audit/audit.test.ts
+++ b/backend/src/audit/audit.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ACTIVE_CLINICAL_VERSIONS } from '../clinical-versions/index.js'
 import { prisma } from '../lib/prisma.js'
 import { type AuditEventInput, getAuditHistory, recordAuditEvent } from './index.js'
 
@@ -46,8 +47,7 @@ describe('recordAuditEvent', () => {
         versions: {
           provider: 'qwen',
           model: 'qwen-flash',
-          redFlagListVersion: '2026-08-13',
-          guidelineCorpusVersion: '2026-08-13',
+          clinicalContent: ACTIVE_CLINICAL_VERSIONS,
         },
       },
     })
@@ -58,8 +58,7 @@ describe('recordAuditEvent', () => {
       versions: {
         provider: 'qwen',
         model: 'qwen-flash',
-        redFlagListVersion: '2026-08-13',
-        guidelineCorpusVersion: '2026-08-13',
+        clinicalContent: ACTIVE_CLINICAL_VERSIONS,
       },
     })
   })
@@ -92,8 +91,7 @@ describe('recordAuditEvent', () => {
           versions: {
             provider: 'qwen',
             model: 'qwen-flash',
-            redFlagListVersion: 'v1',
-            guidelineCorpusVersion: 'v1',
+            clinicalContent: ACTIVE_CLINICAL_VERSIONS,
           },
         },
       },

--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -1,3 +1,4 @@
+import type { ACTIVE_CLINICAL_VERSIONS } from '../clinical-versions/index.js'
 import { prisma } from '../lib/prisma.js'
 
 /**
@@ -14,12 +15,16 @@ export type AnalysisFailureReason =
 /**
  * Which versions of the system produced one analysis (issue #12). Enough to
  * answer "what generated this note?" months later without guessing.
+ *
+ * `clinicalContent` is typed as the aggregator itself rather than a hand-listed
+ * set of fields (issue #16), so adding a versioned artefact cannot leave the
+ * stamp behind: the only way to satisfy this type is to write the whole of
+ * `ACTIVE_CLINICAL_VERSIONS`.
  */
 export interface AnalysisVersions {
   provider: string
   model: string
-  redFlagListVersion: string
-  guidelineCorpusVersion: string
+  clinicalContent: typeof ACTIVE_CLINICAL_VERSIONS
 }
 
 /**

--- a/backend/src/clinical-versions/index.test.ts
+++ b/backend/src/clinical-versions/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { GAP_CHECKLIST } from '../gaps/index.js'
+import { GUIDELINE_CORPUS } from '../guidelines/index.js'
+import { RED_FLAG_LIST_VERSION, REDFLAG_TRIGGERS } from '../redflags/index.js'
+import { ACTIVE_CLINICAL_VERSIONS } from './index.js'
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+describe('clinical content versions (issue #16)', () => {
+  it('covers exactly the three versioned artefacts', () => {
+    expect(Object.keys(ACTIVE_CLINICAL_VERSIONS).sort()).toEqual([
+      'gapChecklist',
+      'guidelineCorpus',
+      'redFlagList',
+    ])
+  })
+
+  for (const [artefact, version] of Object.entries(ACTIVE_CLINICAL_VERSIONS)) {
+    it(`gives ${artefact} a version id and an effective date`, () => {
+      expect(version.id).not.toHaveLength(0)
+      expect(version.effectiveDate).toMatch(ISO_DATE)
+      expect(Number.isNaN(Date.parse(version.effectiveDate))).toBe(false)
+    })
+  }
+
+  it('gives each artefact a distinct id, so a stamp names one thing', () => {
+    const ids = Object.values(ACTIVE_CLINICAL_VERSIONS).map((version) => version.id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  /**
+   * `evaluate.test.ts` asserts the triggers agree with each other. This asserts
+   * they agree with the version that actually gets stamped, which is the pair
+   * that can drift once the two are edited separately.
+   */
+  it('stamps the same rule-list version that every trigger carries', () => {
+    for (const trigger of REDFLAG_TRIGGERS) {
+      expect(trigger.listVersion).toBe(RED_FLAG_LIST_VERSION.id)
+    }
+
+    expect(ACTIVE_CLINICAL_VERSIONS.redFlagList).toBe(RED_FLAG_LIST_VERSION)
+  })
+
+  it('versions artefacts that are actually populated', () => {
+    expect(REDFLAG_TRIGGERS.length).toBeGreaterThan(0)
+    expect(GAP_CHECKLIST.length).toBeGreaterThan(0)
+    expect(GUIDELINE_CORPUS.length).toBeGreaterThan(0)
+  })
+})

--- a/backend/src/clinical-versions/index.ts
+++ b/backend/src/clinical-versions/index.ts
@@ -1,0 +1,22 @@
+import { GAP_CHECKLIST_VERSION } from '../gaps/index.js'
+import { GUIDELINE_CORPUS_VERSION } from '../guidelines/index.js'
+import { RED_FLAG_LIST_VERSION } from '../redflags/index.js'
+import type { ClinicalArtefactVersion } from './types.js'
+
+export type { ClinicalArtefactVersion } from './types.js'
+
+/**
+ * The clinical content active for this build (docs/trd.md §15). Every
+ * completed analysis is stamped with this object, so a past note can be traced
+ * back to the exact rule list, checklist and corpus that produced it.
+ *
+ * Each version is defined in the data file it describes, never here: changing
+ * one is a diff to that file alone. This module only collects them, which is
+ * what makes the stamp a single write rather than three the caller could
+ * forget one of.
+ */
+export const ACTIVE_CLINICAL_VERSIONS = {
+  redFlagList: RED_FLAG_LIST_VERSION,
+  gapChecklist: GAP_CHECKLIST_VERSION,
+  guidelineCorpus: GUIDELINE_CORPUS_VERSION,
+} as const satisfies Record<string, ClinicalArtefactVersion>

--- a/backend/src/clinical-versions/no-stray-clinical-constants.test.ts
+++ b/backend/src/clinical-versions/no-stray-clinical-constants.test.ts
@@ -1,0 +1,127 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { GAP_CHECKLIST } from '../gaps/index.js'
+import { REDFLAG_TRIGGERS } from '../redflags/index.js'
+
+/**
+ * Issue #16, acceptance criteria 3 and 4. Clinical content is versioned data;
+ * this fails the build when a piece of it is written down somewhere else.
+ *
+ * The failure it exists to stop is not a style problem. A `ruleId === '...'`
+ * branch in a route or a component is a clinical rule that no version stamp
+ * describes, so "what rules were active when this note was approved?" stops
+ * having an answer, and updating the rule list silently leaves the copy behind.
+ *
+ * Scope is deliberately narrow, because a guard that cries wolf gets deleted:
+ *
+ * 1. **Whole single-quoted literals** equal to a trigger or checklist id.
+ *    Biome pins `quoteStyle: 'single'` (biome.json), so a string in code is
+ *    always single-quoted, while the same word in a comment or inside prompt
+ *    prose is not. That one distinction is what keeps `analysis/prompt.ts`,
+ *    which discusses the "diagnosis" field at length, from tripping this.
+ * 2. **Guideline scoring-system names.** These carry the thresholds the two
+ *    Malaysian sources disagree on (docs/trd.md §11), so a hard-coded one is
+ *    a manufactured consensus with nothing citing it.
+ *
+ * The id set is read from the data at runtime rather than listed here. A
+ * hand-maintained copy would be the same duplication this test forbids.
+ */
+const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url))
+
+/** Where clinical content is allowed to be written down. */
+const VERSIONED_DATA_FILES = [
+  'backend/src/redflags/triggers.ts',
+  'backend/src/gaps/checklist.ts',
+  'backend/src/guidelines/corpus.ts',
+]
+
+const SCANNED_TREES = [
+  { dir: 'backend/src', extensions: ['.ts'] },
+  { dir: 'frontend/src', extensions: ['.ts', '.tsx'] },
+]
+
+const SCORING_SYSTEMS = /\b(centor|mcisaac)\b/i
+
+const CLINICAL_IDS = [
+  ...REDFLAG_TRIGGERS.map((trigger) => trigger.id),
+  ...GAP_CHECKLIST.map((entry) => entry.id),
+]
+
+/**
+ * Tests assert against the data by design, and fixtures are synthetic clinical
+ * text by design. Neither is a rule the application reads.
+ */
+function isExempt(path: string): boolean {
+  return (
+    VERSIONED_DATA_FILES.includes(path) ||
+    path.startsWith('backend/src/fixtures/') ||
+    /\.test\.tsx?$/.test(path)
+  )
+}
+
+function sourceFiles(): string[] {
+  const found: string[] = []
+
+  for (const { dir, extensions } of SCANNED_TREES) {
+    const walk = (absolute: string) => {
+      for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+        const child = join(absolute, entry.name)
+        if (entry.isDirectory()) {
+          walk(child)
+        } else if (extensions.some((extension) => entry.name.endsWith(extension))) {
+          found.push(relative(REPO_ROOT, child).replaceAll('\\', '/'))
+        }
+      }
+    }
+
+    walk(join(REPO_ROOT, dir))
+  }
+
+  return found
+}
+
+function violations(match: (line: string) => boolean): string[] {
+  const found: string[] = []
+
+  for (const path of sourceFiles()) {
+    if (isExempt(path)) continue
+
+    const lines = readFileSync(join(REPO_ROOT, path), 'utf8').split('\n')
+    lines.forEach((line, index) => {
+      if (match(line)) found.push(`${path}:${index + 1}: ${line.trim()}`)
+    })
+  }
+
+  return found
+}
+
+describe('clinical constants live only in the versioned data files (issue #16)', () => {
+  it('finds source to scan in both workspaces, so an empty pass means something', () => {
+    const scanned = sourceFiles()
+
+    expect(scanned.some((path) => path.startsWith('backend/src/'))).toBe(true)
+    expect(scanned.some((path) => path.startsWith('frontend/src/'))).toBe(true)
+    expect(CLINICAL_IDS.length).toBeGreaterThan(0)
+  })
+
+  it('defines no red-flag trigger or checklist id outside its data file', () => {
+    const literals = CLINICAL_IDS.map((id) => `'${id}'`)
+
+    expect(
+      violations((line) => literals.some((literal) => line.includes(literal))),
+      'A clinical rule is written down outside the versioned data. Branch on data read ' +
+        'from REDFLAG_TRIGGERS or GAP_CHECKLIST, or move the behaviour into the entry itself.',
+    ).toEqual([])
+  })
+
+  it('names no guideline scoring system outside the versioned data', () => {
+    expect(
+      violations((line) => SCORING_SYSTEMS.test(line)),
+      'A guideline scoring system is named outside the corpus, where no version stamp ' +
+        'covers it and the two Malaysian sources disagree. Render it from a GUIDELINE_CORPUS ' +
+        'chunk instead.',
+    ).toEqual([])
+  })
+})

--- a/backend/src/clinical-versions/types.ts
+++ b/backend/src/clinical-versions/types.ts
@@ -1,0 +1,19 @@
+/**
+ * docs/trd.md §15 (Clinical Content Versioning). The stamp every versioned
+ * clinical artefact carries: the red-flag trigger list, the gap checklist, and
+ * the guideline corpus.
+ *
+ * `id` and `effectiveDate` are separate fields because they answer different
+ * questions. `id` names the version and is what gets written into the audit
+ * trail, so it must stay stable once a run has recorded it. `effectiveDate`
+ * says when that version took effect, which is editorial and may be set ahead
+ * of the authoring date.
+ *
+ * Declared here rather than beside the aggregator so the three data files can
+ * import the type without a cycle back through the module that reads them.
+ */
+export interface ClinicalArtefactVersion {
+  readonly id: string
+  /** ISO 8601 calendar date, `YYYY-MM-DD`. */
+  readonly effectiveDate: string
+}

--- a/backend/src/gaps/checklist.ts
+++ b/backend/src/gaps/checklist.ts
@@ -1,4 +1,15 @@
 import type { ClinicalAssertion, ClinicalFacts, OperationalBlock } from '@shared/types'
+import type { ClinicalArtefactVersion } from '../clinical-versions/types.js'
+
+/**
+ * Bumped whenever an entry is added, removed, or its selector, priority or
+ * wording changes. Recorded with every analysis (docs/trd.md §15) so a past
+ * set of gaps can be traced back to the checklist that produced it.
+ */
+export const GAP_CHECKLIST_VERSION: ClinicalArtefactVersion = {
+  id: 'gap-checklist-v1',
+  effectiveDate: '2026-08-13',
+}
 
 /**
  * Materiality rule (GitHub issue #6; docs/prd.md §12 alert fatigue).

--- a/backend/src/gaps/index.ts
+++ b/backend/src/gaps/index.ts
@@ -1,2 +1,2 @@
-export { GAP_CHECKLIST, type GapChecklistEntry } from './checklist.js'
+export { GAP_CHECKLIST, GAP_CHECKLIST_VERSION, type GapChecklistEntry } from './checklist.js'
 export { deriveGaps } from './derive.js'

--- a/backend/src/guidelines/corpus.ts
+++ b/backend/src/guidelines/corpus.ts
@@ -1,11 +1,18 @@
 import { type GuidelineChunk, GuidelineChunkSchema } from '@shared/types'
+import type { ClinicalArtefactVersion } from '../clinical-versions/types.js'
 
 /**
  * Bumped whenever a chunk is added, removed, or its summary/threshold
- * changes. Recorded with every analysis (docs/trd.md §11) so a past
+ * changes. Recorded with every analysis (docs/trd.md §11, §15) so a past
  * suggestion can be traced back to the corpus state that produced it.
+ *
+ * This is the version of the corpus as an artefact. Each chunk separately
+ * carries its own source's `publisher` and `year`.
  */
-export const CORPUS_VERSION = '2026-08-13'
+export const GUIDELINE_CORPUS_VERSION: ClinicalArtefactVersion = {
+  id: 'guideline-corpus-v1',
+  effectiveDate: '2026-08-13',
+}
 
 /**
  * Source selection resolved 13/08/26 (docs/trd.md §11, §19 row 3, closed).

--- a/backend/src/guidelines/index.ts
+++ b/backend/src/guidelines/index.ts
@@ -1,2 +1,2 @@
-export { CORPUS_VERSION, corpusIds, GUIDELINE_CORPUS } from './corpus.js'
+export { corpusIds, GUIDELINE_CORPUS, GUIDELINE_CORPUS_VERSION } from './corpus.js'
 export { serialiseCorpusForPrompt } from './prompt.js'

--- a/backend/src/redflags/index.ts
+++ b/backend/src/redflags/index.ts
@@ -1,3 +1,3 @@
 export { evaluateRedFlags, mergeRedFlags } from './evaluate.js'
-export { ACTIVE_RED_FLAG_LIST_VERSION, REDFLAG_TRIGGERS } from './triggers.js'
+export { RED_FLAG_LIST_VERSION, REDFLAG_TRIGGERS } from './triggers.js'
 export type { RedFlagTrigger } from './types.js'

--- a/backend/src/redflags/triggers.ts
+++ b/backend/src/redflags/triggers.ts
@@ -1,4 +1,5 @@
 import type { Transcript } from '@shared/types'
+import type { ClinicalArtefactVersion } from '../clinical-versions/types.js'
 import type { RedFlagTrigger } from './types.js'
 
 /**
@@ -7,8 +8,14 @@ import type { RedFlagTrigger } from './types.js'
  * (MOH NAG 4th ed. 2024, Abdullah et al. 2024, Ooi et al. 2022) rather than
  * NICE, whose licence forbids AI use. Where those sources restate Centor /
  * McIsaac, this list expresses them in our own words per docs/trd.md §10.
+ *
+ * Bumped whenever a trigger is added, removed, or its matcher or severity
+ * changes. Recorded with every analysis (docs/trd.md §15).
  */
-export const ACTIVE_RED_FLAG_LIST_VERSION = '2026-08-13'
+export const RED_FLAG_LIST_VERSION: ClinicalArtefactVersion = {
+  id: 'redflag-list-v1',
+  effectiveDate: '2026-08-13',
+}
 
 const findSpan = (transcript: Transcript, patterns: readonly RegExp[]): string | null => {
   for (const turn of transcript.turns) {
@@ -44,7 +51,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /\bha?emoptysis\b/i,
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
-    listVersion: ACTIVE_RED_FLAG_LIST_VERSION,
+    listVersion: RED_FLAG_LIST_VERSION.id,
   },
   {
     id: 'significant-dyspnoea',
@@ -61,7 +68,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /gasping\s+for\s+(?:air|breath)/i,
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
-    listVersion: ACTIVE_RED_FLAG_LIST_VERSION,
+    listVersion: RED_FLAG_LIST_VERSION.id,
   },
   {
     id: 'chest-pain',
@@ -74,7 +81,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /tight(?:ness)?\s+in\s+(?:my|the|his|her)\s+chest/i,
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
-    listVersion: ACTIVE_RED_FLAG_LIST_VERSION,
+    listVersion: RED_FLAG_LIST_VERSION.id,
   },
   {
     id: 'stridor-airway-compromise',
@@ -90,7 +97,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /voice\s+sounds?\s+muffled/i,
       ]),
     clinicalSource: DELPHI_AIRWAY_NOTE,
-    listVersion: ACTIVE_RED_FLAG_LIST_VERSION,
+    listVersion: RED_FLAG_LIST_VERSION.id,
   },
   {
     id: 'swallowing-oral-intake',
@@ -106,7 +113,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /no\s+oral\s+intake/i,
       ]),
     clinicalSource: DELPHI_AIRWAY_NOTE,
-    listVersion: ACTIVE_RED_FLAG_LIST_VERSION,
+    listVersion: RED_FLAG_LIST_VERSION.id,
   },
   {
     /**
@@ -132,6 +139,6 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
       "(NAG 2024, Abdullah et al. 2024, Ooi et al. 2022); this trigger matches the clinician's " +
       'own stated severity assessment rather than an invented cutoff — see docs/trd.md §10 ' +
       '"What Stays Undecided".',
-    listVersion: ACTIVE_RED_FLAG_LIST_VERSION,
+    listVersion: RED_FLAG_LIST_VERSION.id,
   },
 ]

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -1,5 +1,6 @@
 import type { Server } from 'node:http'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ACTIVE_CLINICAL_VERSIONS } from '../clinical-versions/index.js'
 
 /**
  * The analyse pipeline is mocked at the module seam so these tests exercise the
@@ -28,7 +29,8 @@ vi.mock('../analysis/index.js', () => ({
   })),
 }))
 
-vi.mock('../gaps/index.js', () => ({
+vi.mock('../gaps/index.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   deriveGaps: vi.fn(() => [
     { id: 'derived-gap', question: 'Duration?', rationale: 'Needed', priority: 'high' },
   ]),
@@ -80,7 +82,7 @@ const TRANSCRIPT = {
 
 /** Minimal in-memory stand-in for the two tables these routes touch. */
 const store = new Map<string, Record<string, unknown>>()
-const audits: { action: string; consultationId: string }[] = []
+const audits: { action: string; consultationId: string; metadata?: unknown }[] = []
 
 vi.mock('../lib/prisma.js', () => ({
   prisma: {
@@ -114,10 +116,20 @@ vi.mock('../lib/prisma.js', () => ({
       ),
     },
     auditEvent: {
-      create: vi.fn(async ({ data }: { data: { action: string; consultationId: string } }) => {
-        audits.push({ action: data.action, consultationId: data.consultationId })
-        return data
-      }),
+      create: vi.fn(
+        async ({
+          data,
+        }: {
+          data: { action: string; consultationId: string; metadata?: unknown }
+        }) => {
+          audits.push({
+            action: data.action,
+            consultationId: data.consultationId,
+            metadata: data.metadata,
+          })
+          return data
+        },
+      ),
       findMany: vi.fn(async () => []),
     },
   },
@@ -260,6 +272,16 @@ describe('analyse output', () => {
       'consultation.analysis_started',
       'consultation.analysis_completed',
     ])
+
+    // Compared against the aggregator itself rather than literal ids, so a
+    // version bump does not need this assertion edited, but dropping an
+    // artefact from the stamp still fails it (issue #16).
+    const completed = audits.find((a) => a.action === 'consultation.analysis_completed')
+
+    expect(completed?.metadata).toMatchObject({
+      discardedFieldIds: ['fever'],
+      versions: { clinicalContent: ACTIVE_CLINICAL_VERSIONS },
+    })
   })
 })
 

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -11,14 +11,14 @@ import { Router } from 'express'
 import { z } from 'zod'
 import { analyseNote } from '../analysis/index.js'
 import { type AnalysisFailureReason, getAuditHistory, recordAuditEvent } from '../audit/index.js'
+import { ACTIVE_CLINICAL_VERSIONS } from '../clinical-versions/index.js'
 import { DeidentificationError, deidentifyTranscript } from '../deid/index.js'
 import { deriveGaps } from '../gaps/index.js'
-import { CORPUS_VERSION } from '../guidelines/index.js'
 import { assertOwnedConsultation } from '../lib/authz.js'
 import { HttpError } from '../lib/http-error.js'
 import { getLLMDescriptor, LLMResponseError } from '../lib/llm/index.js'
 import { prisma } from '../lib/prisma.js'
-import { ACTIVE_RED_FLAG_LIST_VERSION, evaluateRedFlags, mergeRedFlags } from '../redflags/index.js'
+import { evaluateRedFlags, mergeRedFlags } from '../redflags/index.js'
 import { generateSuggestions } from '../suggestions/index.js'
 
 export const consultationsRouter = Router()
@@ -226,8 +226,7 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
         versions: {
           provider: llm.provider,
           model: llm.model,
-          redFlagListVersion: ACTIVE_RED_FLAG_LIST_VERSION,
-          guidelineCorpusVersion: CORPUS_VERSION,
+          clinicalContent: ACTIVE_CLINICAL_VERSIONS,
         },
       },
     })

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -453,6 +453,8 @@ interface RedFlagTrigger {
 }
 ```
 
+`listVersion` is `RED_FLAG_LIST_VERSION.id`, and every entry carries the same value. The list is one of the three versioned clinical artefacts stamped on each analysis; see §15 (Clinical Content Versioning).
+
 ### Evaluation
 
 - `evaluateRedFlags(transcript: Transcript): RedFlag[]` — a pure function over the transcript directly. It runs in-process and never leaves the API, so it does not need to pass through `deid/` first (§9 exists for the LLM egress path only).
@@ -495,6 +497,8 @@ interface GuidelineChunk {
   quote?: string      // short verbatim excerpt — only permitted when verbatimAllowed
 }
 ```
+
+The corpus as a whole carries `GUIDELINE_CORPUS_VERSION`, one of the three versioned clinical artefacts stamped on each analysis; see §15 (Clinical Content Versioning). Per-chunk source versions are not modelled, and the reason is recorded there.
 
 `sourceLicence` and `verbatimAllowed` were added 13/08/26 because the licensing difference between sources is legally load-bearing and the schema previously had no way to express it. `verbatimAllowed: false` means the chunk may be summarised and linked but never quoted; a `quote` present on such a chunk is a corpus-authoring defect and should fail a corpus validation test.
 
@@ -657,7 +661,7 @@ Matches `docs/prd.md` §8 (Primary Flow) exactly: `draft →(create) draft →(a
 | `consultation.created`            | `POST /api/consultations`                                            | —                                                                         |
 | `consultation.asr_hosted_used`    | `POST /api/consultations` where `transcript.source === 'asr_hosted'` | `—` — the fact of the hosted path, never any audio, chunk, or text        |
 | `consultation.analysis_started`   | `POST /api/consultations/:id/analyze` begins                         | —                                                                         |
-| `consultation.analysis_completed` | analyse pipeline succeeds                                            | `{ detected: string[] }` — detector labels only (§9)                      |
+| `consultation.analysis_completed` | analyse pipeline succeeds                                            | `{ detected, discardedFieldIds, versions }` — see below                   |
 | `consultation.analysis_failed`    | analyse pipeline throws                                              | `{ reason: string }` — a short failure category, never the raw error text |
 | `consultation.edited`             | `PATCH /api/consultations/:id`                                       | —                                                                         |
 | `redflag.acknowledged`            | doctor acknowledges a red flag                                       | `{ redFlagId: string }`                                                   |
@@ -668,9 +672,50 @@ Every row also carries `actorId` (the authenticated doctor) and `consultationId`
 
 **Why `consultation.asr_hosted_used` fires at creation rather than at consent.** The doctor's consent to hosted transcription happens in the browser, before a `Consultation` row exists — `docs/prd.md` §8 step 1 creates the row only once a `Transcript` does. An event written at the moment of consent would therefore have no `consultationId` to hang on, which is the one field that makes the audit trail navigable. The event is instead written by `POST /api/consultations` on the declared `source` (§3), which is the first point at which the fact and the consultation id coexist. The consequence is stated plainly: like `source` itself, this row records a **client-asserted** fact.
 
+### Clinical Content Versioning
+
+**Status: `Built`** (issue #16). Clinical content changes on a different cadence from code, so it is versioned data rather than conditionals spread through the application. Three artefacts carry a version, each defined in the file it describes:
+
+| Artefact          | Version Constant           | Defined In                         |
+| ----------------- | -------------------------- | ---------------------------------- |
+| Red-flag rule set | `RED_FLAG_LIST_VERSION`    | `backend/src/redflags/triggers.ts` |
+| Gap checklist     | `GAP_CHECKLIST_VERSION`    | `backend/src/gaps/checklist.ts`    |
+| Guideline corpus  | `GUIDELINE_CORPUS_VERSION` | `backend/src/guidelines/corpus.ts` |
+
+Each is a `ClinicalArtefactVersion` (`backend/src/clinical-versions/types.ts`):
+
+```
+interface ClinicalArtefactVersion {
+  id: string             // stable name; what the audit trail records
+  effectiveDate: string  // ISO 8601 date the version took effect
+}
+```
+
+`id` and `effectiveDate` are separate because they answer different questions. `id` must stay stable once a run has recorded it; `effectiveDate` is editorial and may be set ahead of the authoring date.
+
+**One stamping path.** `backend/src/clinical-versions/index.ts` collects the three into `ACTIVE_CLINICAL_VERSIONS`, which is what the analyse route writes. The metadata on `consultation.analysis_completed` as built:
+
+```
+{
+  detected: string[],            // de-identification detector labels only (§9)
+  discardedFieldIds: string[],   // fields the §21.4 evidence check dropped
+  versions: {
+    provider: string,            // LLM provider and model (§6)
+    model: string,
+    clinicalContent: { redFlagList, gapChecklist, guidelineCorpus },
+  },
+}
+```
+
+Because `AuditEvent` is append-only, a past analysis keeps the versions it ran under even after the artefacts are revised. That is what makes "which rules were active when this note was approved?" answerable, and it is why the stamp lives here rather than on `Consultation.analysis`, which is overwritten on re-analysis.
+
+**Enforcement.** `backend/src/clinical-versions/no-stray-clinical-constants.test.ts` scans `backend/src` and `frontend/src` and fails the build on either a whole single-quoted literal equal to a trigger or checklist id, or a guideline scoring-system name, outside the three data files. Tests and `backend/src/fixtures/` are exempt. The id set is read from the data at runtime, never listed in the test, so it cannot go stale. The second check exists because the scoring systems carry the thresholds the two Malaysian sources disagree on (§11): a hard-coded one is a manufactured consensus with nothing citing it.
+
+**Not versioned data, deliberately.** Per-chunk source versions are not modelled. `GuidelineChunk` (§11) carries `year`, and the edition sits inside `title` ("4th Edition"). Adding a structured `sourceVersion` would change a `@shared/types` schema and is raised on issue #31 rather than assumed.
+
 ### Forbidden Content
 
-Per `.claude/skills/healthcare-phi-compliance/SKILL.md`: no `AuditEvent.metadata` value may ever contain a transcript body, note text, gap/suggestion text, or a `TokenVault` entry. `metadata` is typed as `Json?` with no schema constraint today (§4); constraining its shape to a discriminated union keyed by `action` is proposed here but not yet implemented.
+Per `.claude/skills/healthcare-phi-compliance/SKILL.md`: no `AuditEvent.metadata` value may ever contain a transcript body, note text, gap/suggestion text, or a `TokenVault` entry. The column stays `Json?` in Prisma (§4), but `recordAuditEvent` now accepts only a discriminated union keyed by `action` (`backend/src/audit/index.ts`, issue #12), so a row carrying an unlisted metadata field is a compile error rather than a review catch.
 
 ---
 


### PR DESCRIPTION
## What Changed

The red-flag trigger list, the gap checklist and the guideline corpus each carry a version id and an effective date, defined in the data file they describe. One aggregator collects them and the analyse route stamps it onto every `consultation.analysis_completed` audit event. A new test fails the build when a clinical constant is written down outside those three files.

The gap checklist had no version at all before this, so the versioned-trigger-list claim `docs/README.md` and `docs/prd.md` section 11 make was two thirds true.

Closes #16

## Why

Clinical content changes on a different cadence from code. Without a stamp, "which rules were active when this note was approved?" has no answer, and without a guard, the next component that branches on `ruleId === '...'` quietly reintroduces a rule that no version describes.

## Verification

- [x] `bun run lint` (4 pre-existing `noConsole` warnings in `prisma/seed.ts`, untouched)
- [x] `bun run typecheck`
- [x] `bun run test` (backend 219 to 229, shared 29)
- [x] Manually exercised the affected flow

Tests added:

| Test | Asserts |
| --- | --- |
| `clinical-versions/index.test.ts` | exactly three artefacts, each with an id and an ISO effective date, ids distinct, every `RedFlagTrigger.listVersion` equal to the stamped rule-list version |
| `clinical-versions/no-stray-clinical-constants.test.ts` | no trigger or checklist id as a whole single-quoted literal, and no guideline scoring-system name, outside the three data files |
| `routes/consultations.test.ts` | the `analysis_completed` metadata carries all three versions, compared against the aggregator so a version bump needs no test edit |

**Negative control, since a guard that cannot fail is theatre.** Planted `const URGENT_RULE = 'haemoptysis'` in `routes/consultations.ts` and a `Modified Centor` comment in `frontend/src/App.tsx`. Both checks failed with the offending `file:line`, then both plants were reverted:

```
× defines no red-flag trigger or checklist id outside its data file
× names no guideline scoring system outside the versioned data
+   "backend/src/routes/consultations.ts:24: const URGENT_RULE = 'haemoptysis'",
+   "frontend/src/App.tsx:1: // Antibiotics per Modified Centor score of 3 or more."
```

The same control was run on the version stamp: dropping two artefacts from the audit metadata fails the route test with a diff naming `gapChecklist`.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider; egress still goes through `deid/` then `LLMClient`
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model
- [x] Citations remain ID-constrained; no free-text references accepted
- [x] No transcript bodies, note contents, or vault entries written to logs. The stamp adds version ids and dates only
- [x] Fixtures added are synthetic (none added)

## Decision

**Version ids are stable names, not dates.** `redflag-list-v1` rather than `2026-08-13`, with the date carried separately as `effectiveDate`. An id must stay fixed once a run has recorded it; an effective date is editorial and may be set ahead of the authoring date. This changes the values previously written into audit metadata, which is harmless: past rows legitimately keep the string that was current when they were written.

**The stamp lives on the audit event, not on the analysis.** `AuditEvent` is append-only, so a past analysis keeps the versions it ran under. `Consultation.analysis` is overwritten on re-analysis and would lose them.

**`AnalysisVersions.clinicalContent` is typed as the aggregator itself** rather than a hand-listed set of fields, so adding a fourth artefact cannot leave the stamp behind: the only way to satisfy the type is to write the whole object.

## Notes For The Reviewer

**This guard scans `frontend/src`.** Static UI copy naming a scoring system, or a component branching on a literal gap or rule id, will fail `bun run test` in the frontend lane. That is the intended behaviour of the issue's third acceptance criterion, and the fix is to render the value from the versioned data rather than retype it. Flagging it because it lands in someone else's lane.

**Deliberately not done, both raised on #31 rather than assumed, since `shared/` is not this lane:**

1. The three version ids are not on `ConsultationAnalysisSchema`, so the review UI cannot display them without reading `GET /api/consultations/:id/history`.
2. `GuidelineChunk` gains no per-entry `sourceVersion`. The edition still sits inside `title` ("4th Edition") and the date is `year`. The issue lists this under Scope but not under Acceptance Criteria.

**Two removals worth a glance.** `CORPUS_VERSION` and `ACTIVE_RED_FLAG_LIST_VERSION` are deleted rather than kept as aliases, because nothing read either one after the aggregator landed.

**Two stale TRD claims corrected in the section being edited.** The `analysis_completed` metadata row still described the shape from before #12, and Forbidden Content still called the discriminated union unimplemented when #12 implemented it.

**No migration and no schema change.** All six acceptance criteria are reachable without either.
