### PR TITLE
fix(infra): disable Vercel Git-integration deploys on all branches

### DIFF
--- a/docs/trd.md
+++ b/docs/trd.md
@@ -823,7 +823,22 @@ Frontend → Vercel; backend → Render (Singapore); database → Supabase (Sing
 
 ### Free-Tier Seats And Collaborator Access
 
-Both Vercel and Render stay on **free tiers**, deliberately: Vercel Hobby is a single seat with no collaborators, and Render's free plan is a single workspace member. Neither collaborator's platform access is paid for. @Andersonnn7788 works through the GitHub repository, not a platform seat — pushing to `main` triggers Vercel's and Render's Git-integrated deploys, and build logs are readable from each platform's GitHub check without a dashboard login. Only genuinely dashboard-level configuration (environment variables, custom domains) needs a seat, and that is expected to stay a single-owner task.
+Both Vercel and Render stay on **free tiers**, deliberately: Vercel Hobby is a single seat with no collaborators, and Render's free plan is a single workspace member. Neither collaborator's platform access is paid for. @Andersonnn7788 works through the GitHub repository, not a platform seat, and build logs are readable from each platform's GitHub check without a dashboard login. Only genuinely dashboard-level configuration (environment variables, custom domains) needs a seat, and that is expected to stay a single-owner task.
+
+**Vercel Git-integration deploys are off entirely** (`vercel.json` → `git.deploymentEnabled: false`, issue #58). The CI `deploy` job is the only path to production. Do not reconnect the integration: it deployed without regard to CI status, and on pull requests it produced a permanently failing check that no branch could ever turn green. Render's Git integration is unaffected and still deploys the backend.
+
+#### The Hobby Author Restriction Is Not Bypassed By CI
+
+Vercel Hobby only builds commits authored by the account owner. This was originally believed to affect Git-integration deploys only, on the reasoning that a token-authenticated CLI deploy is attributed to the token owner. **That reasoning is wrong**, and the deployment record disproves it:
+
+| Observation                                                    | Evidence                                                    |
+| -------------------------------------------------------------- | ----------------------------------------------------------- |
+| The CLI attaches the checkout's git metadata to the deployment | `meta.githubCommitAuthorName` is populated on CLI deploys   |
+| Vercel applies the author check to that metadata               | `dpl_BLGhgtaTjfujznqt8aoofmZkZPcB`, `source=cli`, `BLOCKED` |
+| Every `BLOCKED` deployment was authored by a non-owner         | 10 of the last 100, across both the Git and CLI paths       |
+| Every owner-authored deployment built                          | same sample                                                 |
+
+**Consequence:** a merge of a collaborator-authored commit does not reach production. Squash-merge preserves the PR author, so this applies to roughly half of all merges. The CI `deploy` job now fails fast and names the author rather than hanging until the job timeout, but it cannot fix the restriction. Resolving it requires a plan decision (Vercel Pro, or moving the project to a team), not a workflow change.
 
 ### Render Service Definition (`render.yaml`)
 
@@ -854,7 +869,20 @@ Locally: `bun run db:migrate` (`prisma migrate dev`, against `DIRECT_URL`). In p
 
 ### CI
 
-**Status: `Open`** — no CI workflow exists in the repo. `.github/workflows/ci.yml` (previously `Built`, running `bun install --frozen-lockfile`, `prisma generate`, `bun run lint`, `bun run typecheck`, and `bun run test` on every push to `main` and every PR) has been removed. Whether and when to reinstate automated CI, including the dependency-scan step proposed in §16, is unresolved. See the Open Decisions Register, §19, row 12.
+**Status: `Built`** — `.github/workflows/ci.yml`, reinstated 13/08/26 (issue #13), extended to deployment 13/08/26 (issue #52). It answers §19 row 12 in practice: CI runs on every push to `main` and every pull request. The register row is left open pending the dependency-scan half of the question (§16), which is still not built.
+
+Two jobs, the second gated on the first:
+
+| Job      | Runs on               | Does                                                                                                                                                                    |
+| -------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `verify` | every push and PR     | `bun install --frozen-lockfile`, `prisma generate` + `migrate deploy` against a throwaway Postgres service container, `lint`, `typecheck`, `test`, confidentiality grep |
+| `deploy` | pushes to `main` only | `vercel pull` / `build` / `deploy --prebuilt`, then asserts what production actually serves                                                                             |
+
+Two properties of `verify` are deliberate. It uses a **throwaway Postgres**, never the shared Supabase instance, because the route and auth suites exercise real ownership scoping and audit writes rather than mocking the database. It carries **no LLM provider key**, because LLM-dependent tests stub at the `LLMClient` port, the same boundary that makes the provider swappable.
+
+`deploy` asserts rather than trusts, because each of these has shipped at least once: a deployment Vercel refused to build, a production alias left pointing at an older build, and a bundle built without `VITE_API_URL` so every API call landed on the static origin. Exit code 0 from `vercel deploy` establishes none of that, so the job checks the deployment's ready state, the domain's resolved deployment id, and the served bundle.
+
+**Concurrency:** superseded runs are cancelled on pull requests but never on `main`, because a run on `main` deploys, and cancelling between the deploy and its assertions is precisely how an unverified build is left live.
 
 ### Free-Tier Auto-Pause Mitigation
 

--- a/vercel.json
+++ b/vercel.json
@@ -11,8 +11,6 @@
     }
   ],
   "git": {
-    "deploymentEnabled": {
-      "main": false
-    }
+    "deploymentEnabled": false
   }
 }


### PR DESCRIPTION
Closes #58.

## What Changed

`vercel.json` now carries `"git": { "deploymentEnabled": false }` instead of disabling only `main`. #52 closed the `main` half; pull-request branches still triggered the integration, so every PR from @Andersonnn7788 carried a permanently failing `Vercel` check.

`docs/trd.md` §17 records that Git-integration deploys are off entirely and that the CI `deploy` job is the only path to production, so the next person does not reconnect it. The §17 `CI` subsection also said "no CI workflow exists in the repo", which has been untrue since #13.

**This PR is its own test.** The branch carries the fix, so if the change works, no Vercel check appears below.

## Correction To The Issue's Reasoning

#58 states, quoting the old `ci.yml` comment, that "a token-authenticated CLI deploy is attributed to the token owner, so authorship stops mattering", and lists upgrading the plan as a non-goal on that basis.

**That reasoning is wrong.** I wrote it in #52 and the deployment record disproves it. The Vercel CLI attaches the checkout's git metadata to the deployment, and Vercel applies the Hobby author check to that metadata:

- `dpl_BLGhgtaTjfujznqt8aoofmZkZPcB`, `source=cli`, sha `511de77`, state `BLOCKED`. That is our GitHub Actions deploy, refused.
- Of the last 100 deployments, all 10 `BLOCKED` were authored by a non-owner, across both the Git and CLI paths. Every owner-authored one built.

So a merge of a collaborator-authored commit still does not reach production, and since squash-merge preserves the PR author, that is roughly half of all merges. #54 never went live for this reason.

It also failed almost invisibly: `vercel deploy` blocks on a refused deployment, so the job sat 14 minutes and hit its timeout, which GitHub reports as `cancelled`. That is fixed separately in `cc5f7db`, which now fails in seconds and names the author.

**The plan question is therefore live, not a non-goal.** Vercel Pro, or moving the project to a team. That is @AlaskanTuna's call and is out of scope here.

## Acceptance Criteria

- [x] No Vercel Git-integration check runs on pull requests
- [ ] A PR authored by @Andersonnn7788 shows no failing check when nothing is actually wrong (confirmed on his next PR)
- [x] Production deploys still work through the CI `deploy` job
- [x] `docs/trd.md` §17 records that Git-integration deploys are off entirely and that CI is the only path

## Clinical-Safety Checklist

Not applicable. The diff touches deployment configuration and documentation only: no `deid/`, `lib/llm/`, `redflags/`, `guidelines/`, or logging code is changed.

## Noted, Not Fixed

Two places outside this file scope still say CI does not exist: §16's dependency-posture row, and §19 row 12. Left for whoever closes the dependency-scan half of row 12.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated deployment documentation to clarify that production frontend deployments run through the CI deploy process.
  - Documented deployment restrictions, verification steps, database isolation, LLM stubbing, production checks, and concurrency behavior.

- **Chores**
  - Disabled automatic Git-integrated deployments through Vercel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->