### PR TITLE
test(qa): take auth route-protection tests off the live database

### DIFF
--- a/backend/src/routes/auth.test.ts
+++ b/backend/src/routes/auth.test.ts
@@ -1,6 +1,43 @@
 import type { Server } from 'node:http'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApp } from '../app.js'
+
+/**
+ * better-auth reaches the database through the same client as everything else
+ * (`prismaAdapter(prisma)`, `../lib/auth.ts`), so mocking this one module takes
+ * every database path in this file offline at once: session resolution, sign-up,
+ * and the database-backed rate limiter that was persisting 429s across runs
+ * (issue #57).
+ *
+ * `requireSession` is deliberately NOT mocked. These tests exist to prove it
+ * rejects anonymous callers, so stubbing it would remove what is under test. It
+ * runs unmodified here and returns 401 because the mocked client resolves no
+ * session, which is the same code path a real anonymous request takes.
+ */
+vi.mock('../lib/prisma.js', () => {
+  const model = {
+    findFirst: async () => null,
+    findUnique: async () => null,
+    findMany: async () => [],
+    create: async ({ data }: { data: unknown }) => data,
+    update: async ({ data }: { data: unknown }) => data,
+    updateMany: async () => ({ count: 0 }),
+    upsert: async ({ create }: { create: unknown }) => create,
+    delete: async () => null,
+    deleteMany: async () => ({ count: 0 }),
+    count: async () => 0,
+  }
+
+  return {
+    prisma: new Proxy(
+      {},
+      {
+        get: (_target, property) =>
+          typeof property === 'string' && property.startsWith('$') ? async () => undefined : model,
+      },
+    ),
+  }
+})
 
 let server: Server
 let origin: string


### PR DESCRIPTION
Closes #57.

## What Changed

`backend/src/routes/auth.test.ts` mocks `../lib/prisma.js` with a client that resolves empty for every model. That is the only change.

better-auth reaches the database through the same client as everything else (`prismaAdapter(prisma)`, `backend/src/lib/auth.ts:24`), so mocking that one module takes every database path in the file offline at once: session resolution, sign-up, and the database-backed rate limiter whose 429s were persisting across runs.

## Why Not Mock `require-session.js`

The issue suggested mocking `../lib/prisma.js` **and** `../middleware/require-session.js`, matching `consultations.test.ts`. I deliberately did not do the second half.

`consultations.test.ts` stubs `requireSession` so it *injects* a `doctorId`, i.e. it bypasses authentication. That is right for a file testing consultation logic. This file tests the opposite: that an unauthenticated caller is rejected. Stubbing `requireSession` here would replace the thing under test, and all seven "rejects an unauthenticated caller with 401" cases would pass while asserting nothing, which conflicts with the issue's own third acceptance criterion.

Mocking prisma alone is sufficient. `requireSession` runs unmodified and returns 401 because the mocked client resolves no session, which is the same code path a real anonymous request takes.

## Verification

**No database call**, proven rather than assumed. The suite passes with `DATABASE_URL` pointed at an unroutable host, which it could not do if anything reached the database:

```
$ DATABASE_URL="postgresql://x:x@127.0.0.1:1/x" bunx vitest run src/routes/auth.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

**Five consecutive runs of the backend suite, inside 20 seconds** (the issue's repro is five inside one minute):

```
run 1  (4s):  Tests  295 passed (295)
run 2  (7s):  Tests  295 passed (295)
run 3  (11s): Tests  295 passed (295)
run 4  (17s): Tests  295 passed (295)
run 5  (20s): Tests  295 passed (295)
```

**Coverage unchanged.** All 12 tests still run and still assert the same things. Sign-up still reaches better-auth and still returns 400 on invalid input, so it continues to prove the route is mounted and validating rather than merely present. Per-assertion time dropped from roughly 10,000ms to 1-13ms.

## Acceptance Criteria

- [x] `backend/src/routes/auth.test.ts` makes no network call to Supabase
- [x] The suite passes on five consecutive runs inside one minute
- [x] Route-protection coverage is unchanged: seven protected routes, the `/api/health` and `/api/auth/**` exemptions, and the no-leak assertion on the 401 body
- [x] No test writes to the production `RateLimit` table
- [x] The `consultations.test.ts` ownership failures are addressed below

## On The Two `consultations.test.ts` Failures

Criterion 5 asked that these not be assumed fixed. **They did not recur in any of the five runs above**, which is consistent with the issue's own hypothesis that worker contention from `auth.test.ts` holding network round-trips open was the cause. Removing those round-trips removes the contention.

Stating that precisely: five clean runs is evidence, not proof, for an intermittent fault. If they reappear they are a separate finding and should get their own issue, exactly as the issue asked.

## Clinical-Safety Checklist

Not applicable to the diff, which touches one test file. Worth noting that it *improves* one posture item: the suite no longer writes rate-limit rows to the shared Supabase instance on every local run.
