### PR TITLE
fix(db): chain auth session events instead of bypassing the hash chain

### DIFF
--- a/backend/src/audit/audit.test.ts
+++ b/backend/src/audit/audit.test.ts
@@ -4,7 +4,7 @@ import { prisma } from '../lib/prisma.js'
 import {
   AUDIT_CHAIN_GENESIS,
   type AuditChainRow,
-  type AuditEventInput,
+  type ConsultationAuditEvent,
   computeAuditHash,
   getAuditHistory,
   recordAuditEvent,
@@ -50,7 +50,13 @@ beforeEach(() => {
   vi.mocked(prisma.auditEvent.findFirst).mockClear()
 })
 
-const write = (event: AuditEventInput) =>
+/** What Prisma throws when a second append reads the same chain head. */
+const chainHeadRace = () =>
+  Object.assign(new Error('Unique constraint failed on the fields: (`prevHash`)'), {
+    code: 'P2002',
+  })
+
+const write = (event: ConsultationAuditEvent) =>
   recordAuditEvent({ ...event, actorId: 'doctor-1', consultationId: 'consult-1' })
 
 function lastWrite() {
@@ -117,7 +123,7 @@ describe('recordAuditEvent', () => {
    * clinical prose (issue #12; docs/trd.md §15).
    */
   it('writes no transcript text, note content or vault entry for any action', async () => {
-    const everyAction: AuditEventInput[] = [
+    const everyAction: ConsultationAuditEvent[] = [
       { action: 'consultation.created' },
       { action: 'consultation.asr_hosted_used' },
       { action: 'consultation.analysis_started' },
@@ -234,6 +240,61 @@ describe('the hash chain (issue #27)', () => {
       failedAtId: appended[1]?.id,
       reason: 'hash_mismatch',
     })
+  })
+
+  /**
+   * Issue #55. The better-auth session hook wrote this row directly for as long
+   * as the chain existed, so every session event sat outside it.
+   */
+  it('chains an auth session event, which carries no consultation', async () => {
+    await recordAuditEvent({ action: 'auth.session.created', actorId: 'doctor-1' })
+
+    expect(lastWrite().data).toMatchObject({
+      action: 'auth.session.created',
+      actorId: 'doctor-1',
+      consultationId: null,
+      prevHash: AUDIT_CHAIN_GENESIS,
+    })
+    expect(lastWrite().data.hash).toEqual(expect.any(String))
+  })
+
+  it('verifies a chain that mixes auth and consultation events', async () => {
+    await write({ action: 'consultation.created' })
+    await recordAuditEvent({ action: 'auth.session.created', actorId: 'doctor-1' })
+    await write({ action: 'consultation.approved' })
+
+    expect(verifyAuditChain(appended)).toMatchObject({ ok: true, verified: 3 })
+  })
+
+  /**
+   * Login writes to the chain now and the guest account is shared, so two
+   * appends reading the same head is a normal event rather than a fault.
+   */
+  it('retries when an append loses the race for the chain head', async () => {
+    vi.mocked(prisma.auditEvent.create).mockRejectedValueOnce(chainHeadRace())
+
+    await write({ action: 'consultation.created' })
+
+    expect(prisma.auditEvent.create).toHaveBeenCalledTimes(2)
+    expect(appended).toHaveLength(1)
+  })
+
+  it('gives up after a bounded number of attempts rather than looping', async () => {
+    vi.mocked(prisma.auditEvent.create)
+      .mockRejectedValueOnce(chainHeadRace())
+      .mockRejectedValueOnce(chainHeadRace())
+      .mockRejectedValueOnce(chainHeadRace())
+
+    await expect(write({ action: 'consultation.created' })).rejects.toThrow('Unique constraint')
+    expect(prisma.auditEvent.create).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not retry a failure that is not a chain-head race', async () => {
+    const broken = Object.assign(new Error('connection lost'), { code: 'P1001' })
+    vi.mocked(prisma.auditEvent.create).mockRejectedValueOnce(broken)
+
+    await expect(write({ action: 'consultation.created' })).rejects.toThrow('connection lost')
+    expect(prisma.auditEvent.create).toHaveBeenCalledTimes(1)
   })
 
   it('keeps metadata out of the hash inputs', async () => {

--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -54,7 +54,7 @@ export interface AnalysisVersions {
  * that can hold a transcript body, note text, gap or suggestion text, or a
  * vault entry — only identifiers, detector labels, and version stamps.
  */
-export type AuditEventInput =
+export type ConsultationAuditEvent =
   | { action: 'consultation.created' }
   | { action: 'consultation.asr_hosted_used' }
   | { action: 'consultation.analysis_started' }
@@ -75,50 +75,94 @@ export type AuditEventInput =
   | { action: 'consultation.approved' }
 
 /**
+ * Auth events belong to an actor but to no consultation (issue #14). They are
+ * split out so `consultationId` can stay **required** on everything above
+ * rather than being loosened to optional across the whole taxonomy, which would
+ * let a consultation event be recorded without the consultation it describes.
+ */
+export type AuthAuditEvent = { action: 'auth.session.created' }
+
+export type AuditEventInput = ConsultationAuditEvent | AuthAuditEvent
+
+/**
+ * How many times an append may lose the race for the chain head before giving
+ * up. Three is enough that exhausting it means something is actually wrong
+ * rather than that two requests arrived together.
+ */
+const CHAIN_HEAD_ATTEMPTS = 3
+
+/** Prisma's unique-constraint violation. */
+const UNIQUE_VIOLATION = 'P2002'
+
+function isChainHeadRace(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: unknown }).code === UNIQUE_VIOLATION
+  )
+}
+
+/**
  * Appends one audit row, linked to the current chain head. Append-only by
- * construction: this module exposes no update or delete, and nothing else in
- * the codebase writes `auditEvent`.
+ * construction: this module exposes no update or delete.
+ *
+ * **This is the only place in the codebase that may write `auditEvent`**, and
+ * `no-stray-audit-writes.test.ts` fails the build if that stops being true. It
+ * was a comment before issue #55, and a comment is what let the auth hook write
+ * unchained rows for as long as it did.
  *
  * `id` and `createdAt` are minted here rather than left to their column
  * defaults, because both are hash inputs and the database would otherwise not
  * produce them until after the hash had to be computed.
  *
- * The transaction is what keeps the head read and the append atomic. The unique
- * constraint on `prevHash` is the backstop: under enough write concurrency two
- * appends can still read the same head, and the constraint turns that into a
- * loud failure rather than a silently forked chain. A deployment with real
- * write concurrency wants a retry here.
+ * The transaction keeps the head read and the append atomic; the unique
+ * constraint on `prevHash` is the backstop that turns a lost race into an error
+ * rather than a silently forked chain. Losing that race is a normal event now
+ * that login writes to the chain and the guest account is shared, so it is
+ * retried rather than surfaced.
  */
 export async function recordAuditEvent(
-  event: AuditEventInput & { actorId: string; consultationId: string },
+  event:
+    | (ConsultationAuditEvent & { actorId: string; consultationId: string })
+    | (AuthAuditEvent & { actorId: string }),
 ): Promise<void> {
-  const { action, actorId, consultationId } = event
+  const { action, actorId } = event
+  const consultationId = 'consultationId' in event ? event.consultationId : undefined
   const metadata = 'metadata' in event ? event.metadata : undefined
 
-  await prisma.$transaction(async (tx) => {
-    const head = await tx.auditEvent.findFirst({
-      where: { hash: { not: null } },
-      orderBy: { seq: 'desc' },
-      select: { hash: true },
-    })
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await prisma.$transaction(async (tx) => {
+        const head = await tx.auditEvent.findFirst({
+          where: { hash: { not: null } },
+          orderBy: { seq: 'desc' },
+          select: { hash: true },
+        })
 
-    const row = {
-      prevHash: head?.hash ?? AUDIT_CHAIN_GENESIS,
-      id: randomUUID(),
-      action,
-      actorId,
-      consultationId,
-      createdAt: new Date(),
+        const row = {
+          prevHash: head?.hash ?? AUDIT_CHAIN_GENESIS,
+          id: randomUUID(),
+          action,
+          actorId,
+          consultationId: consultationId ?? null,
+          createdAt: new Date(),
+        }
+
+        await tx.auditEvent.create({
+          data: {
+            ...row,
+            hash: computeAuditHash(row),
+            metadata: metadata === undefined ? undefined : JSON.parse(JSON.stringify(metadata)),
+          },
+        })
+      })
+
+      return
+    } catch (error) {
+      if (attempt >= CHAIN_HEAD_ATTEMPTS || !isChainHeadRace(error)) throw error
     }
-
-    await tx.auditEvent.create({
-      data: {
-        ...row,
-        hash: computeAuditHash(row),
-        metadata: metadata === undefined ? undefined : JSON.parse(JSON.stringify(metadata)),
-      },
-    })
-  })
+  }
 }
 
 /**

--- a/backend/src/audit/no-stray-audit-writes.test.ts
+++ b/backend/src/audit/no-stray-audit-writes.test.ts
@@ -1,0 +1,104 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Issue #55. `recordAuditEvent` is the only thing that may write `auditEvent`,
+ * and this fails the build when something else does.
+ *
+ * That invariant was a doc comment until #55, and the comment was wrong: the
+ * better-auth session hook wrote `prisma.auditEvent.create` directly, so every
+ * `auth.session.created` row landed with no `prevHash` and sat permanently
+ * outside the hash chain. Nothing failed, because nothing was checking.
+ *
+ * Two scope choices, both deliberate:
+ *
+ * 1. **Every write verb, not just `create`.** `audit_event` is append-only, so
+ *    an `update` or `delete` reaching it is worse than a bypassed insert, not
+ *    better.
+ * 2. **`prisma/` is scanned as well as `backend/src`.** The seed runs against
+ *    the same table, and a guard that cannot see the file it would most plausibly
+ *    be bypassed from is not much of a guard.
+ */
+const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url))
+
+/** The one module allowed to write the table. */
+const AUDIT_MODULE = 'backend/src/audit/'
+
+const SCANNED_TREES = [
+  { dir: 'backend/src', extensions: ['.ts'] },
+  { dir: 'prisma', extensions: ['.ts'] },
+]
+
+const AUDIT_WRITE =
+  /\b\w+\.auditEvent\.(create|createMany|update|updateMany|upsert|delete|deleteMany)\b/
+
+/**
+ * Tests stand in for Prisma at the module seam, so they name these methods by
+ * necessity. The real writers are what this guards.
+ */
+function isExempt(path: string): boolean {
+  return path.startsWith(AUDIT_MODULE) || /\.test\.tsx?$/.test(path)
+}
+
+/**
+ * A guard that forbids *describing* the thing it guards against is a guard that
+ * gets worked around. Prose explaining why the direct write was wrong should not
+ * itself trip it, and no line starting a comment can execute.
+ */
+function isComment(line: string): boolean {
+  return /^\s*(\/\/|\/\*|\*)/.test(line)
+}
+
+function sourceFiles(): string[] {
+  const found: string[] = []
+
+  for (const { dir, extensions } of SCANNED_TREES) {
+    const walk = (absolute: string) => {
+      for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+        const child = join(absolute, entry.name)
+        if (entry.isDirectory()) {
+          if (entry.name !== 'migrations' && entry.name !== 'node_modules') walk(child)
+        } else if (extensions.some((extension) => entry.name.endsWith(extension))) {
+          found.push(relative(REPO_ROOT, child).replaceAll('\\', '/'))
+        }
+      }
+    }
+
+    walk(join(REPO_ROOT, dir))
+  }
+
+  return found
+}
+
+describe('only the audit module writes AuditEvent (issue #55)', () => {
+  it('finds source to scan in both trees, so an empty pass means something', () => {
+    const scanned = sourceFiles()
+
+    expect(scanned.some((path) => path.startsWith('backend/src/'))).toBe(true)
+    expect(scanned.some((path) => path.startsWith('prisma/'))).toBe(true)
+  })
+
+  it('routes every audit write through recordAuditEvent', () => {
+    const violations: string[] = []
+
+    for (const path of sourceFiles()) {
+      if (isExempt(path)) continue
+
+      readFileSync(join(REPO_ROOT, path), 'utf8')
+        .split('\n')
+        .forEach((line, index) => {
+          if (isComment(line) || !AUDIT_WRITE.test(line)) return
+          violations.push(`${path}:${index + 1}: ${line.trim()}`)
+        })
+    }
+
+    expect(
+      violations,
+      'An AuditEvent write bypasses the hash chain. Rows written outside ' +
+        'recordAuditEvent carry no prevHash and are not tamper-evident. Call ' +
+        'recordAuditEvent instead, adding an action to the taxonomy if needed.',
+    ).toEqual([])
+  })
+})

--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -1,6 +1,8 @@
 import { betterAuth } from 'better-auth'
 import { prismaAdapter } from 'better-auth/adapters/prisma'
+import { recordAuditEvent } from '../audit/index.js'
 import { env } from '../config/env.js'
+import { logger } from './logger.js'
 import { prisma } from './prisma.js'
 
 /**
@@ -102,14 +104,35 @@ export const auth = betterAuth({
   /**
    * Auth audit trail (issue #14). Actor id and event type only — never an
    * email, a password, a session token, an IP, or any clinical content.
+   *
+   * Routed through `recordAuditEvent` so the row joins the hash chain. Writing
+   * `prisma.auditEvent.create` here directly is what issue #55 fixed: it
+   * produced session rows with no `prevHash`, permanently outside the
+   * tamper-evidence the chain exists to provide.
+   *
+   * **This is the one audit write that fails open.** Every consultation path
+   * propagates a failed append, because a note whose approval was not recorded
+   * should not read as approved. Sign-in is the opposite: after the retry in
+   * `recordAuditEvent` is exhausted, locking a doctor out of a clinical system
+   * because an audit row lost a race is the worse failure. The drop is logged
+   * under its own error class rather than swallowed, so the gap is visible.
    */
   databaseHooks: {
     session: {
       create: {
         after: async (session) => {
-          await prisma.auditEvent.create({
-            data: { action: 'auth.session.created', actorId: session.userId },
-          })
+          try {
+            await recordAuditEvent({
+              action: 'auth.session.created',
+              actorId: session.userId,
+            })
+          } catch (error) {
+            logger.error('audit write dropped', {
+              actorId: session.userId,
+              errorClass: 'audit_write_error',
+              errorName: error instanceof Error ? error.name : 'UnknownError',
+            })
+          }
         },
       },
     },

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -65,6 +65,10 @@ export const ERROR_CLASSES = [
   'deidentification_error',
   'validation_error',
   'auth_error',
+  // Its own class rather than `internal_error`: a dropped audit write is a gap
+  // in the tamper-evident chain (issue #55), and an on-call engineer has to be
+  // able to spot it without opening a payload.
+  'audit_write_error',
   'internal_error',
 ] as const
 

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -211,7 +211,7 @@ Index: `@@index([doctorId, status])` — supports the doctor's own consultation-
 
 Indexes: `@@index([consultationId, createdAt])`, `@@index([actorId, createdAt])`.
 
-`prevHash` and `hash` are nullable only because rows written before the chain existed cannot be given one honestly. Every row written by `recordAuditEvent` carries both. See §15.
+`prevHash` and `hash` are nullable only because rows written before the chain existed cannot be given one honestly. Every row written since carries both, including `auth.session.created` from the better-auth session hook. `recordAuditEvent` is the only writer, enforced by `backend/src/audit/no-stray-audit-writes.test.ts`. See §15.
 
 `analysis` and `editedNote` are separate columns rather than one field so that the model's raw output is never overwritten by the doctor's edits — both remain independently inspectable, which matters both for review-trail integrity and for the "every output editable before approval" safety posture. `AuditEvent.metadata` is restricted to detector labels, never values, because the audit trail must not become a second PHI leak vector — it directly enforces the "no vault entries in logs" clinical-safety do-not.
 
@@ -774,10 +774,20 @@ hash = sha256( prevHash | id | action | actorId | consultationId | createdAt )
 - It is **not** a defence against an attacker with write access who recomputes the whole chain. It makes tampering **detectable by an auditor holding a head hash from an earlier point in time**, not impossible.
 - **A `metadata` rewrite is not detectable**, because `metadata` is deliberately excluded from the hash.
 - **Truncation of the newest rows is not self-detecting.** Deleting from the end leaves a shorter chain that is internally valid; only a previously recorded head hash reveals it. `verifyAuditChain` takes that head as an optional argument, and `chain.test.ts` asserts this limitation rather than only documenting it.
-- **Rows written before the migration are not chained.** 18 such rows exist. Integrity cannot be retrofitted onto history that was not recorded while it happened, so they carry no hash and verification skips them.
+- **Rows written before the migration are not chained.** 19 such rows exist. Integrity cannot be retrofitted onto history that was not recorded while it happened, so they carry no hash and verification skips them.
 - No blockchain, no distributed ledger, no external anchoring. Immutability was rejected on 13/08/26 because it conflicts directly with PDPA rights to correction and withdrawal of consent.
 
-Under real write concurrency the head read and the append want a retry around the unique-constraint failure. The current single-instance deployment does not reach that, and the constraint means the failure is loud rather than silent.
+### One Writer, Enforced (issue #55)
+
+`recordAuditEvent` is the only thing permitted to write `audit_event`, and `backend/src/audit/no-stray-audit-writes.test.ts` fails the build when anything else does.
+
+That invariant was a doc comment until #55, and the comment was **wrong**. The better-auth session hook wrote `prisma.auditEvent.create` directly, so every `auth.session.created` row landed with no `prevHash` and sat permanently outside the chain. It was found in production, not in review, because nothing executable was checking. The guard scans `backend/src` and `prisma/` for every write verb, not only `create`: on an append-only table an `update` or `delete` reaching it is worse than a bypassed insert.
+
+### Losing the Race for the Chain Head
+
+Login writes to the chain now, and the guest account is shared by design (`docs/prd.md` §6), so two appends reading the same head is a normal event rather than a fault. `recordAuditEvent` retries the transaction up to three times on the `prevHash` unique violation, re-reading the head each attempt. Anything that is not that violation rethrows untouched.
+
+**One call site fails open, and only one.** Every consultation path propagates a failed append, because a note whose approval was not recorded must not read as approved. The better-auth session hook is the exception: after the retry is exhausted it logs under `audit_write_error` and lets sign-in proceed. Locking a doctor out of a clinical system because an audit row lost a race is the worse failure. The `catch` sits at the hook rather than inside `recordAuditEvent`, so the asymmetry is visible at the call site instead of hidden in the shared path, and the gap is logged rather than swallowed.
 
 ### Forbidden Content
 


### PR DESCRIPTION
## What Changed

Auth session events now join the hash chain instead of bypassing it, and the "only `recordAuditEvent` writes `audit_event`" invariant is enforced by a test rather than asserted by a comment.

Closes #55

## Why

#27 shipped with a hole. `backend/src/lib/auth.ts` wrote `prisma.auditEvent.create` directly, so every `auth.session.created` row landed with no `prevHash` and sat permanently outside the tamper-evidence the chain exists to provide. Deleting a session row was undetectable, and "who logged in and when" is exactly the evidence an auditor would expect to be covered.

It was found in production rather than in review because the invariant was a doc comment. That comment was already wrong before #27 and got repeated into TRD §15.

## Verification

- [x] `bun run lint`, `Checked 120 files. Found 4 warnings.` (the same pre-existing `noConsole` hits in `prisma/seed.ts`)
- [x] `bun run typecheck`, clean across all three workspaces
- [x] `bun run test`, `shared 31 passed | backend 295 passed (24 files)`, up from 288
- [x] Verified against the live database

**The guard was proven to fail before it was trusted.** Planted a bypass in a route handler:

```
× routes every audit write through recordAuditEvent
+   "backend/src/routes/consultations.ts:25: const PLANTED = () => prisma.auditEvent.create({ data: { action: \"x\" } })",
```

Named the exact file and line. Reverted, all green.

**Live state confirmed** through `DATABASE_URL`, the pooled Supavisor connection production actually uses. Read-only, nothing written:

```
before: 19 rows, 19 unchained
verify existing chain: {"ok":true,"verified":0,"head":"genesis"}
after: 19 rows
```

**No migration.** `consultationId` and `actorId` were already nullable, so `prisma/` is untouched and this does not re-enter the migration lane or block #19 and #17.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model
- [x] Citations remain ID-constrained
- [x] No transcript bodies, note contents, or vault entries written to logs
- [x] Fixtures added are synthetic (none added)

The new log line carries `actorId`, `errorClass` and `errorName` only, all of which were already in the `FIELD_RULES` allowlist in `backend/src/lib/logger.ts`. No new field shape was introduced.

## Decision

**1. The union split, rather than making `consultationId` optional.** `AuditEventInput` is now `ConsultationAuditEvent | AuthAuditEvent`, and `recordAuditEvent` requires `consultationId` on the first and not the second. Loosening it globally would have been one character shorter and would have let a consultation event be recorded without the consultation it describes.

**2. Login fails open. Nothing else does.** Routing the hook through `recordAuditEvent` puts a transactional head read on the login path, and the guest account is shared by design (`docs/prd.md` §6), so concurrent logins racing the chain head is a real path rather than a hypothetical. `recordAuditEvent` retries three times on the `prevHash` unique violation; if that is exhausted, the hook logs under `audit_write_error` and lets sign-in proceed. Locking a doctor out of a clinical system because an audit row lost a race is the worse failure.

The `catch` sits at the hook, not inside `recordAuditEvent`. Every consultation path still propagates a failed append, because a note whose approval was not recorded must not read as approved. Putting the fail-open in the shared function would have silently applied that weaker guarantee to approval as well.

**3. `audit_write_error` is its own `ERROR_CLASSES` member.** That module states its purpose as making a failure class "distinguishable in a log line without inspecting any payload". A dropped audit write is precisely what an on-call engineer needs to spot, so it should not hide under `internal_error`.

**4. The guard ignores comment lines.** Its first run failed on the doc comment in `auth.ts` explaining why the direct write was wrong. A guard that forbids describing the thing it guards against is a guard that gets worked around, and no line beginning a comment can execute.

## Notes For The Reviewer

**The guard scans `prisma/` as well as `backend/src`.** The #16 guard it is modelled on scans only the two `src` trees. `prisma/seed.ts` runs against the same table and is the most plausible place for the next bypass, so a guard that cannot see it has the same shape of hole this PR is closing.

**Four route tests failed intermittently during development and are not related to this diff.** `backend/src/routes/auth.test.ts` runs against the real Supabase and better-auth's database-backed rate limiter at 60s/3 on sign-up, so running the suite several times inside a minute returns 429 where the test expects otherwise. They pass on `main` and pass here on a cold run. Worth knowing before someone chases it as a regression, and arguably worth its own issue.

**The 19 unchained rows stay unchained.** Unchanged from #27: integrity cannot be retrofitted onto history that was not recorded while it happened. TRD §15 now says 19 rather than 18 and states the reason.
