### PR TITLE
feat(infra): add privacy-safe logging and request tracing

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import helmet from 'helmet'
 import { env } from './config/env.js'
 import { errorHandler } from './middleware/error-handler.js'
 import { analyzeRateLimit } from './middleware/rate-limit.js'
+import { requestContext } from './middleware/request-context.js'
 import { requireSession } from './middleware/require-session.js'
 import { authRouter } from './routes/auth.js'
 import { consultationsRouter } from './routes/consultations.js'
@@ -20,6 +21,10 @@ export function createApp() {
   // Render terminates TLS at its proxy, so the socket address is the proxy's.
   // Without this, express-rate-limit buckets every caller into one buffer.
   app.set('trust proxy', 1)
+
+  // First, so every response carries `x-request-id` and no later middleware can
+  // log without a request id in scope (GitHub issue #15).
+  app.use(requestContext)
 
   // CSP is left at helmet's default: the SPA is served by Vercel, not by this
   // API, so this process only ever emits JSON (docs/trd.md §16).

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -42,6 +42,11 @@ const EnvSchema = z.object({
   DEEPSEEK_BASE_URL: z.string().url().default('https://api.deepseek.com'),
   DEEPSEEK_MODEL: z.string().default('deepseek-v4-flash'),
 
+  // Verbosity only. No level widens what may be written: redaction in
+  // lib/logger.ts is unconditional, so there is no debug flag that unlocks raw
+  // content (GitHub issue #15, non-goals).
+  LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+
   DEID_FAIL_CLOSED: z
     .enum(['true', 'false'])
     .default('true')

--- a/backend/src/lib/logger.leak.test.ts
+++ b/backend/src/lib/logger.leak.test.ts
@@ -1,0 +1,323 @@
+import type { Server } from 'node:http'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FIXTURES } from '../fixtures/index.js'
+
+/**
+ * The test that actually holds the line for GitHub issue #15.
+ *
+ * It runs a real fixture analysis end to end against the real de-identification
+ * gate, the real logger and the real middleware, captures everything written to
+ * stdout, and asserts that not one identifier, transcript span, note field or
+ * vault token appears anywhere in it.
+ *
+ * The fixture is `urti-identifier-dense-routine`, which exists precisely
+ * because it carries a name, NRIC, phone, address, date of birth, clinic
+ * registration number and email in a single consultation.
+ *
+ * Only the two LLM calls are mocked, and they are mocked to behave like the
+ * real thing at its most dangerous: echoing vault tokens back and quoting the
+ * de-identified transcript verbatim in evidence spans.
+ */
+
+const FIXTURE = FIXTURES.find((f) => f.id === 'urti-identifier-dense-routine')
+if (!FIXTURE) throw new Error('identifier-dense fixture missing')
+
+vi.mock('../analysis/index.js', () => ({
+  analyseNote: vi.fn(async () => ({
+    note: {
+      subjective: '[PATIENT_1] reports cough and sore throat for two days.',
+      objective: 'Temperature 38.9. Chest clear.',
+      assessment: 'Acute upper respiratory tract infection.',
+      plan: 'Symptomatic relief. Review if worsening.',
+    },
+    clinicalFacts: {},
+    operational: {},
+    gaps: [
+      {
+        id: 'gap-1',
+        question: 'Has [PATIENT_1] had any recent travel?',
+        rationale: 'Relevant to differential.',
+        priority: 'low',
+      },
+    ],
+    discardedFieldIds: [],
+  })),
+}))
+
+vi.mock('../suggestions/index.js', () => ({
+  generateSuggestions: vi.fn(async () => ({
+    outOfScope: false,
+    redFlags: [],
+    suggestions: [
+      {
+        id: 's1',
+        text: 'Advise [PATIENT_1] on fluids and rest.',
+        citations: [{ guidelineId: 'moh-nag-2024-urti' }],
+      },
+    ],
+  })),
+}))
+
+// Partial: `clinical-versions/` reads `GAP_CHECKLIST_VERSION` from this module,
+// so replacing it wholesale breaks the version stamp at import time.
+vi.mock('../gaps/index.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  deriveGaps: vi.fn(() => []),
+}))
+
+vi.mock('../middleware/require-session.js', () => ({
+  requireSession: (req: { doctorId?: string }, _res: unknown, next: () => void) => {
+    req.doctorId = 'doctor-1'
+    next()
+  },
+}))
+
+const store = new Map<string, Record<string, unknown>>()
+
+vi.mock('../lib/prisma.js', () => ({
+  prisma: {
+    consultation: {
+      findFirst: vi.fn(async ({ where }: { where: { id: string; doctorId: string } }) => {
+        const row = store.get(where.id)
+        return row && row.doctorId === where.doctorId ? { ...row } : null
+      }),
+      update: vi.fn(
+        async ({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
+          const row = { ...store.get(where.id), ...data, updatedAt: new Date() }
+          store.set(where.id, row)
+          return { ...row }
+        },
+      ),
+    },
+    auditEvent: { create: vi.fn(async () => ({})) },
+  },
+}))
+
+let server: Server
+let origin: string
+let captured: string[] = []
+
+beforeAll(async () => {
+  const { createApp } = await import('../app.js')
+  server = createApp().listen(0)
+  await new Promise((r) => server.once('listening', r))
+  const addr = server.address()
+  if (typeof addr === 'string' || addr === null) throw new Error('no port')
+  origin = `http://127.0.0.1:${addr.port}`
+})
+
+afterAll(() => server.close())
+
+beforeEach(() => {
+  captured = []
+  store.set('c1', {
+    id: 'c1',
+    doctorId: 'doctor-1',
+    status: 'draft',
+    transcript: FIXTURE.transcript,
+    analysis: null,
+    editedNote: null,
+    approvedAt: null,
+    acknowledgedRedFlagIds: null,
+    reviewedGapIds: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  })
+})
+
+async function analyseAndCaptureLogs(): Promise<{ status: number; logs: string }> {
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    captured.push(String(chunk))
+    return true
+  })
+  let status = 0
+  try {
+    status = (await fetch(`${origin}/api/consultations/c1/analyze`, { method: 'POST' })).status
+    // The request-completed line is emitted from a `finish` handler, which can
+    // land just after fetch resolves.
+    await new Promise((r) => setTimeout(r, 50))
+  } finally {
+    spy.mockRestore()
+  }
+  return { status, logs: captured.join('') }
+}
+
+describe('no clinical content reaches the log drain', () => {
+  it('logs a real fixture analysis without leaking anything from it', async () => {
+    const { status, logs } = await analyseAndCaptureLogs()
+
+    expect(status).toBe(200)
+
+    // Guards against the test passing vacuously: absence proves nothing if
+    // nothing was written.
+    expect(logs.length).toBeGreaterThan(0)
+    expect(logs).toContain('pipeline stage complete')
+
+    // Every identifier the fixture deliberately carries.
+    for (const identifier of [
+      'Ahmad',
+      'Ismail',
+      '850523-14-5677',
+      '012-3456789',
+      'Jalan Meranti',
+      'Kajang',
+      'Selangor',
+      'ahmad.ismail85@example.com',
+      '23 May 1985',
+    ]) {
+      expect(logs, `identifier leaked: ${identifier}`).not.toContain(identifier)
+    }
+
+    // Verbatim transcript spans.
+    for (const turn of FIXTURE.transcript.turns) {
+      const span = turn.text.slice(0, 40)
+      expect(logs, `transcript span leaked: ${span}`).not.toContain(span)
+    }
+
+    // Note content produced by the model.
+    for (const noteText of [
+      'reports cough and sore throat',
+      'Temperature 38.9',
+      'Acute upper respiratory tract infection',
+      'Symptomatic relief',
+      'recent travel',
+      'fluids and rest',
+    ]) {
+      expect(logs, `note content leaked: ${noteText}`).not.toContain(noteText)
+    }
+
+    // Vault tokens are pseudonyms, not identifiers, but they are the key to the
+    // vault and have no business in a log line either.
+    expect(logs).not.toMatch(/\[[A-Z]+_\d+\]/)
+  })
+
+  it('still records what an on-call engineer actually needs', async () => {
+    const { logs } = await analyseAndCaptureLogs()
+    const records = logs
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+
+    // A request id on every line, so the whole analysis is one trace.
+    expect(records.every((r) => typeof r.requestId === 'string')).toBe(true)
+    expect(new Set(records.map((r) => r.requestId)).size).toBe(1)
+
+    // Latency for each stage the issue names.
+    const stages = records.filter((r) => r.stage).map((r) => r.stage)
+    expect(stages).toEqual(
+      expect.arrayContaining(['deidentification', 'rules', 'note_generation', 'retrieval']),
+    )
+    for (const record of records.filter((r) => r.stage)) {
+      expect(typeof record.durationMs).toBe('number')
+    }
+
+    // Detector labels and a count, which is the de-identification observability
+    // the issue asks for, with no values anywhere.
+    const deidRecord = records.find((r) => Array.isArray(r.detectorLabels))
+    expect(deidRecord).toBeDefined()
+    expect(deidRecord?.detectorCount).toBeGreaterThan(0)
+    expect(deidRecord?.detectorLabels).toEqual(
+      expect.arrayContaining(['NRIC', 'PATIENT', 'PHONE', 'EMAIL']),
+    )
+  })
+
+  it('leaks nothing when the pipeline fails, which is when logging is loudest', async () => {
+    const { generateSuggestions } = await import('../suggestions/index.js')
+    vi.mocked(generateSuggestions).mockRejectedValueOnce(
+      // Exactly the shape of a provider error that quotes the payload back.
+      new Error(
+        'upstream rejected request: {"content":"Encik Ahmad bin Ismail, NRIC 850523-14-5677, batuk 2 days"}',
+      ),
+    )
+
+    const { status, logs } = await analyseAndCaptureLogs()
+
+    expect(status).toBe(500)
+    expect(logs).toContain('pipeline stage failed')
+    expect(logs).not.toContain('Ahmad')
+    expect(logs).not.toContain('850523-14-5677')
+    expect(logs).not.toContain('batuk')
+    expect(logs).not.toContain('upstream rejected')
+  })
+
+  /**
+   * The test above proves the *wired call sites* are clean. That is the weaker
+   * property, and on its own it passes even with redaction switched off,
+   * because nothing in the pipeline currently hands the logger anything
+   * dangerous.
+   *
+   * This one proves the property that actually matters: the logger refuses
+   * clinical content even when a call site hands it over deliberately. It uses
+   * the real fixture transcript and the real analysis the pipeline just
+   * produced, in the shapes a tired engineer reaches for at 2am.
+   */
+  it('refuses clinical content even when a call site hands it over directly', async () => {
+    await analyseAndCaptureLogs()
+    const produced = store.get('c1')?.analysis as {
+      note: Record<string, string>
+      gaps: { question: string }[]
+      suggestions: { text: string }[]
+    }
+    const { logger } = await import('./logger.js')
+
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      captured.push(String(chunk))
+      return true
+    })
+    captured = []
+
+    // Each cast is what a genuine bypass looks like: `LogFields` rejects these
+    // keys at compile time, so reaching the serialiser at all takes an `as`.
+    logger.info('debugging', { transcript: FIXTURE.transcript } as never)
+    logger.error('analysis failed', { analysis: produced } as never)
+    logger.warn('note', { operation: JSON.stringify(FIXTURE.transcript) } as never)
+    logger.info('note', { operation: produced.note.subjective } as never)
+    logger.info('gap', { operation: produced.gaps[0]?.question ?? '' } as never)
+    logger.info('suggestion', { operation: produced.suggestions[0]?.text ?? '' } as never)
+    logger.info(`analysing ${FIXTURE.transcript.turns[1]?.text}`)
+    logger.info('vault', { operation: '[PATIENT_1] maps to Ahmad bin Ismail' } as never)
+
+    spy.mockRestore()
+    const logs = captured.join('')
+
+    expect(logs.length).toBeGreaterThan(0)
+    for (const secret of [
+      'Ahmad',
+      'Ismail',
+      '850523-14-5677',
+      'ahmad.ismail85@example.com',
+      'Jalan Meranti',
+      'cough and sore throat',
+      'Acute upper respiratory',
+      'recent travel',
+      'fluids and rest',
+      'batuk',
+    ]) {
+      expect(logs, `leaked via direct call: ${secret}`).not.toContain(secret)
+    }
+    expect(logs).not.toMatch(/\[[A-Z]+_\d+\]/)
+  })
+
+  it('never writes the request body, however the request fails', async () => {
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      captured.push(String(chunk))
+      return true
+    })
+    captured = []
+    await fetch(`${origin}/api/consultations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        transcript: { source: 'paste', turns: [{ speaker: 'patient', text: 'not a valid shape' }] },
+        stray: 'Encik Ahmad bin Ismail 850523-14-5677',
+      }),
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    spy.mockRestore()
+
+    const logs = captured.join('')
+    expect(logs).not.toContain('Ahmad')
+    expect(logs).not.toContain('850523-14-5677')
+    expect(logs).not.toContain('not a valid shape')
+  })
+})

--- a/backend/src/lib/logger.test.ts
+++ b/backend/src/lib/logger.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ALLOWED_FIELDS, type LogFields, logger, scrub, timeStage } from './logger.js'
+
+// A level low enough that nothing is filtered, which is the point: redaction
+// must not depend on verbosity.
+vi.mock('../config/env.js', () => ({ env: { LOG_LEVEL: 'debug' } }))
+
+function captureLines(run: () => void): string[] {
+  const lines: string[] = []
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    lines.push(String(chunk))
+    return true
+  })
+  try {
+    run()
+  } finally {
+    spy.mockRestore()
+  }
+  return lines
+}
+
+describe('field allowlist', () => {
+  it('drops any field not on the allowlist', () => {
+    const scrubbed = scrub({
+      requestId: 'req-1',
+      transcript: 'Patient reports a productive cough for five days',
+      note: 'Assessment: likely viral URTI',
+      editedNote: 'anything',
+      analysis: 'anything',
+      vault: 'anything',
+      password: 'hunter2',
+    })
+
+    expect(Object.keys(scrubbed)).toEqual(['requestId'])
+  })
+
+  it('keeps LogFields and the field rules from drifting apart', () => {
+    // Every optional key of LogFields, populated. If someone adds a field to
+    // the interface without a matching rule it silently stops being logged;
+    // this fails instead.
+    const everyField: Required<LogFields> = {
+      requestId: 'r',
+      consultationId: 'c',
+      actorId: 'a',
+      method: 'GET',
+      route: '/api',
+      status: 200,
+      durationMs: 1,
+      stage: 'rules',
+      operation: 'note_and_gaps',
+      errorClass: 'model_error',
+      errorName: 'Error',
+      outcome: 'ok',
+      detectorLabels: ['NRIC'],
+      detectorCount: 1,
+      provider: 'qwen',
+      model: 'qwen-flash',
+      count: 0,
+    }
+
+    expect(Object.keys(everyField).sort()).toEqual([...ALLOWED_FIELDS].sort())
+    expect(Object.keys(scrub(everyField)).sort()).toEqual([...ALLOWED_FIELDS].sort())
+  })
+})
+
+/**
+ * The property that matters. Every allowlisted field is an enum, an identifier
+ * or a number, so there is no field clinical prose can be assigned to. These
+ * tests assert the rules reject rather than pass through, which is what makes
+ * the boundary structural rather than probabilistic.
+ */
+describe('no field accepts free text', () => {
+  it('rejects prose in every string-valued field', () => {
+    const prose = 'Has Ahmad had any recent travel?'
+    const stringFields = [
+      'requestId',
+      'consultationId',
+      'actorId',
+      'method',
+      'route',
+      'stage',
+      'operation',
+      'errorClass',
+      'errorName',
+      'outcome',
+      'provider',
+      'model',
+    ] as const
+
+    for (const field of stringFields) {
+      const scrubbed = scrub({ [field]: prose })
+      expect(scrubbed[field], `${field} accepted prose`).toBe('[redacted:invalid]')
+    }
+  })
+
+  /**
+   * The exact string that defeated the previous design. `deid`'s detector is
+   * scored and context sensitive, so it scores this below `ACCEPT_THRESHOLD`
+   * and lets it through. The field rule does not care.
+   */
+  it('rejects the phrasing the detector alone misses', () => {
+    expect(scrub({ operation: 'Has Ahmad had any recent travel?' }).operation).toBe(
+      '[redacted:invalid]',
+    )
+    expect(scrub({ operation: 'Advise Ahmad on fluids and rest.' }).operation).toBe(
+      '[redacted:invalid]',
+    )
+  })
+
+  it('refuses to serialise an object, however it arrives', () => {
+    const consultation = {
+      id: 'c1',
+      transcript: { turns: [{ speaker: 'patient', text: 'I have chest pain' }] },
+    }
+
+    const scrubbed = scrub({ operation: consultation, consultationId: consultation })
+
+    expect(scrubbed.operation).toBe('[redacted:invalid]')
+    expect(JSON.stringify(scrubbed)).not.toContain('chest pain')
+  })
+
+  it('rejects a vault token wherever it is placed', () => {
+    expect(scrub({ operation: '[PATIENT_1]' }).operation).toBe('[redacted:invalid]')
+    expect(scrub({ consultationId: 'note for [PATIENT_1]' }).consultationId).toBe(
+      '[redacted:invalid]',
+    )
+  })
+
+  it('drops an unrecognised detector label rather than echoing it', () => {
+    expect(scrub({ detectorLabels: ['NRIC', 'Ahmad bin Ismail', 'EMAIL'] }).detectorLabels).toEqual(
+      ['NRIC', 'EMAIL'],
+    )
+  })
+
+  it('leaves genuine operational values untouched', () => {
+    const fields = {
+      requestId: '0873d816-87c9-44fe-9e79-9e8734ec5b8b',
+      consultationId: 'cmeg1q2r30000abcd1234efgh',
+      method: 'POST',
+      route: '/api/consultations/:id/analyze',
+      operation: 'suggestions_and_red_flags',
+      model: 'qwen-flash',
+      provider: 'qwen',
+      status: 200,
+      durationMs: 42,
+      stage: 'retrieval',
+      errorClass: 'model_error',
+      errorName: 'LLMResponseError',
+      outcome: 'error',
+      detectorLabels: ['NRIC', 'PATIENT'],
+    }
+
+    expect(scrub(fields)).toEqual(fields)
+  })
+})
+
+describe('emitted records', () => {
+  it('scrubs the message itself, not only the fields', () => {
+    const [line] = captureLines(() => logger.info('analysing for Ahmad bin Ismail'))
+
+    expect(line).not.toContain('Ahmad')
+    expect(line).toContain('[redacted:')
+  })
+
+  it('escapes newlines so a message cannot forge a second log line', () => {
+    const [line] = captureLines(() => logger.info('done\n{"level":"info","msg":"forged"}'))
+
+    expect(line?.trimEnd().split('\n')).toHaveLength(1)
+    expect(String(line)).not.toContain('"msg":"forged"')
+  })
+
+  it('emits one parseable JSON object per line', () => {
+    const [line] = captureLines(() => logger.warn('request failed', { status: 409 }))
+    const record = JSON.parse(line ?? '{}')
+
+    expect(record).toMatchObject({ level: 'warn', msg: 'request failed', status: 409 })
+    expect(typeof record.ts).toBe('string')
+  })
+
+  /**
+   * Issue #15 non-goal: no debug flag may enable raw content logging, because
+   * the flag itself becomes the vulnerability. Redaction sits at the
+   * serialiser, so the most verbose level is exactly as safe as the least.
+   */
+  it('does not widen what may be written at debug level', () => {
+    const [line] = captureLines(() =>
+      logger.debug('trace', { operation: 'patient Ahmad bin Ismail said [PATIENT_1]' } as never),
+    )
+
+    expect(line).toBeDefined()
+    expect(line).not.toContain('Ahmad')
+    expect(line).not.toContain('[PATIENT_1]')
+  })
+})
+
+describe('timeStage', () => {
+  it('records duration and outcome without logging the stage result', async () => {
+    const lines: string[] = []
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      lines.push(String(chunk))
+      return true
+    })
+
+    const result = await timeStage('deidentification', async () => ({
+      secret: 'Patient reports haemoptysis',
+    }))
+    spy.mockRestore()
+
+    expect(result).toEqual({ secret: 'Patient reports haemoptysis' })
+    expect(lines.join('')).not.toContain('haemoptysis')
+
+    const record = JSON.parse(lines[0] ?? '{}')
+    expect(record).toMatchObject({ stage: 'deidentification', outcome: 'ok' })
+    expect(typeof record.durationMs).toBe('number')
+  })
+
+  it('records a failed stage by error class and rethrows', async () => {
+    const lines: string[] = []
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      lines.push(String(chunk))
+      return true
+    })
+
+    class LLMResponseError extends Error {
+      override name = 'LLMResponseError'
+    }
+    const failing = timeStage('note_generation', async () => {
+      throw new LLMResponseError('model returned: patient Ahmad has chest pain')
+    })
+
+    await expect(failing).rejects.toThrow()
+    spy.mockRestore()
+
+    const record = JSON.parse(lines[0] ?? '{}')
+    expect(record).toMatchObject({
+      stage: 'note_generation',
+      outcome: 'error',
+      errorName: 'LLMResponseError',
+    })
+    // The message is where the transcript fragment would be.
+    expect(lines.join('')).not.toContain('chest pain')
+  })
+})

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -1,0 +1,270 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { env } from '../config/env.js'
+import { detect } from '../deid/detectors.js'
+
+/**
+ * Privacy-safe structured logger (GitHub issue #15).
+ *
+ * The goal is that logging clinical content is *impossible*, not merely
+ * discouraged. Two controls do the work, and the second is the one that
+ * matters:
+ *
+ *  1. A positive allowlist of field names. A denylist fails open the moment
+ *     someone invents a new field name; an allowlist fails closed.
+ *  2. A value rule per field. Every allowlisted field is an enum, an
+ *     identifier, or a number. No field accepts free text, so there is no
+ *     field a transcript span, note body, gap question or suggestion can be
+ *     assigned to. A value that fails its rule is replaced, not emitted.
+ *
+ * Control 2 exists because control 1 alone is not enough, and that was proven
+ * rather than assumed. An earlier version of this file allowed `operation` to
+ * be any string and relied on `deid`'s detector to catch anything clinical in
+ * it. The detector is scored and context sensitive (`ACCEPT_THRESHOLD`), so it
+ * caught "Ahmad reports cough" and missed "Has Ahmad had any recent travel?".
+ * A probabilistic check is a useful backstop and a poor boundary.
+ *
+ * The remaining free-text surface is the log message itself, which is
+ * developer-authored and should be a literal. It is still passed through the
+ * detector and truncated, but a name interpolated into a message is a residual
+ * risk that field rules cannot reach. Put data in fields, not in the message.
+ *
+ * Neither control is conditional on log level. There is deliberately no debug
+ * flag that widens what may be written: per the issue's non-goals, that flag
+ * would itself become the vulnerability.
+ *
+ * Output is one JSON object per line on stdout, which Render already drains.
+ * Because every record is `JSON.stringify`d, an embedded newline cannot forge
+ * a second log line.
+ */
+
+const LEVELS = { debug: 10, info: 20, warn: 30, error: 40 } as const
+
+export type LogLevel = keyof typeof LEVELS
+
+/** Stages timed by `timeStage`, matching the pipeline in docs/trd.md §12. */
+export const PIPELINE_STAGES = [
+  'deidentification',
+  'extraction',
+  'note_generation',
+  'rules',
+  'retrieval',
+  'persistence',
+] as const
+
+export type PipelineStage = (typeof PIPELINE_STAGES)[number]
+
+/**
+ * Failure taxonomy. Each class is distinguishable in a log line without
+ * inspecting any payload, which is the entire purpose of the field.
+ */
+export const ERROR_CLASSES = [
+  'model_error',
+  'schema_parse_error',
+  'rule_engine_error',
+  'retrieval_error',
+  'deidentification_error',
+  'validation_error',
+  'auth_error',
+  'internal_error',
+] as const
+
+export type ErrorClass = (typeof ERROR_CLASSES)[number]
+
+/** `GenerateRequest.operation` values, which name an LLM call site. */
+const LLM_OPERATIONS = ['clinical_facts', 'note_and_gaps', 'suggestions_and_red_flags'] as const
+
+export type LlmOperation = (typeof LLM_OPERATIONS)[number]
+
+const DETECTOR_LABELS = ['PATIENT', 'NRIC', 'PHONE', 'ADDRESS', 'DOB', 'MRN', 'EMAIL'] as const
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const
+const OUTCOMES = ['ok', 'error'] as const
+const PROVIDERS = ['qwen', 'gemini', 'deepseek'] as const
+
+type LogValue = string | number | readonly string[]
+
+/** Substituted for anything that fails its field rule. */
+const INVALID = '[redacted:invalid]'
+
+/** Opaque ids: cuid, uuid, better-auth session ids. */
+const ID_PATTERN = /^[A-Za-z0-9._:-]{1,64}$/
+/** Constructor names and model ids. */
+const NAME_PATTERN = /^[A-Za-z0-9_.-]{1,64}$/
+/** A normalised route, already stripped of query and opaque segments. */
+const ROUTE_PATTERN = /^[A-Za-z0-9/_:.-]{1,120}$/
+
+type Rule = (value: unknown) => LogValue
+
+const labelSet = new Set<string>(DETECTOR_LABELS)
+
+const matching =
+  (pattern: RegExp): Rule =>
+  (value) =>
+    typeof value === 'string' && pattern.test(value) ? value : INVALID
+
+const oneOf =
+  (allowed: readonly string[]): Rule =>
+  (value) =>
+    typeof value === 'string' && allowed.includes(value) ? value : INVALID
+
+const asInteger: Rule = (value) =>
+  typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : INVALID
+
+const asDetectorLabels: Rule = (value) =>
+  Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && labelSet.has(item))
+    : INVALID
+
+/**
+ * The single source of truth for what may be logged and what shape it must
+ * take. Adding a field is a deliberate act, visible in a diff, and it must come
+ * with a rule that is an enum, an identifier pattern, or a number. A rule that
+ * accepts arbitrary strings would reopen the hole described above.
+ */
+const FIELD_RULES = {
+  requestId: matching(ID_PATTERN),
+  consultationId: matching(ID_PATTERN),
+  actorId: matching(ID_PATTERN),
+  method: oneOf(HTTP_METHODS),
+  route: matching(ROUTE_PATTERN),
+  status: asInteger,
+  durationMs: asInteger,
+  stage: oneOf(PIPELINE_STAGES),
+  operation: oneOf(LLM_OPERATIONS),
+  errorClass: oneOf(ERROR_CLASSES),
+  errorName: matching(NAME_PATTERN),
+  outcome: oneOf(OUTCOMES),
+  detectorLabels: asDetectorLabels,
+  detectorCount: asInteger,
+  provider: oneOf(PROVIDERS),
+  model: matching(NAME_PATTERN),
+  count: asInteger,
+} as const satisfies Record<string, Rule>
+
+export const ALLOWED_FIELDS = Object.keys(FIELD_RULES) as readonly (keyof typeof FIELD_RULES)[]
+
+/**
+ * Ergonomic mirror of `FIELD_RULES`. Excess-property checking makes
+ * `logger.info('x', { transcript })` a compile error at the call site, while
+ * the rules are what hold when the object arrives as a variable or through a
+ * cast.
+ */
+export interface LogFields {
+  requestId?: string
+  consultationId?: string
+  actorId?: string
+  method?: string
+  route?: string
+  status?: number
+  durationMs?: number
+  stage?: PipelineStage
+  /** Names an LLM call site, never its content. */
+  operation?: LlmOperation
+  errorClass?: ErrorClass
+  /** Constructor name only. Never `error.message`, which may quote a transcript. */
+  errorName?: string
+  outcome?: 'ok' | 'error'
+  /** Detector labels that fired, e.g. ["NRIC"]. Never the matched values. */
+  detectorLabels?: readonly string[]
+  detectorCount?: number
+  provider?: string
+  model?: string
+  count?: number
+}
+
+/** Long enough for a sentence, far too short for a clinical narrative. */
+const MAX_MESSAGE_LENGTH = 120
+
+/** An already-minted vault token, e.g. `[PATIENT_1]`. */
+const TOKEN_PATTERN = /\[[A-Z]+_\d+\]/
+
+/**
+ * The message is the one free-text surface, so it gets the probabilistic
+ * treatment the fields no longer need: vault tokens stripped, detector run,
+ * length capped.
+ */
+function scrubMessage(message: string): string {
+  if (TOKEN_PATTERN.test(message)) return '[redacted:vault-token]'
+
+  const hits = detect(message)
+  if (hits.length > 0) {
+    const labels = [...new Set(hits.map((hit) => hit.label))].sort().join(',')
+    return `[redacted:${labels}]`
+  }
+
+  return message.length > MAX_MESSAGE_LENGTH
+    ? `${message.slice(0, MAX_MESSAGE_LENGTH)}...`
+    : message
+}
+
+/** Exported for the tests that prove the boundary holds. */
+export function scrub(fields: Readonly<Record<string, unknown>>): Record<string, LogValue> {
+  const out: Record<string, LogValue> = {}
+  for (const [key, value] of Object.entries(fields)) {
+    const rule = (FIELD_RULES as Record<string, Rule | undefined>)[key]
+    if (!rule) continue
+    if (value === undefined || value === null) continue
+    out[key] = rule(value)
+  }
+  return out
+}
+
+const requestStore = new AsyncLocalStorage<{ requestId: string }>()
+
+/** Binds a request id to everything `fn` triggers, including async work. */
+export function withRequestContext<T>(requestId: string, fn: () => T): T {
+  return requestStore.run({ requestId }, fn)
+}
+
+export function currentRequestId(): string | undefined {
+  return requestStore.getStore()?.requestId
+}
+
+function write(level: LogLevel, message: string, fields: LogFields = {}): void {
+  if (LEVELS[level] < LEVELS[env.LOG_LEVEL]) return
+
+  const requestId = currentRequestId()
+  const record = {
+    level,
+    msg: scrubMessage(message),
+    ...(requestId ? { requestId } : {}),
+    ...scrub(fields as Readonly<Record<string, unknown>>),
+    ts: new Date().toISOString(),
+  }
+
+  process.stdout.write(`${JSON.stringify(record)}\n`)
+}
+
+export const logger = {
+  debug: (message: string, fields?: LogFields) => write('debug', message, fields),
+  info: (message: string, fields?: LogFields) => write('info', message, fields),
+  warn: (message: string, fields?: LogFields) => write('warn', message, fields),
+  error: (message: string, fields?: LogFields) => write('error', message, fields),
+}
+
+/**
+ * Times one pipeline stage and records the outcome. Wrapping a call is the
+ * entire instrumentation cost, which is deliberate: the issue's framing is that
+ * the safe thing has to also be the easy thing.
+ *
+ * The stage's return value passes through untouched and is never logged.
+ */
+export async function timeStage<T>(stage: PipelineStage, run: () => Promise<T> | T): Promise<T> {
+  const startedAt = performance.now()
+  try {
+    const result = await run()
+    logger.info('pipeline stage complete', {
+      stage,
+      outcome: 'ok',
+      durationMs: Math.round(performance.now() - startedAt),
+    })
+    return result
+  } catch (error) {
+    logger.warn('pipeline stage failed', {
+      stage,
+      outcome: 'error',
+      durationMs: Math.round(performance.now() - startedAt),
+      errorName: error instanceof Error ? error.name : typeof error,
+    })
+    throw error
+  }
+}

--- a/backend/src/middleware/error-handler.test.ts
+++ b/backend/src/middleware/error-handler.test.ts
@@ -52,8 +52,15 @@ describe('errorHandler', () => {
     spy.mockRestore()
   })
 
+  // Logging moved from `console.error` to `lib/logger.ts` in issue #15, so the
+  // assertion now reads the log drain rather than the console. The intent is
+  // unchanged: the class is recorded, the message never is.
   it('never writes the error message to the log', () => {
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const lines: string[] = []
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      lines.push(String(chunk))
+      return true
+    })
 
     errorHandler(
       new Error('transcript: patient reports chest pain'),
@@ -62,11 +69,34 @@ describe('errorHandler', () => {
       vi.fn(),
     )
 
-    const logged = spy.mock.calls.flat().join(' ')
-    expect(logged).not.toContain('chest pain')
-    expect(logged).toContain('Error')
-
     spy.mockRestore()
+
+    const logged = lines.join('')
+    expect(logged).not.toContain('chest pain')
+    expect(logged).toContain('"errorName":"Error"')
+    expect(logged).toContain('"errorClass":"internal_error"')
+  })
+
+  it('classifies a de-identification failure distinctly from a model failure', () => {
+    const lines: string[] = []
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      lines.push(String(chunk))
+      return true
+    })
+
+    class DeidentificationError extends Error {
+      override name = 'DeidentificationError'
+    }
+    class LLMResponseError extends Error {
+      override name = 'LLMResponseError'
+    }
+
+    errorHandler(new DeidentificationError('x'), {} as Request, mockRes(), vi.fn())
+    errorHandler(new LLMResponseError('y'), {} as Request, mockRes(), vi.fn())
+    spy.mockRestore()
+
+    expect(lines.join('')).toContain('"errorClass":"deidentification_error"')
+    expect(lines.join('')).toContain('"errorClass":"model_error"')
   })
 
   it('delegates to express when headers are already sent', () => {

--- a/backend/src/middleware/error-handler.ts
+++ b/backend/src/middleware/error-handler.ts
@@ -1,16 +1,44 @@
 import type { NextFunction, Request, Response } from 'express'
 import { HttpError } from '../lib/http-error.js'
+import { type ErrorClass, logger } from '../lib/logger.js'
 
 /**
- * Terminal error handler. Two rules, both from issue #14's acceptance criteria:
+ * Maps a failure onto the taxonomy in `lib/logger.ts` so each class is
+ * distinguishable in a log line without anyone opening a payload
+ * (GitHub issue #15).
+ *
+ * Classification reads the error's *type* and an `HttpError`'s developer
+ * authored `code`. It never reads `message`, which on this codepath routinely
+ * quotes a transcript.
+ */
+function classify(err: unknown): ErrorClass {
+  if (err instanceof HttpError) {
+    if (err.code === 'unauthenticated') return 'auth_error'
+    if (err.code === 'invalid_body') return 'validation_error'
+    if (err.code === 'analysis_failed') return 'model_error'
+    return 'internal_error'
+  }
+
+  const name = err instanceof Error ? err.name : ''
+  if (name === 'DeidentificationError') return 'deidentification_error'
+  if (name === 'LLMResponseError') return 'model_error'
+  if (name === 'ZodError') return 'schema_parse_error'
+  return 'internal_error'
+}
+
+/**
+ * Terminal error handler. Three rules, from issues #14 and #15:
  *
  *  1. Only an `HttpError` carries its message to the caller. Every other throw
  *     collapses to a generic 500, so a Prisma message, a stack frame, a file
  *     path, or a fragment of transcript embedded in an exception cannot reach
  *     the client.
- *  2. Nothing about the error is logged beyond its type. Transcript bodies and
- *     note contents routinely appear inside thrown values on this codepath;
- *     logging `err` would put clinical text in Render's log drain (AGENTS.md).
+ *  2. Nothing about the error is logged beyond its class and constructor name.
+ *     `err.message`, `err.stack` and the request body are never touched, so
+ *     there is no exception path that carries clinical text into the drain.
+ *  3. The request id is on the response already (`requestContext` sets the
+ *     header before any route runs), so a caller can quote it and an engineer
+ *     can find the matching line without reading any content.
  */
 export function errorHandler(err: unknown, _req: Request, res: Response, next: NextFunction) {
   if (res.headersSent) {
@@ -18,14 +46,18 @@ export function errorHandler(err: unknown, _req: Request, res: Response, next: N
     return
   }
 
+  const errorClass = classify(err)
+  const errorName = err instanceof Error ? err.name : typeof err
+
   if (err instanceof HttpError) {
+    // Expected, client-visible failures. Logged at warn so they are greppable
+    // without drowning genuine faults.
+    logger.warn('request failed', { errorClass, errorName, status: err.status })
     res.status(err.status).json({ error: { code: err.code, message: err.message } })
     return
   }
 
-  console.error(
-    `Unhandled error: ${err instanceof Error ? err.name : typeof err} (message withheld — may contain clinical text)`,
-  )
+  logger.error('unhandled error', { errorClass, errorName, status: 500 })
 
   res.status(500).json({
     error: { code: 'internal_error', message: 'An unexpected error occurred.' },

--- a/backend/src/middleware/request-context.test.ts
+++ b/backend/src/middleware/request-context.test.ts
@@ -1,0 +1,147 @@
+import type { Server } from 'node:http'
+import express from 'express'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { requestContext } from './request-context.js'
+
+let server: Server
+let origin: string
+let captured: string[] = []
+
+beforeAll(async () => {
+  const app = express()
+  app.use(requestContext)
+  app.get('/api/health', (_req, res) => {
+    res.json({ ok: true })
+  })
+  app.get('/api/consultations/:id', (_req, res) => {
+    res.status(404).json({ error: { code: 'not_found', message: 'Consultation not found.' } })
+  })
+
+  server = app.listen(0)
+  await new Promise((r) => server.once('listening', r))
+  const addr = server.address()
+  if (typeof addr === 'string' || addr === null) throw new Error('no port')
+  origin = `http://127.0.0.1:${addr.port}`
+})
+
+afterAll(() => server.close())
+
+beforeEach(() => {
+  captured = []
+})
+
+async function call(path: string, headers: Record<string, string> = {}) {
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    captured.push(String(chunk))
+    return true
+  })
+  try {
+    const res = await fetch(`${origin}${path}`, { headers })
+    await new Promise((r) => setTimeout(r, 30))
+    return res
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+function records() {
+  return captured
+    .join('')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+}
+
+describe('request id', () => {
+  it('generates one and returns it on the response', async () => {
+    const res = await call('/api/health')
+
+    const header = res.headers.get('x-request-id')
+    expect(header).toMatch(/^[0-9a-f-]{36}$/)
+    expect(records()[0]?.requestId).toBe(header)
+  })
+
+  it('is present on an error response, not only a success', async () => {
+    const res = await call('/api/consultations/cmeg1q2r30000abcd1234efgh')
+
+    expect(res.status).toBe(404)
+    expect(res.headers.get('x-request-id')).toBeTruthy()
+  })
+
+  it('echoes a well-formed client-supplied id so a caller can correlate', async () => {
+    const res = await call('/api/health', { 'x-request-id': 'client-trace-42' })
+
+    expect(res.headers.get('x-request-id')).toBe('client-trace-42')
+  })
+
+  /**
+   * The header is attacker-controlled, so it is a way to write arbitrary text
+   * into the log drain from outside the system. Anything not matching the id
+   * shape is discarded and replaced rather than sanitised in place.
+   */
+  it.each([
+    ['clinical text', 'Encik Ahmad bin Ismail NRIC 850523-14-5677'],
+    ['an over-long value', 'a'.repeat(200)],
+    ['an empty value', ''],
+    ['path traversal', '../../etc/passwd'],
+  ])('refuses a hostile client-supplied id: %s', async (_label, hostile) => {
+    const res = await call('/api/health', { 'x-request-id': hostile })
+
+    const header = res.headers.get('x-request-id')
+    expect(header).toMatch(/^[0-9a-f-]{36}$/)
+    expect(captured.join('')).not.toContain('Ahmad')
+    expect(captured.join('')).not.toContain('850523-14-5677')
+    expect(captured.join('')).not.toContain('etc/passwd')
+  })
+
+  /**
+   * A newline in a header is not deliverable through a compliant HTTP client
+   * (Node's `fetch` rejects it before it reaches the server, and so does the
+   * http parser), so this exercises the middleware directly rather than
+   * pretending the attack arrives over the wire. The guard is cheap and the
+   * next transport may be less strict.
+   */
+  it('refuses an id carrying a forged log line, tested at the middleware', () => {
+    const headers: Record<string, string> = {
+      'x-request-id': 'x\n{"level":"error","msg":"forged"}',
+    }
+    const req = { header: (k: string) => headers[k.toLowerCase()], method: 'GET', path: '/api/x' }
+    const setHeader = vi.fn()
+    const res = { setHeader, on: vi.fn(), statusCode: 200 }
+
+    requestContext(
+      req as unknown as Parameters<typeof requestContext>[0],
+      res as unknown as Parameters<typeof requestContext>[1],
+      () => {},
+    )
+
+    expect(setHeader).toHaveBeenCalledWith('x-request-id', expect.stringMatching(/^[0-9a-f-]{36}$/))
+    expect(setHeader).not.toHaveBeenCalledWith('x-request-id', expect.stringContaining('forged'))
+  })
+})
+
+describe('request logging', () => {
+  it('records method, route, status and duration', async () => {
+    await call('/api/health')
+
+    expect(records()[0]).toMatchObject({
+      msg: 'request completed',
+      method: 'GET',
+      route: '/api/health',
+      status: 200,
+    })
+    expect(typeof records()[0]?.durationMs).toBe('number')
+  })
+
+  /**
+   * A consultation id is opaque, but a URL is the wrong place for it: it ends
+   * up in log tooling and search indexes as a path rather than a field
+   * (healthcare-phi-compliance, "URL parameters").
+   */
+  it('normalises opaque path segments so the route stays a pattern', async () => {
+    await call('/api/consultations/cmeg1q2r30000abcd1234efgh')
+
+    expect(records()[0]?.route).toBe('/api/consultations/:id')
+  })
+})

--- a/backend/src/middleware/request-context.ts
+++ b/backend/src/middleware/request-context.ts
@@ -1,0 +1,58 @@
+import { randomUUID } from 'node:crypto'
+import type { NextFunction, Request, Response } from 'express'
+import { logger, withRequestContext } from '../lib/logger.js'
+
+/**
+ * A client-supplied id is echoed only if it is short and alphanumeric. An
+ * unvalidated header would let a caller write arbitrary text into the log
+ * drain, which is both a log-injection vector and a way to place clinical text
+ * into logs from outside the system.
+ */
+const SAFE_REQUEST_ID = /^[A-Za-z0-9._-]{1,64}$/
+
+/**
+ * Opaque identifiers are replaced with `:id` so a route reads as a low
+ * cardinality pattern rather than a specific record. The consultation id is
+ * still logged, but as an explicit `consultationId` field, which keeps it out
+ * of any URL that might be indexed or scraped by a log tool
+ * (healthcare-phi-compliance, "URL parameters").
+ */
+function normaliseRoute(path: string): string {
+  return (path.split('?')[0] ?? path)
+    .split('/')
+    .map((segment) => (/^[A-Za-z0-9_-]{16,}$/.test(segment) ? ':id' : segment))
+    .join('/')
+}
+
+/**
+ * Assigns a request id, exposes it on the response, and records one line per
+ * completed request (GitHub issue #15).
+ *
+ * The id is surfaced as the `x-request-id` response header rather than inside
+ * the error envelope: the envelope is a contract the SPA parses
+ * (`ErrorEnvelopeSchema` in `@shared/types`), while a correlation id is
+ * transport metadata. Header placement also means every response carries it,
+ * not just failures.
+ *
+ * Mounted first in `app.ts`, so no later middleware can log without a request
+ * id in scope.
+ */
+export function requestContext(req: Request, res: Response, next: NextFunction) {
+  const supplied = req.header('x-request-id')
+  const requestId = supplied && SAFE_REQUEST_ID.test(supplied) ? supplied : randomUUID()
+
+  res.setHeader('x-request-id', requestId)
+
+  const startedAt = performance.now()
+  res.on('finish', () => {
+    logger.info('request completed', {
+      requestId,
+      method: req.method,
+      route: normaliseRoute(req.path),
+      status: res.statusCode,
+      durationMs: Math.round(performance.now() - startedAt),
+    })
+  })
+
+  withRequestContext(requestId, next)
+}

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -17,6 +17,7 @@ import { deriveGaps } from '../gaps/index.js'
 import { assertOwnedConsultation } from '../lib/authz.js'
 import { HttpError } from '../lib/http-error.js'
 import { getLLMDescriptor, LLMResponseError } from '../lib/llm/index.js'
+import { logger, timeStage } from '../lib/logger.js'
 import { prisma } from '../lib/prisma.js'
 import { evaluateRedFlags, mergeRedFlags } from '../redflags/index.js'
 import { generateSuggestions } from '../suggestions/index.js'
@@ -171,15 +172,24 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
   })
 
   try {
-    const { text, vault, detected } = deidentifyTranscript(transcript.data)
+    const { text, vault, detected } = await timeStage('deidentification', () =>
+      deidentifyTranscript(transcript.data),
+    )
+
+    // Labels and a count, never the matched values (GitHub issue #15).
+    logger.info('de-identification complete', {
+      consultationId: consultation.id,
+      detectorLabels: detected,
+      detectorCount: detected.length,
+    })
 
     // Runs on the raw transcript, in-process, regardless of model output. It
     // never leaves the API, so it needs no gate.
-    const ruleFlags = evaluateRedFlags(transcript.data)
+    const ruleFlags = await timeStage('rules', () => evaluateRedFlags(transcript.data))
 
     const [noteResult, suggestionResult] = await Promise.all([
-      analyseNote(text, text),
-      generateSuggestions(text),
+      timeStage('note_generation', () => analyseNote(text, text)),
+      timeStage('retrieval', () => generateSuggestions(text)),
     ])
 
     const rehydrate = (value: string) => vault.rehydrate(value)
@@ -210,10 +220,12 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
       })),
     }
 
-    const updated = await prisma.consultation.update({
-      where: { id: consultation.id },
-      data: { status: 'awaiting_review', analysis },
-    })
+    const updated = await timeStage('persistence', () =>
+      prisma.consultation.update({
+        where: { id: consultation.id },
+        data: { status: 'awaiting_review', analysis },
+      }),
+    )
 
     const llm = getLLMDescriptor()
     await recordAuditEvent({

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -1172,3 +1172,48 @@ The third row is the sharpest corroboration of the _mechanism_: "more thorough +
 - The rate at which facts are downgraded to `NOT_ASSESSED` by §21.4 is itself a quality signal worth recording, but no metric for it is specified. Related to, but distinct from, the alert-fatigue limitation in `docs/prd.md` §12.
 - **Whether the structured schema helps or hurts is untested** (§3, ratification condition 2). The one published study that imposed a template on note generation measured _increased_ major hallucinations. This is the single largest unvalidated assumption in the guardrail architecture.
 - **The ASR layer is a second fabrication surface these controls do not reach** (§20). Nothing in §21 protects against a transcript that is already wrong.
+
+---
+
+## 22. Observability & Privacy-Safe Logging
+
+**Status: `Built`** (GitHub issue #15)
+
+Appended as a new section rather than inserted near §15, because renumbering would break the many `§19, row N` cross-references in both documents. §15 covers the **database** audit trail; this section covers **process logs**.
+
+### Why It Is Structural, Not Conventional
+
+The instinct when an LLM call misbehaves is to log the payload, which here would put transcript text into a log drain. `backend/src/lib/logger.ts` makes that impossible rather than discouraged:
+
+| Control              | Mechanism                                                                                          |
+| -------------------- | -------------------------------------------------------------------------------------------------- |
+| Field-name allowlist | A key absent from `FIELD_RULES` is dropped. An allowlist fails closed where a denylist fails open. |
+| Per-field value rule | Every field is an enum, an id pattern, or a number. **No field accepts free text.**                |
+| Message scrubbing    | The one free-text surface. Vault tokens stripped, `deid` detector run, length capped at 120.       |
+| Level independence   | Redaction sits at the serialiser, so `debug` is exactly as safe as `error`.                        |
+
+### The Finding That Shaped The Design
+
+An earlier revision allowed `operation` to be any string and relied on the `deid` detector to catch clinical content in it. **That is not sufficient, and it was measured rather than assumed.** The detector is scored and context-sensitive (`ACCEPT_THRESHOLD`, §9):
+
+- `"Ahmad reports cough"` fires, and is redacted.
+- `"Has Ahmad had any recent travel?"` does not, and passed through.
+
+A probabilistic check is a useful backstop and a poor boundary. Per-field value rules replaced it as the primary control.
+
+### What Is Recorded
+
+- **Request id** on every line, via `AsyncLocalStorage`, so one analysis is one trace. Returned as the `x-request-id` response header on every response, success or failure. It is deliberately _not_ in the JSON error envelope: `ErrorEnvelopeSchema` (§13) is a contract the SPA parses, whereas a correlation id is transport metadata.
+- **Per-stage latency** via `timeStage()`: `deidentification`, `rules`, `note_generation`, `retrieval`, `persistence`.
+- **Error class** from a fixed taxonomy, so model, schema-parse, rule-engine, retrieval and de-identification failures are distinguishable without opening a payload.
+- **De-identification observability**: detector labels and a count, never values.
+
+### Deliberate Omissions
+
+- **No third-party APM.** Sending a clinical application's exceptions to an external processor is a PDPA data-processor decision with a DPIA attached (§19, row 11), not a library choice. Structured JSON on stdout, which Render already drains, satisfies the issue's "works with Render and move on" constraint without creating a new cross-border data flow.
+- **No debug flag for raw content.** Named as a non-goal in the issue and enforced by test: the flag would itself become the vulnerability.
+- **Per-provider-call timing is not split.** `analyseNote` issues `clinical_facts` and `note_and_gaps` concurrently (§12), and `timeStage` wraps the pair, so `note_generation` is the wall-clock of the slower half. Splitting them needs a hook inside `backend/src/analysis/`. Worth doing, because per-call variance rather than the mean is what threatens the CAP-1 budget.
+
+### Residual Risk
+
+The log **message** is developer-authored and interpolation into it is not reachable by field rules. A name templated into a message string is caught only if the detector scores it above threshold. The convention is therefore load-bearing: **put data in fields, not in the message.**

--- a/render.yaml
+++ b/render.yaml
@@ -30,6 +30,11 @@ services:
         value: qwen-flash
       - key: DEID_FAIL_CLOSED
         value: 'true'
+      # Verbosity only. No level widens what may be written: redaction in
+      # backend/src/lib/logger.ts is unconditional, and there is deliberately
+      # no flag that unlocks raw clinical content (GitHub issue #15).
+      - key: LOG_LEVEL
+        value: info
       # Guest sign-in (#29). Credentials stay server-side — the /api/auth/guest
       # route exchanges them for a real session, so the demo password is never
       # in the SPA bundle. Without these set in the dashboard the guest button


### PR DESCRIPTION
## What Changed

Structured JSON logging in which clinical content **cannot be serialised**, plus request tracing, per-stage latency, and an error-class taxonomy.

Closes #15

## Why

Observability had to be designed so the safe thing is also the easy thing. The instinct when an LLM call misbehaves is to log the payload, which here would put transcript text into a log drain.

Two controls, and the second is the one that matters:

| Control | Mechanism |
| --- | --- |
| Field-name allowlist | A key absent from `FIELD_RULES` is dropped. An allowlist fails closed where a denylist fails open. |
| **Per-field value rule** | Every field is an enum, an id pattern, or a number. **No field accepts free text.** |
| Message scrubbing | The one free-text surface: vault tokens stripped, `deid` detector run, length capped. |
| Level independence | Redaction sits at the serialiser, so `debug` is exactly as safe as `error`. |

## The Finding That Shaped The Design

The first version allowed `operation` to be any string and leaned on the `deid` detector to catch clinical content in it. I tested that assumption by **disabling redaction entirely** to see whether the end-to-end leak test measured the protection or merely the current call sites.

It measured the call sites. The test still passed, because nothing in the pipeline hands the logger anything dangerous today. A green test proving "the code we happen to have written does not leak" reads identically to one proving "this component cannot leak", right up until someone adds a call site.

Adding an adversarial call site exposed a real hole. The detector is scored and context-sensitive (`ACCEPT_THRESHOLD = 0.5`):

- `"Ahmad reports cough"` fires, and is redacted.
- `"Has Ahmad had any recent travel?"` does **not**, and went straight through.

A probabilistic check is a useful backstop and a poor boundary. This is the same argument as `docs/trd.md` §21.3's tiering: per-field value rules make the leak **unrepresentable** rather than **unlikely**. The detector now guards the log message only.

**Residual risk, documented not buried:** the log message is developer-authored free text, and a name interpolated into it is caught only if the detector scores it above threshold. Field rules cannot reach that, so "put data in fields, not the message" is load-bearing and is stated as such in §22.

## Verification

- [x] `bun run lint` — 4 warnings, 0 errors (the pre-existing `prisma/seed.ts` console calls)
- [x] `bun run typecheck` — clean across shared, backend and frontend
- [x] `bun run test` — **31 shared + 262 backend = 293 passed**, up from 253 at `ce3b83f`
- [x] Manually exercised: redaction disabled to confirm the tests fail (9 of 19 fail, including the adversarial leak case)

Tests added: `logger.test.ts` (allowlist, value rules, emitted records, `timeStage`), `logger.leak.test.ts` (a real `urti-identifier-dense-routine` fixture analysis with stdout captured and greped, plus an adversarial call site handing the logger the real transcript and note), `request-context.test.ts` (request id generation, echo, hostile-header rejection, route normalisation).

> **Correction to an earlier revision of this description.** It claimed `bun run typecheck` was red on `main` because of `frontend/src/lib/api.ts`. That was wrong. The failure was entirely local: I rebased onto FE v1 (#50) without re-running `bun install`, so `frontend/node_modules/zod` was missing and `z.ZodType<T>` inference collapsed to `unknown`. After `bun install`, typecheck is clean across all three workspaces, matching CI. `main` was never broken and #50 is not at fault.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider — egress still goes through `deid/` then `LLMClient`
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model — `timeStage` wraps calls without altering the union
- [x] Citations remain ID-constrained; no free-text references accepted
- [x] **No transcript bodies, note contents, or vault entries written to logs** — this is the substance of the PR, asserted by the leak suite against a real fixture
- [x] Fixtures added are synthetic — none added; reuses the existing `urti-identifier-dense-routine`

## Notes For The Reviewer

**No APM vendor was added, deliberately.** The issue asks for "error reporting configured with scrubbing". Sending a clinical application's exceptions to a third-party processor is a PDPA data-processor decision with a DPIA attached (§19, row 11), not a library choice. Structured JSON on stdout, which Render already drains, satisfies the non-goal "pick something that works with Render and move on" without creating a new cross-border data flow. Under-delivering the bullet with the reasoning stated is worth more than quietly satisfying it.

Other deliberate choices:

- **Request id is the `x-request-id` response header, not a field in the JSON error envelope.** `ErrorEnvelopeSchema` is a contract the SPA parses; a correlation id is transport metadata. Header placement also means every response carries it, not only failures.
- **`docs/trd.md` §22 is appended, not inserted.** Inserting near §15 would renumber §16 to §21 and break the many `§19, row N` cross-references in both documents.
- **Per-provider-call timing is not split.** `analyseNote` issues `clinical_facts` and `note_and_gaps` concurrently since #48, and `timeStage` wraps the pair, so `note_generation` is the wall-clock of the slower half. Splitting them needs a hook inside `backend/src/analysis/`, which is another workstream. Worth doing: per-call variance rather than the mean is what threatens the CAP-1 budget.
- **Unrelated dead code noticed, not touched:** `backend/src/routes/consultations.ts` carries an orphaned docblock for `serialiseTranscript` (the function moved to `deid/`, the comment stayed).
