### PR TITLE
feat(api): persist the reviewed clinical checklist with the analysis

### DIFF
--- a/backend/src/lib/logger.leak.test.ts
+++ b/backend/src/lib/logger.leak.test.ts
@@ -30,8 +30,20 @@ vi.mock('../analysis/index.js', () => ({
       assessment: 'Acute upper respiratory tract infection.',
       plan: 'Symptomatic relief. Review if worsening.',
     },
-    clinicalFacts: {},
-    operational: {},
+    // Now persisted and returned, so it has to satisfy `ClinicalFactsSchema`.
+    // `evidence` carries a vault token deliberately: this suite exists to prove
+    // none of it reaches the log drain.
+    clinicalFacts: {
+      symptoms: {
+        cough: { state: 'PRESENT', value: 'dry cough', evidence: '[PATIENT_1] has a dry cough' },
+      },
+      history: {},
+      observations: {},
+      examination: {},
+    },
+    operational: {
+      diagnosis: { state: 'PRESENT', value: 'URTI', evidence: '[PATIENT_1] likely has a URTI' },
+    },
     gaps: [
       {
         id: 'gap-1',

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -15,8 +15,29 @@ vi.mock('../analysis/index.js', () => ({
       assessment: 'Likely viral URTI',
       plan: 'Fluids and rest',
     },
-    clinicalFacts: {},
-    operational: {},
+    // Shaped like the real thing: assertions nested under groups, and an array
+    // of them under `medicationsDispensed`. `evidence` is a verbatim span from
+    // the de-identified transcript, so it carries a vault token by construction.
+    clinicalFacts: {
+      symptoms: {
+        cough: { state: 'PRESENT', value: 'dry cough', evidence: '[PATIENT_1] has a dry cough' },
+        haemoptysis: { state: 'NOT_ASSESSED' },
+      },
+      history: {
+        smoking: { state: 'DENIED', value: 'non-smoker', evidence: '[PATIENT_1] does not smoke' },
+      },
+      // Present but empty: every field carries its own NOT_ASSESSED default, so
+      // the groups fill themselves in. The group keys are still required.
+      observations: {},
+      examination: {},
+    },
+    operational: {
+      diagnosis: { state: 'PRESENT', value: 'URTI', evidence: 'I think [PATIENT_1] has a URTI' },
+      medicationsDispensed: [
+        { state: 'PRESENT', value: 'paracetamol', evidence: 'giving [PATIENT_1] paracetamol' },
+      ],
+      mcDays: { state: 'NOT_ASSESSED' },
+    },
     gaps: [
       {
         id: 'model-gap',
@@ -236,9 +257,15 @@ describe('analyse output', () => {
   beforeEach(() => seed('draft'))
 
   async function analysed() {
+    type Assertion = { state: string; value?: string; evidence?: string }
     const body = (await (await call('POST', '/api/consultations/c1/analyze')).json()) as {
       consultation: {
-        analysis: { redFlags: { id: string }[]; gaps: { id: string }[] }
+        analysis: {
+          redFlags: { id: string }[]
+          gaps: { id: string }[]
+          clinicalFacts?: Record<string, Record<string, Assertion>>
+          operational?: Record<string, Assertion> & { medicationsDispensed?: Assertion[] }
+        }
       }
     }
     return body.consultation.analysis
@@ -263,6 +290,42 @@ describe('analyse output', () => {
     const body = await res.text()
 
     expect(body).not.toMatch(/\[[A-Z]+_\d+\]/)
+  })
+
+  /**
+   * docs/prd.md §10 requires a field the consultation never touched to read as
+   * unestablished rather than absent, and the review screen cannot render a
+   * `NOT_ASSESSED` it was never sent. These were computed, fed to `deriveGaps`,
+   * and then discarded before this.
+   */
+  it('persists the reviewed checklist rather than discarding it', async () => {
+    const analysis = await analysed()
+
+    expect(analysis.clinicalFacts?.symptoms?.cough?.state).toBe('PRESENT')
+    expect(analysis.clinicalFacts?.symptoms?.haemoptysis?.state).toBe('NOT_ASSESSED')
+    expect(analysis.operational?.diagnosis?.state).toBe('PRESENT')
+  })
+
+  it('rehydrates assertion values and evidence, including inside arrays', async () => {
+    const analysis = await analysed()
+
+    // `evidence` is a verbatim span from the de-identified transcript, so it
+    // carries a token essentially always. A pseudonym reaching the evidence
+    // trail is what the doctor would actually notice.
+    expect(analysis.clinicalFacts?.symptoms?.cough?.evidence).toContain('Ahmad')
+    expect(analysis.clinicalFacts?.history?.smoking?.evidence).toContain('Ahmad')
+    expect(analysis.operational?.diagnosis?.evidence).toContain('Ahmad')
+    // The array case a per-field map would silently miss.
+    expect(analysis.operational?.medicationsDispensed?.[0]?.evidence).toContain('Ahmad')
+
+    expect(JSON.stringify(analysis)).not.toMatch(/\[[A-Z]+_\d+\]/)
+  })
+
+  it('leaves an assertion with no value or evidence untouched', async () => {
+    const analysis = await analysed()
+
+    expect(analysis.clinicalFacts?.symptoms?.haemoptysis).toEqual({ state: 'NOT_ASSESSED' })
+    expect(analysis.operational?.mcDays).toEqual({ state: 'NOT_ASSESSED' })
   })
 
   it('records version stamps and discarded field ids on completion', async () => {

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -66,6 +66,36 @@ function mergeGaps(derived: InformationGap[], modelGaps: InformationGap[]): Info
   return [...derived, ...modelGaps.filter((gap) => !seen.has(gap.id))]
 }
 
+/**
+ * Rehydrates every `value` and `evidence` string anywhere in an assertion tree.
+ *
+ * Recursive rather than a per-field map, for two reasons. The structure is not
+ * uniform: `ClinicalFacts` nests assertions two levels under four groups, while
+ * `OperationalBlock` is flat except for `medicationsDispensed`, which is an
+ * array of them. And a hard-coded field list would silently stop covering a
+ * field the moment the 29-key checklist grows, which is the same failure the
+ * clinical-version guard exists to prevent.
+ *
+ * `evidence` in particular is a verbatim span from the *de-identified*
+ * transcript by construction, so it carries `[PATIENT_1]`-style tokens
+ * essentially always rather than occasionally.
+ */
+function rehydrateAssertions<T>(node: T, rehydrate: (value: string) => string): T {
+  if (Array.isArray(node)) {
+    return node.map((item) => rehydrateAssertions(item, rehydrate)) as T
+  }
+  if (node !== null && typeof node === 'object') {
+    return Object.fromEntries(
+      Object.entries(node).map(([key, value]) =>
+        (key === 'value' || key === 'evidence') && typeof value === 'string'
+          ? [key, rehydrate(value)]
+          : [key, rehydrateAssertions(value, rehydrate)],
+      ),
+    ) as T
+  }
+  return node
+}
+
 function classifyFailure(error: unknown): AnalysisFailureReason {
   if (error instanceof DeidentificationError) return 'deidentification_failed'
   if (error instanceof LLMResponseError) return 'llm_response_invalid'
@@ -214,6 +244,12 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
         label: rehydrate(flag.label),
         evidence: rehydrate(flag.evidence),
       })),
+      // The reviewed checklist, surfaced rather than discarded. Without these
+      // the UI cannot render a `NOT_ASSESSED` it was never sent, and docs/prd.md
+      // §10's "unestablished, never absent" requirement has nothing to display
+      // (Demo Script step 5).
+      clinicalFacts: rehydrateAssertions(noteResult.clinicalFacts, rehydrate),
+      operational: rehydrateAssertions(noteResult.operational, rehydrate),
       suggestions: suggestionResult.suggestions.map((suggestion) => ({
         ...suggestion,
         text: rehydrate(suggestion.text),


### PR DESCRIPTION
## What Changed

`POST /api/consultations/:id/analyze` now persists and returns `clinicalFacts` and `operational` instead of computing them, feeding them to `deriveGaps`, and throwing them away.

## Why

Two committed requirements were unbuildable without them:

- **`docs/prd.md` §10** requires a field the consultation never touched to read as *unestablished*, never as absent. A UI cannot render a `NOT_ASSESSED` it was never sent.
- **Demo Script step 5** asks for the SOAP scaffold **plus the operational block**, with **`NOT_ASSESSED` fields visible rather than blank**. That is an evaluator instruction, and it failed on the day.

There is a quieter cost too. The fixed 29-key design exists so that "we checked, and the transcript was silent on haemoptysis" is a claim the doctor can *see*. Discarding the facts meant the product did all that work and then showed four paragraphs of prose, which a reviewer cannot distinguish from any other scribe.

## Rehydration Is The Part That Would Have Been Got Wrong

`evidence` is a verbatim span from the **de-identified** transcript by construction, so it carries `[PATIENT_1]`-style tokens essentially always rather than occasionally. `value` can too. Passing these through unmapped would put pseudonyms in the evidence trail the doctor reads.

The walk is **recursive rather than a per-field map**, for two reasons:

1. **The structure is not uniform.** `ClinicalFacts` nests assertions two levels under four groups; `OperationalBlock` is flat *except* `medicationsDispensed`, which is an **array** of assertions. A per-field map silently misses the array.
2. **A hard-coded field list would rot.** It would stop covering a field the moment the 29-key checklist grows, which is the same failure mode the clinical-version guard in #49 exists to prevent. This derives from `Object.entries` and has no field list at all.

## Why The Schema Fields Are Optional

Deliberate, and the reason is safety rather than backward compatibility alone. A row analysed before this change has no facts. A UI that renders absence as "nothing was assessed" states the precise falsehood §10 exists to prevent. **Absence means "not recorded by this version", which is a different claim from "assessed and found absent."** The review screen distinguishes the two explicitly.

## Verification

- [x] `bun run lint` — 4 warnings, 0 errors (pre-existing `prisma/seed.ts` console calls)
- [x] `bun run typecheck` — clean across all three workspaces
- [x] `bun run test` — **31 shared + 265 backend = 296 passed**

Tests added to `consultations.test.ts`, with the mock reshaped to match the real contract (assertions nested under groups, plus the `medicationsDispensed` array):

- the checklist is persisted rather than discarded, including a `NOT_ASSESSED` field
- `value` and `evidence` are rehydrated at every depth, **including inside the array**, and no vault token survives anywhere in the response
- an assertion carrying neither `value` nor `evidence` is left untouched

**Mutation-tested rather than assumed.** Removing rehydration fails two tests; dropping the array branch fails the suite. A test asserting the absence of tokens is worthless if it cannot fail.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider — this only reshapes data already returned from `analyseNote`, after the gate
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model — untouched
- [x] Citations remain ID-constrained; no free-text references accepted
- [x] No transcript bodies, note contents, or vault entries written to logs — nothing added to the logging path
- [x] Fixtures added are synthetic — no fixtures added; test mocks only

**Worth stating plainly for the reviewer:** assertion `value` and `evidence` now land in the `analysis` JSON column, so this **does add a persisted data surface**. It changes no trust boundary — it is already-persisted-class data, written by an authenticated request and returned to the owning doctor over an ownership-checked route that returns `404` rather than `403` on a mismatch — but it is a new surface and should be reviewed as one rather than as a two-line change.

## Notes For The Reviewer

- Depends on `ConsultationAnalysisSchema` carrying both fields as optional, merged in `9fc6a1e`. Before that, `ConsultationDetailSchema.parse()` stripped them and this change would have looked inert.
- Two test mocks previously used `clinicalFacts: {}` / `operational: {}`. Harmless while the fields were discarded; now they fail schema validation, which is the validation doing its job. Both updated to real shapes.
