### PR TITLE
feat(guidelines): make the clinical content layer profile-configurable

### DIFF
--- a/backend/src/analysis/index.ts
+++ b/backend/src/analysis/index.ts
@@ -1,9 +1,10 @@
 import { ClinicalFactsResponseSchema, NoteAndGapsResponseSchema } from '@shared/types'
+import { type ClinicalProfile, getClinicalProfile } from '../clinical-profiles/index.js'
 import type { Deidentified } from '../deid/types.js'
 import { getLLMClient } from '../lib/llm/index.js'
 import { stripDiagnosticProse } from './diagnostic-guard.js'
 import { applyEvidenceCheck } from './evidence.js'
-import { CLINICAL_FACTS_SYSTEM_PROMPT, NOTE_AND_GAPS_SYSTEM_PROMPT } from './prompt.js'
+import { buildClinicalFactsSystemPrompt, buildNoteAndGapsSystemPrompt } from './prompt.js'
 import type { NoteAndGapsResult } from './types.js'
 
 export { buildEvidenceLinks, type EvidenceLink } from './note.js'
@@ -33,20 +34,21 @@ export type { NoteAndGapsResult } from './types.js'
 export async function analyseNote(
   content: Deidentified,
   transcriptText: string,
+  profile: ClinicalProfile = getClinicalProfile(),
 ): Promise<NoteAndGapsResult> {
   const client = getLLMClient()
 
   const [facts, prose] = await Promise.all([
     client.generate({
       operation: 'clinical_facts',
-      system: CLINICAL_FACTS_SYSTEM_PROMPT,
+      system: buildClinicalFactsSystemPrompt(profile),
       content,
       schema: ClinicalFactsResponseSchema,
       schemaName: 'clinical_facts',
     }),
     client.generate({
       operation: 'note_and_gaps',
-      system: NOTE_AND_GAPS_SYSTEM_PROMPT,
+      system: buildNoteAndGapsSystemPrompt(profile),
       content,
       schema: NoteAndGapsResponseSchema,
       schemaName: 'note_and_gaps',

--- a/backend/src/analysis/prompt.ts
+++ b/backend/src/analysis/prompt.ts
@@ -14,9 +14,12 @@
  * the SOAP prose constraints in context while filling a 34-key checklist.
  */
 
-const SHARED_PREAMBLE = `You are extracting structured clinical information from a de-identified GP
-consultation transcript for adult upper-respiratory presentations (cough,
-sore throat, and related URTI symptoms). You do not diagnose and you do not
+import type { ClinicalProfile } from '../clinical-profiles/index.js'
+
+const sharedPreamble = (
+  profile: ClinicalProfile,
+) => `You are extracting structured clinical information from a de-identified GP
+consultation transcript for ${profile.scope}. You do not diagnose and you do not
 replace clinical judgement: every output you produce is reviewed and edited
 by the treating doctor before it is used.`
 
@@ -24,7 +27,8 @@ by the treating doctor before it is used.`
  * Operation 1a. Carries the evidence rules, because it is the only half that
  * emits assertions.
  */
-export const CLINICAL_FACTS_SYSTEM_PROMPT = `${SHARED_PREAMBLE}
+export function buildClinicalFactsSystemPrompt(profile: ClinicalProfile): string {
+  return `${sharedPreamble(profile)}
 
 Produce two things from the transcript:
 
@@ -70,16 +74,18 @@ Produce two things from the transcript:
 
 Do not produce a differential diagnosis, a clinical impression, or a
 probability statement anywhere in your output.`
+}
 
 /**
  * Operation 1b. Carries the diagnostic-prose rules, because it is the only
  * half that emits free text a doctor reads as narrative.
  */
-export const NOTE_AND_GAPS_SYSTEM_PROMPT = `${SHARED_PREAMBLE}
+export function buildNoteAndGapsSystemPrompt(profile: ClinicalProfile): string {
+  return `${sharedPreamble(profile)}
 
 Produce two things from the transcript:
 
-1. A SOAP note (subjective, objective, assessment, plan). The "assessment"
+1. A SOAP note (subjective, objective, assessment, plan). ${profile.noteTemplate} The "assessment"
    section is a synthesis of the findings recorded. It must never state,
    imply, or name a diagnosis, differential, or clinical impression. A
    diagnosis is recorded elsewhere in this system, in a structured field, and
@@ -102,3 +108,4 @@ Produce two things from the transcript:
 
 Do not produce a differential diagnosis, a clinical impression, or a
 probability statement anywhere in your output.`
+}

--- a/backend/src/audit/audit.test.ts
+++ b/backend/src/audit/audit.test.ts
@@ -88,6 +88,7 @@ describe('recordAuditEvent', () => {
       metadata: {
         detected: ['NRIC', 'NAME'],
         discardedFieldIds: ['fever', 'cough_duration'],
+        profileId: 'adult-acute-urti',
         versions: {
           provider: 'qwen',
           model: 'qwen-flash',
@@ -99,6 +100,7 @@ describe('recordAuditEvent', () => {
     expect(lastWrite().data.metadata).toEqual({
       detected: ['NRIC', 'NAME'],
       discardedFieldIds: ['fever', 'cough_duration'],
+      profileId: 'adult-acute-urti',
       versions: {
         provider: 'qwen',
         model: 'qwen-flash',
@@ -132,6 +134,7 @@ describe('recordAuditEvent', () => {
         metadata: {
           detected: ['NRIC'],
           discardedFieldIds: ['fever'],
+          profileId: 'adult-acute-urti',
           versions: {
             provider: 'qwen',
             model: 'qwen-flash',

--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
-import type { ACTIVE_CLINICAL_VERSIONS } from '../clinical-versions/index.js'
+import type { ProfileId } from '../clinical-profiles/index.js'
+import type { ActiveClinicalVersions } from '../clinical-versions/index.js'
 import { prisma } from '../lib/prisma.js'
 import {
   AUDIT_CHAIN_GENESIS,
@@ -40,7 +41,7 @@ export type AnalysisFailureReason =
 export interface AnalysisVersions {
   provider: string
   model: string
-  clinicalContent: typeof ACTIVE_CLINICAL_VERSIONS
+  clinicalContent: ActiveClinicalVersions
 }
 
 /**
@@ -65,6 +66,7 @@ export type ConsultationAuditEvent =
         detected: readonly string[]
         /** Field ids forced to NOT_ASSESSED by the evidence check. Ids, never content. */
         discardedFieldIds: readonly string[]
+        profileId: ProfileId
         versions: AnalysisVersions
       }
     }

--- a/backend/src/clinical-profiles/index.test.ts
+++ b/backend/src/clinical-profiles/index.test.ts
@@ -1,0 +1,92 @@
+import type { Transcript } from '@shared/types'
+import { describe, expect, it } from 'vitest'
+import { ACTIVE_CLINICAL_VERSIONS, getActiveClinicalVersions } from '../clinical-versions/index.js'
+import { GAP_CHECKLIST } from '../gaps/index.js'
+import { GUIDELINE_CORPUS } from '../guidelines/index.js'
+import { evaluateRedFlags, REDFLAG_TRIGGERS } from '../redflags/index.js'
+import { getClinicalProfile } from './index.js'
+
+describe('clinical profiles', () => {
+  it('selects only membership-tagged content for adult acute uncomplicated urinary presentations', () => {
+    const profile = getClinicalProfile('adult-acute-uncomplicated-uti')
+
+    expect(profile.redFlagTriggers).not.toEqual(REDFLAG_TRIGGERS)
+    expect(profile.gapChecklist).not.toEqual(GAP_CHECKLIST)
+    expect(profile.guidelineCorpus).not.toEqual(GUIDELINE_CORPUS)
+    expect(profile.redFlagTriggers).toHaveLength(7)
+    expect(profile.gapChecklist).toHaveLength(5)
+    expect(profile.guidelineCorpus).toHaveLength(1)
+    expect(profile.redFlagTriggers.every((trigger) => trigger.profiles.includes(profile.id))).toBe(
+      true,
+    )
+    expect(profile.gapChecklist.every((entry) => entry.profiles.includes(profile.id))).toBe(true)
+    expect(profile.guidelineCorpus.every((chunk) => chunk.profiles.includes(profile.id))).toBe(true)
+  })
+
+  it('fires every deliberately broad UTI rule on its matching transcript evidence', () => {
+    const fixtures: Record<string, Transcript> = {
+      'vital-signs-concern': {
+        source: 'fixture',
+        turns: [{ speaker: 'doctor', text: 'The oxygen saturation is very low.' }],
+      },
+      'uti-systemic-features': {
+        source: 'fixture',
+        turns: [{ speaker: 'patient', text: 'I have fever and chills.' }],
+      },
+      'uti-flank-or-back-pain': {
+        source: 'fixture',
+        turns: [{ speaker: 'patient', text: 'There is pain in my lower back.' }],
+      },
+      'uti-systemic-deterioration': {
+        source: 'fixture',
+        turns: [{ speaker: 'patient', text: 'I feel extremely weak.' }],
+      },
+      'uti-pregnancy-mentioned': {
+        source: 'fixture',
+        turns: [{ speaker: 'patient', text: 'I might be pregnant.' }],
+      },
+      'uti-unable-to-pass-urine': {
+        source: 'fixture',
+        turns: [{ speaker: 'patient', text: 'I cannot pass urine.' }],
+      },
+      'uti-potentially-complicating-context': {
+        source: 'fixture',
+        turns: [{ speaker: 'patient', text: 'I have kidney disease.' }],
+      },
+    }
+    const profile = getClinicalProfile('adult-acute-uncomplicated-uti')
+
+    for (const trigger of profile.redFlagTriggers) {
+      const flags = evaluateRedFlags(fixtures[trigger.id] as Transcript, profile.redFlagTriggers)
+      expect(flags.some((flag) => flag.ruleId === trigger.id)).toBe(true)
+    }
+  })
+
+  it('keeps the adult acute URTI content exactly as it was before profile selection', () => {
+    const profile = getClinicalProfile('adult-acute-urti')
+
+    expect(profile.redFlagTriggers).toEqual(REDFLAG_TRIGGERS)
+    expect(profile.gapChecklist).toEqual(GAP_CHECKLIST)
+    expect(profile.guidelineCorpus).toEqual(GUIDELINE_CORPUS.slice(0, 11))
+  })
+
+  it('includes the selected profile version in each analysis stamp', () => {
+    for (const profileId of ['adult-acute-urti', 'adult-acute-uncomplicated-uti'] as const) {
+      const profile = getClinicalProfile(profileId)
+      const versions = getActiveClinicalVersions(profile)
+
+      expect(versions).toMatchObject({
+        ...ACTIVE_CLINICAL_VERSIONS,
+        clinicalProfile: profile.version,
+      })
+      expect(versions.clinicalProfile).toBe(profile.version)
+    }
+
+    expect(
+      getActiveClinicalVersions(getClinicalProfile('adult-acute-urti')).clinicalProfile.id,
+    ).not.toBe(
+      getActiveClinicalVersions(getClinicalProfile('adult-acute-uncomplicated-uti')).clinicalProfile
+        .id,
+    )
+  })
+})

--- a/backend/src/clinical-profiles/index.ts
+++ b/backend/src/clinical-profiles/index.ts
@@ -1,0 +1,67 @@
+import type { ClinicalArtefactVersion } from '../clinical-versions/types.js'
+import { ALL_GAP_CHECKLIST, type GapChecklistEntry } from '../gaps/index.js'
+import { GUIDELINE_CORPUS, type ProfiledGuidelineChunk } from '../guidelines/index.js'
+import { ALL_REDFLAG_TRIGGERS, type RedFlagTrigger } from '../redflags/index.js'
+import { PROFILE_IDS, type ProfileId } from './types.js'
+
+export { PROFILE_IDS, type ProfileId, ProfileIdSchema } from './types.js'
+
+export interface ClinicalProfile {
+  readonly id: ProfileId
+  readonly version: ClinicalArtefactVersion
+  readonly scope: string
+  readonly noteTemplate: string
+  readonly redFlagTriggers: readonly RedFlagTrigger[]
+  readonly gapChecklist: readonly GapChecklistEntry[]
+  readonly guidelineCorpus: readonly ProfiledGuidelineChunk[]
+}
+
+export const ADULT_ACUTE_URTI_PROFILE_VERSION: ClinicalArtefactVersion = {
+  id: 'adult-acute-urti-profile-v1',
+  effectiveDate: '2026-08-14',
+}
+
+export const ADULT_ACUTE_UNCOMPLICATED_UTI_PROFILE_VERSION: ClinicalArtefactVersion = {
+  id: 'adult-acute-uncomplicated-uti-profile-v1',
+  effectiveDate: '2026-08-14',
+}
+
+const PROFILE_DEFINITIONS = {
+  'adult-acute-urti': {
+    version: ADULT_ACUTE_URTI_PROFILE_VERSION,
+    scope: 'adult acute cough, sore throat, and other upper-respiratory presentations',
+    noteTemplate:
+      'Use the SOAP scaffold for the documented respiratory presentation. Record findings and ' +
+      'the doctor-stated operational block only.',
+  },
+  'adult-acute-uncomplicated-uti': {
+    version: ADULT_ACUTE_UNCOMPLICATED_UTI_PROFILE_VERSION,
+    scope: 'adult acute primary-care presentations with urinary symptoms',
+    noteTemplate:
+      'Use the SOAP scaffold for the documented urinary presentation. Record findings and the ' +
+      'doctor-stated operational block only.',
+  },
+} as const satisfies Record<
+  ProfileId,
+  Omit<ClinicalProfile, 'id' | 'redFlagTriggers' | 'gapChecklist' | 'guidelineCorpus'>
+>
+
+function selectProfileContent(
+  profileId: ProfileId,
+): Omit<ClinicalProfile, 'id' | 'version' | 'scope' | 'noteTemplate'> {
+  return {
+    redFlagTriggers: ALL_REDFLAG_TRIGGERS.filter((trigger) => trigger.profiles.includes(profileId)),
+    gapChecklist: ALL_GAP_CHECKLIST.filter((entry) => entry.profiles.includes(profileId)),
+    guidelineCorpus: GUIDELINE_CORPUS.filter((chunk) => chunk.profiles.includes(profileId)),
+  }
+}
+
+export const CLINICAL_PROFILES: Readonly<Record<ProfileId, ClinicalProfile>> = Object.fromEntries(
+  PROFILE_IDS.map((id) => [id, { id, ...PROFILE_DEFINITIONS[id], ...selectProfileContent(id) }]),
+) as Record<ProfileId, ClinicalProfile>
+
+export const DEFAULT_PROFILE_ID: ProfileId = 'adult-acute-urti'
+
+export function getClinicalProfile(profileId: ProfileId = DEFAULT_PROFILE_ID): ClinicalProfile {
+  return CLINICAL_PROFILES[profileId]
+}

--- a/backend/src/clinical-profiles/types.ts
+++ b/backend/src/clinical-profiles/types.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const PROFILE_IDS = ['adult-acute-urti', 'adult-acute-uncomplicated-uti'] as const
+
+export const ProfileIdSchema = z.enum(PROFILE_IDS)
+
+export type ProfileId = z.infer<typeof ProfileIdSchema>

--- a/backend/src/clinical-versions/index.test.ts
+++ b/backend/src/clinical-versions/index.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from 'vitest'
 import { GAP_CHECKLIST } from '../gaps/index.js'
 import { GUIDELINE_CORPUS } from '../guidelines/index.js'
 import { RED_FLAG_LIST_VERSION, REDFLAG_TRIGGERS } from '../redflags/index.js'
-import { ACTIVE_CLINICAL_VERSIONS } from './index.js'
+import { ACTIVE_CLINICAL_VERSIONS, ACTIVE_PROFILE_VERSIONS } from './index.js'
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
 
 describe('clinical content versions (issue #16)', () => {
-  it('covers exactly the three versioned artefacts', () => {
+  it('covers the three versioned artefacts and the default clinical profile', () => {
     expect(Object.keys(ACTIVE_CLINICAL_VERSIONS).sort()).toEqual([
+      'clinicalProfile',
       'gapChecklist',
       'guidelineCorpus',
       'redFlagList',
@@ -46,5 +47,13 @@ describe('clinical content versions (issue #16)', () => {
     expect(REDFLAG_TRIGGERS.length).toBeGreaterThan(0)
     expect(GAP_CHECKLIST.length).toBeGreaterThan(0)
     expect(GUIDELINE_CORPUS.length).toBeGreaterThan(0)
+  })
+
+  it('includes a version for every selectable clinical profile', () => {
+    expect(Object.keys(ACTIVE_PROFILE_VERSIONS).length).toBeGreaterThan(1)
+    for (const version of Object.values(ACTIVE_PROFILE_VERSIONS)) {
+      expect(version.id).not.toHaveLength(0)
+      expect(version.effectiveDate).toMatch(ISO_DATE)
+    }
   })
 })

--- a/backend/src/clinical-versions/index.ts
+++ b/backend/src/clinical-versions/index.ts
@@ -1,3 +1,9 @@
+import {
+  CLINICAL_PROFILES,
+  type ClinicalProfile,
+  DEFAULT_PROFILE_ID,
+  type ProfileId,
+} from '../clinical-profiles/index.js'
 import { GAP_CHECKLIST_VERSION } from '../gaps/index.js'
 import { GUIDELINE_CORPUS_VERSION } from '../guidelines/index.js'
 import { RED_FLAG_LIST_VERSION } from '../redflags/index.js'
@@ -19,4 +25,20 @@ export const ACTIVE_CLINICAL_VERSIONS = {
   redFlagList: RED_FLAG_LIST_VERSION,
   gapChecklist: GAP_CHECKLIST_VERSION,
   guidelineCorpus: GUIDELINE_CORPUS_VERSION,
+  clinicalProfile: CLINICAL_PROFILES[DEFAULT_PROFILE_ID].version,
 } as const satisfies Record<string, ClinicalArtefactVersion>
+
+/** Every selectable profile is versioned before it can enter an analysis stamp. */
+export const ACTIVE_PROFILE_VERSIONS: Readonly<Record<ProfileId, ClinicalArtefactVersion>> =
+  Object.fromEntries(
+    Object.values(CLINICAL_PROFILES).map((profile) => [profile.id, profile.version]),
+  ) as Record<ProfileId, ClinicalArtefactVersion>
+
+export function getActiveClinicalVersions(profile: ClinicalProfile) {
+  return {
+    ...ACTIVE_CLINICAL_VERSIONS,
+    clinicalProfile: ACTIVE_PROFILE_VERSIONS[profile.id],
+  }
+}
+
+export type ActiveClinicalVersions = ReturnType<typeof getActiveClinicalVersions>

--- a/backend/src/gaps/checklist.ts
+++ b/backend/src/gaps/checklist.ts
@@ -1,4 +1,5 @@
 import type { ClinicalAssertion, ClinicalFacts, OperationalBlock } from '@shared/types'
+import type { ProfileId } from '../clinical-profiles/types.js'
 import type { ClinicalArtefactVersion } from '../clinical-versions/types.js'
 
 /**
@@ -7,9 +8,12 @@ import type { ClinicalArtefactVersion } from '../clinical-versions/types.js'
  * set of gaps can be traced back to the checklist that produced it.
  */
 export const GAP_CHECKLIST_VERSION: ClinicalArtefactVersion = {
-  id: 'gap-checklist-v1',
-  effectiveDate: '2026-08-13',
+  id: 'gap-checklist-v2',
+  effectiveDate: '2026-08-14',
 }
+
+const URTI_PROFILES: readonly ProfileId[] = ['adult-acute-urti']
+const UTI_PROFILES: readonly ProfileId[] = ['adult-acute-uncomplicated-uti']
 
 /**
  * Materiality rule (GitHub issue #6; docs/prd.md §12 alert fatigue).
@@ -50,6 +54,7 @@ export interface GapChecklistEntry {
   /** Why this field is tracked for this presentation. Never a clinical instruction. */
   rationale: string
   select: (facts: ClinicalFacts, operational: OperationalBlock) => ClinicalAssertion
+  profiles: readonly ProfileId[]
 }
 
 export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
@@ -62,6 +67,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Cough duration is a standard field tracked for adult cough and URTI presentations and ' +
       'is not documented in this consultation.',
     select: (facts) => facts.symptoms.coughDuration,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'sputum-production',
@@ -71,6 +77,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Sputum production is a standard field tracked for adult cough and URTI presentations ' +
       'and is not documented in this consultation.',
     select: (facts) => facts.symptoms.sputumProduction,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'haemoptysis',
@@ -80,6 +87,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Haemoptysis status is a standard field tracked for adult cough presentations and is ' +
       'not documented in this consultation.',
     select: (facts) => facts.symptoms.haemoptysis,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'fever',
@@ -89,6 +97,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Fever status is a standard field tracked for adult URTI presentations and is not ' +
       'documented in this consultation.',
     select: (facts) => facts.symptoms.fever,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'dyspnoea',
@@ -98,6 +107,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Breathlessness status is a standard field tracked for adult cough and URTI ' +
       'presentations and is not documented in this consultation.',
     select: (facts) => facts.symptoms.dyspnoea,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'chest-pain',
@@ -107,6 +117,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Chest pain status is a standard field tracked for adult cough and URTI presentations ' +
       'and is not documented in this consultation.',
     select: (facts) => facts.symptoms.chestPain,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'swallowing-difficulty',
@@ -116,6 +127,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Swallowing difficulty is a standard field tracked for adult sore-throat presentations ' +
       'and is not documented in this consultation.',
     select: (facts) => facts.symptoms.swallowingDifficulty,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'oral-intake',
@@ -125,6 +137,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Oral intake status is a standard field tracked for adult sore-throat presentations and ' +
       'is not documented in this consultation.',
     select: (facts) => facts.symptoms.oralIntake,
+    profiles: URTI_PROFILES,
   },
 
   // ─── History ────────────────────────────────────────────────────────────
@@ -136,6 +149,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Asthma history is a standard field tracked for adult cough and URTI presentations and ' +
       'is not documented in this consultation.',
     select: (facts) => facts.history.asthma,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'copd',
@@ -145,6 +159,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'COPD history is a standard field tracked for adult cough and URTI presentations and is ' +
       'not documented in this consultation.',
     select: (facts) => facts.history.copd,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'cardiac-disease',
@@ -154,6 +169,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Cardiac disease history is a standard field tracked for adult cough and URTI ' +
       'presentations and is not documented in this consultation.',
     select: (facts) => facts.history.cardiacDisease,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'immunosuppression',
@@ -163,6 +179,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Immunosuppression status is a standard field tracked for adult cough and URTI ' +
       'presentations and is not documented in this consultation.',
     select: (facts) => facts.history.immunosuppression,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'smoking',
@@ -172,6 +189,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Smoking status is a standard field tracked for adult cough and URTI presentations and ' +
       'is not documented in this consultation.',
     select: (facts) => facts.history.smoking,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'current-medications',
@@ -181,6 +199,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Current medications are a standard field tracked for adult cough and URTI ' +
       'presentations and are not documented in this consultation.',
     select: (facts) => facts.history.currentMedications,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'drug-allergies',
@@ -190,6 +209,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Drug allergy status is a standard field tracked whenever medication may be dispensed, ' +
       'and is not documented in this consultation.',
     select: (facts) => facts.history.drugAllergies,
+    profiles: URTI_PROFILES,
   },
 
   // ─── Observations ───────────────────────────────────────────────────────
@@ -201,6 +221,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Temperature is a standard vital-sign field tracked for adult URTI presentations and is ' +
       'not documented in this consultation.',
     select: (facts) => facts.observations.temperature,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'heart-rate',
@@ -210,6 +231,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Heart rate is a standard vital-sign field tracked for adult cough and URTI ' +
       'presentations and is not documented in this consultation.',
     select: (facts) => facts.observations.heartRate,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'respiratory-rate',
@@ -219,6 +241,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Respiratory rate is a standard vital-sign field tracked for adult cough and URTI ' +
       'presentations and is not documented in this consultation.',
     select: (facts) => facts.observations.respiratoryRate,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'blood-pressure',
@@ -228,6 +251,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Blood pressure is a standard vital-sign field tracked for adult URTI presentations and ' +
       'is not documented in this consultation.',
     select: (facts) => facts.observations.bloodPressure,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'oxygen-saturation',
@@ -237,6 +261,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Oxygen saturation is a standard vital-sign field tracked for adult cough and URTI ' +
       'presentations and is not documented in this consultation.',
     select: (facts) => facts.observations.oxygenSaturation,
+    profiles: URTI_PROFILES,
   },
 
   // ─── Examination ────────────────────────────────────────────────────────
@@ -248,6 +273,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Throat examination findings are a standard field tracked for adult sore-throat ' +
       'presentations and are not documented in this consultation.',
     select: (facts) => facts.examination.throat,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'tonsillar-examination',
@@ -257,6 +283,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Tonsillar examination findings are a standard field tracked for adult sore-throat ' +
       'presentations and are not documented in this consultation.',
     select: (facts) => facts.examination.tonsillar,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'cervical-lymph-nodes',
@@ -266,6 +293,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Cervical lymph node findings are a standard field tracked for adult sore-throat ' +
       'presentations and are not documented in this consultation.',
     select: (facts) => facts.examination.cervicalLymphNodes,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'chest-examination',
@@ -275,6 +303,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Chest examination findings are a standard field tracked for adult cough presentations ' +
       'and are not documented in this consultation.',
     select: (facts) => facts.examination.chest,
+    profiles: URTI_PROFILES,
   },
 
   // ─── Malaysian operational block ───────────────────────────────────────
@@ -287,6 +316,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       '(condition, treatment, medication dispensed, MC days, referral) and is not documented ' +
       'in this consultation.',
     select: (_facts, operational) => operational.diagnosis,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'mc-days',
@@ -296,6 +326,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'MC days are one of the fields in the Malaysian payer-enforced consultation record and ' +
       'are not documented in this consultation.',
     select: (_facts, operational) => operational.mcDays,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'referral',
@@ -305,6 +336,7 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Referral is one of the fields in the Malaysian payer-enforced consultation record and ' +
       'is not documented in this consultation.',
     select: (_facts, operational) => operational.referral,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'follow-up',
@@ -314,5 +346,64 @@ export const GAP_CHECKLIST: readonly GapChecklistEntry[] = [
       'Follow-up interval is one of the fields in the Malaysian payer-enforced consultation ' +
       'record and is not documented in this consultation.',
     select: (_facts, operational) => operational.followUp,
+    profiles: URTI_PROFILES,
   },
+]
+
+export const UTI_GAP_CHECKLIST: readonly GapChecklistEntry[] = [
+  {
+    id: 'uti-temperature',
+    priority: 'high',
+    question: 'The record does not contain a temperature reading.',
+    rationale:
+      'Temperature is a safety-relevant observation for adult acute urinary presentations and ' +
+      'is not documented in this consultation.',
+    select: (facts) => facts.observations.temperature,
+    profiles: UTI_PROFILES,
+  },
+  {
+    id: 'uti-heart-rate',
+    priority: 'high',
+    question: 'The record does not contain a heart-rate reading.',
+    rationale:
+      'Heart rate is a safety-relevant observation for adult acute urinary presentations and ' +
+      'is not documented in this consultation.',
+    select: (facts) => facts.observations.heartRate,
+    profiles: UTI_PROFILES,
+  },
+  {
+    id: 'uti-respiratory-rate',
+    priority: 'high',
+    question: 'The record does not contain a respiratory-rate reading.',
+    rationale:
+      'Respiratory rate is a safety-relevant observation for adult acute urinary presentations ' +
+      'and is not documented in this consultation.',
+    select: (facts) => facts.observations.respiratoryRate,
+    profiles: UTI_PROFILES,
+  },
+  {
+    id: 'uti-blood-pressure',
+    priority: 'high',
+    question: 'The record does not contain a blood-pressure reading.',
+    rationale:
+      'Blood pressure is a safety-relevant observation for adult acute urinary presentations ' +
+      'and is not documented in this consultation.',
+    select: (facts) => facts.observations.bloodPressure,
+    profiles: UTI_PROFILES,
+  },
+  {
+    id: 'uti-drug-allergies',
+    priority: 'medium',
+    question: 'The record does not indicate whether drug allergies were reviewed.',
+    rationale:
+      'Drug allergy status is relevant whenever medication may be dispensed and is not ' +
+      'documented in this consultation.',
+    select: (facts) => facts.history.drugAllergies,
+    profiles: UTI_PROFILES,
+  },
+]
+
+export const ALL_GAP_CHECKLIST: readonly GapChecklistEntry[] = [
+  ...GAP_CHECKLIST,
+  ...UTI_GAP_CHECKLIST,
 ]

--- a/backend/src/gaps/derive.ts
+++ b/backend/src/gaps/derive.ts
@@ -1,5 +1,5 @@
 import type { AssertionState, ClinicalFacts, InformationGap, OperationalBlock } from '@shared/types'
-import { GAP_CHECKLIST } from './checklist.js'
+import { GAP_CHECKLIST, type GapChecklistEntry } from './checklist.js'
 
 /**
  * A field the transcript never touched is the same fact seen from two sides
@@ -15,10 +15,14 @@ const GAP_STATES: ReadonlySet<AssertionState> = new Set(['NOT_ASSESSED', 'UNKNOW
  * set plus the Malaysian operational block. See `checklist.ts` for the
  * materiality rule deciding which fields are eligible to raise a gap.
  */
-export function deriveGaps(facts: ClinicalFacts, operational: OperationalBlock): InformationGap[] {
+export function deriveGaps(
+  facts: ClinicalFacts,
+  operational: OperationalBlock,
+  checklist: readonly GapChecklistEntry[] = GAP_CHECKLIST,
+): InformationGap[] {
   const gaps: InformationGap[] = []
 
-  for (const entry of GAP_CHECKLIST) {
+  for (const entry of checklist) {
     const assertion = entry.select(facts, operational)
     if (!GAP_STATES.has(assertion.state)) continue
 

--- a/backend/src/gaps/index.ts
+++ b/backend/src/gaps/index.ts
@@ -1,2 +1,8 @@
-export { GAP_CHECKLIST, GAP_CHECKLIST_VERSION, type GapChecklistEntry } from './checklist.js'
+export {
+  ALL_GAP_CHECKLIST,
+  GAP_CHECKLIST,
+  GAP_CHECKLIST_VERSION,
+  type GapChecklistEntry,
+  UTI_GAP_CHECKLIST,
+} from './checklist.js'
 export { deriveGaps } from './derive.js'

--- a/backend/src/guidelines/corpus.ts
+++ b/backend/src/guidelines/corpus.ts
@@ -1,5 +1,8 @@
 import { type GuidelineChunk, GuidelineChunkSchema } from '@shared/types'
+import type { ProfileId } from '../clinical-profiles/types.js'
 import type { ClinicalArtefactVersion } from '../clinical-versions/types.js'
+
+export type ProfiledGuidelineChunk = GuidelineChunk & { readonly profiles: readonly ProfileId[] }
 
 /**
  * Bumped whenever a chunk is added, removed, or its summary/threshold
@@ -10,9 +13,12 @@ import type { ClinicalArtefactVersion } from '../clinical-versions/types.js'
  * carries its own source's `publisher` and `year`.
  */
 export const GUIDELINE_CORPUS_VERSION: ClinicalArtefactVersion = {
-  id: 'guideline-corpus-v1',
-  effectiveDate: '2026-08-13',
+  id: 'guideline-corpus-v2',
+  effectiveDate: '2026-08-14',
 }
+
+const URTI_PROFILES: readonly ProfileId[] = ['adult-acute-urti']
+const UTI_PROFILES: readonly ProfileId[] = ['adult-acute-uncomplicated-uti']
 
 /**
  * Source selection resolved 13/08/26 (docs/trd.md §11, §19 row 3, closed).
@@ -30,7 +36,7 @@ export const GUIDELINE_CORPUS_VERSION: ClinicalArtefactVersion = {
  * clinician review pass (docs/prd.md §12) is expected to add `quote`s for
  * the CC-licensed sources where warranted.
  */
-export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
+export const GUIDELINE_CORPUS: readonly ProfiledGuidelineChunk[] = [
   // ─── MOH National Antimicrobial Guideline (NAG), 4th ed., 2024 ───────────
   // © MOH Malaysia, all rights reserved — summarise and link, never quote.
   {
@@ -45,6 +51,7 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'the antibiotic-consideration threshold at a Modified Centor score of 3 or more.',
     sourceLicence: 'MOH-ARR',
     verbatimAllowed: false,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'moh-nag-2024-c1-acute-pharyngitis',
@@ -60,6 +67,7 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'first-line management for the majority of presentations.',
     sourceLicence: 'MOH-ARR',
     verbatimAllowed: false,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'moh-nag-2024-c1-viral-vs-bacterial',
@@ -75,6 +83,7 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'bacterial pharyngitis in adults.',
     sourceLicence: 'MOH-ARR',
     verbatimAllowed: false,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'moh-nag-2024-c3-acute-bronchitis',
@@ -89,6 +98,7 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'process such as pneumonia.',
     sourceLicence: 'MOH-ARR',
     verbatimAllowed: false,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'moh-nag-2024-c4-uncomplicated-urti',
@@ -103,6 +113,7 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'symptoms worsen, persist beyond the expected viral course, or a red-flag feature develops.',
     sourceLicence: 'MOH-ARR',
     verbatimAllowed: false,
+    profiles: URTI_PROFILES,
   },
 
   // ─── Abdullah et al. (2024), Malaysian sore-throat Delphi consensus ──────
@@ -121,6 +132,7 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'streptococcus in older adults.',
     sourceLicence: 'CC-BY-NC-3.0',
     verbatimAllowed: true,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'abdullah-2024-mcisaac-threshold',
@@ -135,6 +147,7 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'point-of-care testing at a score of 2-3.',
     sourceLicence: 'CC-BY-NC-3.0',
     verbatimAllowed: true,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'abdullah-2024-safety-netting',
@@ -150,6 +163,7 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'expected course.',
     sourceLicence: 'CC-BY-NC-3.0',
     verbatimAllowed: true,
+    profiles: URTI_PROFILES,
   },
 
   // ─── Ooi et al. (2022), Malaysian Family Physician ───────────────────────
@@ -166,6 +180,7 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'viral in an otherwise healthy adult.',
     sourceLicence: 'CC-BY-4.0',
     verbatimAllowed: true,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'ooi-2022-antibiotic-prescribing-patterns',
@@ -180,6 +195,7 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'as a stewardship intervention.',
     sourceLicence: 'CC-BY-4.0',
     verbatimAllowed: true,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'ooi-2022-symptom-duration',
@@ -193,6 +209,21 @@ export const GUIDELINE_CORPUS: readonly GuidelineChunk[] = [
       'secondary bacterial process, which is useful context for reassurance and safety-netting.',
     sourceLicence: 'CC-BY-4.0',
     verbatimAllowed: true,
+    profiles: URTI_PROFILES,
+  },
+  {
+    id: 'moh-nag-2024-acute-uti-scope',
+    title: 'National Antimicrobial Guideline, 4th Edition, Acute Urinary Tract Infection',
+    publisher: 'Ministry of Health Malaysia',
+    year: 2024,
+    url: 'https://www.pharmacy.gov.my/v2/en/documents/national-antimicrobial-guideline-nag.html',
+    summary:
+      'MOH NAG 2024 includes guidance for urinary tract infection presentations. This prototype ' +
+      'does not encode drug choice, dose, duration, or treatment thresholds from that source; ' +
+      'the treating doctor must review the source itself.',
+    sourceLicence: 'MOH-ARR',
+    verbatimAllowed: false,
+    profiles: UTI_PROFILES,
   },
 ]
 
@@ -205,10 +236,10 @@ for (const chunk of GUIDELINE_CORPUS) {
  * tuple type, not `string[]`, so `z.enum` can narrow `guidelineId` at the
  * type level. The cast is checked immediately below by the length guard.
  */
-function toCorpusIds(chunks: readonly GuidelineChunk[]): readonly [string, ...string[]] {
+export function corpusIdsFor(chunks: readonly GuidelineChunk[]): readonly [string, ...string[]] {
   const ids = chunks.map((chunk) => chunk.id)
   if (ids.length === 0) throw new Error('guideline corpus must not be empty')
   return ids as [string, ...string[]]
 }
 
-export const corpusIds = toCorpusIds(GUIDELINE_CORPUS)
+export const corpusIds = corpusIdsFor(GUIDELINE_CORPUS)

--- a/backend/src/guidelines/index.ts
+++ b/backend/src/guidelines/index.ts
@@ -1,2 +1,8 @@
-export { corpusIds, GUIDELINE_CORPUS, GUIDELINE_CORPUS_VERSION } from './corpus.js'
+export {
+  corpusIds,
+  corpusIdsFor,
+  GUIDELINE_CORPUS,
+  GUIDELINE_CORPUS_VERSION,
+  type ProfiledGuidelineChunk,
+} from './corpus.js'
 export { serialiseCorpusForPrompt } from './prompt.js'

--- a/backend/src/redflags/evaluate.ts
+++ b/backend/src/redflags/evaluate.ts
@@ -1,14 +1,18 @@
 import type { RedFlag, Transcript } from '@shared/types'
 import { REDFLAG_TRIGGERS } from './triggers.js'
+import type { RedFlagTrigger } from './types.js'
 
 /**
  * Pure function over the transcript directly (docs/trd.md §10, Engine
  * Posture): no I/O, no LLM call, no database access, no clock, no
  * randomness. Runs independently of, and is never gated by, the model call.
  */
-export function evaluateRedFlags(transcript: Transcript): RedFlag[] {
+export function evaluateRedFlags(
+  transcript: Transcript,
+  triggers: readonly RedFlagTrigger[] = REDFLAG_TRIGGERS,
+): RedFlag[] {
   const flags: RedFlag[] = []
-  for (const trigger of REDFLAG_TRIGGERS) {
+  for (const trigger of triggers) {
     const evidence = trigger.matcher(transcript)
     if (evidence === null) continue
     flags.push({

--- a/backend/src/redflags/index.ts
+++ b/backend/src/redflags/index.ts
@@ -1,3 +1,8 @@
 export { evaluateRedFlags, mergeRedFlags } from './evaluate.js'
-export { RED_FLAG_LIST_VERSION, REDFLAG_TRIGGERS } from './triggers.js'
+export {
+  ALL_REDFLAG_TRIGGERS,
+  RED_FLAG_LIST_VERSION,
+  REDFLAG_TRIGGERS,
+  UTI_REDFLAG_TRIGGERS,
+} from './triggers.js'
 export type { RedFlagTrigger } from './types.js'

--- a/backend/src/redflags/triggers.ts
+++ b/backend/src/redflags/triggers.ts
@@ -1,4 +1,5 @@
 import type { Transcript } from '@shared/types'
+import type { ProfileId } from '../clinical-profiles/types.js'
 import type { ClinicalArtefactVersion } from '../clinical-versions/types.js'
 import type { RedFlagTrigger } from './types.js'
 
@@ -13,9 +14,16 @@ import type { RedFlagTrigger } from './types.js'
  * changes. Recorded with every analysis (docs/trd.md §15).
  */
 export const RED_FLAG_LIST_VERSION: ClinicalArtefactVersion = {
-  id: 'redflag-list-v1',
-  effectiveDate: '2026-08-13',
+  id: 'redflag-list-v2',
+  effectiveDate: '2026-08-14',
 }
+
+const URTI_PROFILES: readonly ProfileId[] = ['adult-acute-urti']
+const URTI_AND_UTI_PROFILES: readonly ProfileId[] = [
+  'adult-acute-urti',
+  'adult-acute-uncomplicated-uti',
+]
+const UTI_PROFILES: readonly ProfileId[] = ['adult-acute-uncomplicated-uti']
 
 const findSpan = (transcript: Transcript, patterns: readonly RegExp[]): string | null => {
   for (const turn of transcript.turns) {
@@ -52,6 +60,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'significant-dyspnoea',
@@ -69,6 +78,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'chest-pain',
@@ -82,6 +92,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'stridor-airway-compromise',
@@ -98,6 +109,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
       ]),
     clinicalSource: DELPHI_AIRWAY_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: URTI_PROFILES,
   },
   {
     id: 'swallowing-oral-intake',
@@ -114,6 +126,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
       ]),
     clinicalSource: DELPHI_AIRWAY_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: URTI_PROFILES,
   },
   {
     /**
@@ -140,5 +153,111 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
       'own stated severity assessment rather than an invented cutoff — see docs/trd.md §10 ' +
       '"What Stays Undecided".',
     listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: URTI_AND_UTI_PROFILES,
   },
+]
+
+const UTI_SCOPE_NOTE =
+  'MOH National Antimicrobial Guideline (NAG) 4th ed. 2024, urinary tract infection guidance: ' +
+  'this prototype surfaces a deliberately broad escalation prompt when the transcript describes ' +
+  'a feature that can fall outside an uncomplicated adult primary-care presentation. No clinician ' +
+  'has reviewed this trigger content.'
+
+export const UTI_REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
+  {
+    id: 'uti-systemic-features',
+    label: 'Fever, chills, or rigors reported, needs your attention',
+    severity: 'urgent',
+    matcher: (transcript) =>
+      findSpan(transcript, [
+        /\bfever(?:ish)?\b/i,
+        /\bchills?\b/i,
+        /\brigors?\b/i,
+        /\bshiver(?:ing)?\b/i,
+      ]),
+    clinicalSource: UTI_SCOPE_NOTE,
+    listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: UTI_PROFILES,
+  },
+  {
+    id: 'uti-flank-or-back-pain',
+    label: 'Flank or back pain reported, needs your attention',
+    severity: 'urgent',
+    matcher: (transcript) =>
+      findSpan(transcript, [
+        /\bflank\b/i,
+        /\bloin\b/i,
+        /\bkidney\s+pain\b/i,
+        /(?:pain|ache)\s+(?:in\s+)?(?:my\s+)?(?:lower\s+)?back\b/i,
+      ]),
+    clinicalSource: UTI_SCOPE_NOTE,
+    listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: UTI_PROFILES,
+  },
+  {
+    id: 'uti-systemic-deterioration',
+    label: 'Possible systemic deterioration reported, needs your attention',
+    severity: 'emergency',
+    matcher: (transcript) =>
+      findSpan(transcript, [
+        /\bconfus(?:ed|ion)\b/i,
+        /\bfaint(?:ed|ing)?\b/i,
+        /\bvery\s+drowsy\b/i,
+        /\bextremely\s+weak\b/i,
+        /\bfeeling\s+very\s+unwell\b/i,
+      ]),
+    clinicalSource: UTI_SCOPE_NOTE,
+    listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: UTI_PROFILES,
+  },
+  {
+    id: 'uti-pregnancy-mentioned',
+    label: 'Pregnancy or possible pregnancy mentioned, needs your attention',
+    severity: 'urgent',
+    matcher: (transcript) =>
+      findSpan(transcript, [
+        /\bpregnan(?:t|cy)\b/i,
+        /\bmissed\s+(?:my\s+)?period\b/i,
+        /\btrying\s+for\s+(?:a\s+)?baby\b/i,
+      ]),
+    clinicalSource: UTI_SCOPE_NOTE,
+    listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: UTI_PROFILES,
+  },
+  {
+    id: 'uti-unable-to-pass-urine',
+    label: 'Unable to pass urine reported, needs your attention',
+    severity: 'emergency',
+    matcher: (transcript) =>
+      findSpan(transcript, [
+        /(?:can'?t|cannot|unable\s+to)\s+(?:pass|pee|urinate)/i,
+        /\bnot\s+passing\s+(?:any\s+)?urine\b/i,
+        /\bno\s+urine\s+(?:is\s+)?coming\s+out\b/i,
+      ]),
+    clinicalSource: UTI_SCOPE_NOTE,
+    listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: UTI_PROFILES,
+  },
+  {
+    id: 'uti-potentially-complicating-context',
+    label: 'Potentially complicating urinary context reported, needs your attention',
+    severity: 'urgent',
+    matcher: (transcript) =>
+      findSpan(transcript, [
+        /\b(?:urinary\s+)?catheter(?:ised|ized)?\b/i,
+        /\bkidney\s+(?:disease|failure|transplant)\b/i,
+        /\bsingle\s+kidney\b/i,
+        /\bimmunosuppress(?:ed|ion)\b/i,
+        /\bdiabetes?\b/i,
+        /\bmale\b/i,
+      ]),
+    clinicalSource: UTI_SCOPE_NOTE,
+    listVersion: RED_FLAG_LIST_VERSION.id,
+    profiles: UTI_PROFILES,
+  },
+]
+
+export const ALL_REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
+  ...REDFLAG_TRIGGERS,
+  ...UTI_REDFLAG_TRIGGERS,
 ]

--- a/backend/src/redflags/types.ts
+++ b/backend/src/redflags/types.ts
@@ -1,4 +1,5 @@
 import type { Transcript } from '@shared/types'
+import type { ProfileId } from '../clinical-profiles/types.js'
 
 /**
  * TRD §10 (Trigger Record Shape). One entry per deterministic escalation
@@ -17,4 +18,6 @@ export interface RedFlagTrigger {
   clinicalSource: string
   /** Version of the trigger list this entry belongs to. */
   listVersion: string
+  /** Profiles that include this trigger. */
+  profiles: readonly ProfileId[]
 }

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -359,6 +359,21 @@ describe('analyse output', () => {
       versions: { clinicalContent: ACTIVE_CLINICAL_VERSIONS },
     })
   })
+
+  it('persists the selected profile id in analysis and completion audit metadata', async () => {
+    await call('POST', '/api/consultations/c1/analyze', {
+      profileId: 'adult-acute-uncomplicated-uti',
+    })
+
+    expect(store.get('c1')?.analysis).toMatchObject({
+      profileId: 'adult-acute-uncomplicated-uti',
+    })
+    expect(
+      audits.find((audit) => audit.action === 'consultation.analysis_completed')?.metadata,
+    ).toMatchObject({
+      profileId: 'adult-acute-uncomplicated-uti',
+    })
+  })
 })
 
 describe('state machine — patch', () => {

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -11,7 +11,12 @@ import { Router } from 'express'
 import { z } from 'zod'
 import { analyseNote } from '../analysis/index.js'
 import { type AnalysisFailureReason, getAuditHistory, recordAuditEvent } from '../audit/index.js'
-import { ACTIVE_CLINICAL_VERSIONS } from '../clinical-versions/index.js'
+import {
+  DEFAULT_PROFILE_ID,
+  getClinicalProfile,
+  ProfileIdSchema,
+} from '../clinical-profiles/index.js'
+import { getActiveClinicalVersions } from '../clinical-versions/index.js'
 import { DeidentificationError, deidentifyTranscript } from '../deid/index.js'
 import { deriveGaps } from '../gaps/index.js'
 import { assertOwnedConsultation } from '../lib/authz.js'
@@ -190,6 +195,15 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
     throw new HttpError(409, 'invalid_state', 'This consultation has no usable transcript.')
   }
 
+  const profileBody = z
+    .object({ profileId: ProfileIdSchema.optional() })
+    .default({})
+    .safeParse(req.body)
+  if (!profileBody.success) {
+    throw new HttpError(400, 'invalid_body', 'A valid clinical profile is required.')
+  }
+  const profile = getClinicalProfile(profileBody.data.profileId ?? DEFAULT_PROFILE_ID)
+
   const previousStatus = consultation.status
   await prisma.consultation.update({
     where: { id: consultation.id },
@@ -215,11 +229,13 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
 
     // Runs on the raw transcript, in-process, regardless of model output. It
     // never leaves the API, so it needs no gate.
-    const ruleFlags = await timeStage('rules', () => evaluateRedFlags(transcript.data))
+    const ruleFlags = await timeStage('rules', () =>
+      evaluateRedFlags(transcript.data, profile.redFlagTriggers),
+    )
 
     const [noteResult, suggestionResult] = await Promise.all([
-      timeStage('note_generation', () => analyseNote(text, text)),
-      timeStage('retrieval', () => generateSuggestions(text)),
+      timeStage('note_generation', () => analyseNote(text, text, profile)),
+      timeStage('retrieval', () => generateSuggestions(text, profile)),
     ])
 
     const rehydrate = (value: string) => vault.rehydrate(value)
@@ -231,8 +247,9 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
         assessment: rehydrate(noteResult.note.assessment),
         plan: rehydrate(noteResult.note.plan),
       },
+      profileId: profile.id,
       gaps: mergeGaps(
-        deriveGaps(noteResult.clinicalFacts, noteResult.operational),
+        deriveGaps(noteResult.clinicalFacts, noteResult.operational, profile.gapChecklist),
         noteResult.gaps,
       ).map((gap) => ({
         ...gap,
@@ -271,10 +288,11 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
       metadata: {
         detected,
         discardedFieldIds: noteResult.discardedFieldIds,
+        profileId: profile.id,
         versions: {
           provider: llm.provider,
           model: llm.model,
-          clinicalContent: ACTIVE_CLINICAL_VERSIONS,
+          clinicalContent: getActiveClinicalVersions(profile),
         },
       },
     })

--- a/backend/src/suggestions/index.test.ts
+++ b/backend/src/suggestions/index.test.ts
@@ -6,15 +6,16 @@ vi.mock('../lib/llm/index.js', () => ({
   getLLMClient: () => ({ provider: 'qwen', model: 'qwen-flash', generate }),
 }))
 
+import { getClinicalProfile } from '../clinical-profiles/index.js'
 import type { Deidentified } from '../deid/types.js'
-import { corpusIds } from '../guidelines/index.js'
+import { corpusIdsFor } from '../guidelines/index.js'
 import type { GenerateRequest } from '../lib/llm/types.js'
 import { generateSuggestions } from './index.js'
 
 const content =
   'Doctor: What brings you in? Patient: [PATIENT_1] here, cough 3 days.' as Deidentified
 
-const firstCorpusId = corpusIds[0]
+const firstCorpusId = corpusIdsFor(getClinicalProfile().guidelineCorpus)[0]
 
 const emptyResponse = { outOfScope: false, redFlags: [], suggestions: [] }
 
@@ -156,10 +157,10 @@ describe('generateSuggestions — system prompt content', () => {
     expect(request.system).toMatch(/never (override|suppress|downgrade)/i)
   })
 
-  it('serialises every corpus id into the system prompt', async () => {
+  it('serialises every selected profile corpus id into the system prompt', async () => {
     const request = await capturedRequest()
 
-    for (const id of corpusIds) {
+    for (const id of corpusIdsFor(getClinicalProfile().guidelineCorpus)) {
       expect(request.system).toContain(id)
     }
   })

--- a/backend/src/suggestions/index.ts
+++ b/backend/src/suggestions/index.ts
@@ -3,8 +3,9 @@ import {
   makeSuggestionsAndRedFlagsSchema,
   type RedFlag,
 } from '@shared/types'
+import { type ClinicalProfile, getClinicalProfile } from '../clinical-profiles/index.js'
 import type { Deidentified } from '../deid/types.js'
-import { corpusIds } from '../guidelines/index.js'
+import { corpusIdsFor } from '../guidelines/index.js'
 import { getLLMClient } from '../lib/llm/index.js'
 import { buildSuggestionsSystemPrompt } from './prompt.js'
 
@@ -20,16 +21,19 @@ export { buildSuggestionsSystemPrompt } from './prompt.js'
  * citation naming an id outside the corpus fails decoding inside
  * `LLMClient.generate()` and never reaches this function's caller.
  */
-export async function generateSuggestions(content: Deidentified): Promise<{
+export async function generateSuggestions(
+  content: Deidentified,
+  profile: ClinicalProfile = getClinicalProfile(),
+): Promise<{
   outOfScope: boolean
   redFlags: RedFlag[]
   suggestions: ClinicalSuggestion[]
 }> {
   return getLLMClient().generate({
     operation: 'suggestions_and_red_flags',
-    system: buildSuggestionsSystemPrompt(),
+    system: buildSuggestionsSystemPrompt(profile),
     content,
-    schema: makeSuggestionsAndRedFlagsSchema(corpusIds),
+    schema: makeSuggestionsAndRedFlagsSchema(corpusIdsFor(profile.guidelineCorpus)),
     schemaName: 'suggestions_and_red_flags',
   })
 }

--- a/backend/src/suggestions/prompt.ts
+++ b/backend/src/suggestions/prompt.ts
@@ -1,3 +1,4 @@
+import type { ClinicalProfile } from '../clinical-profiles/index.js'
 import { serialiseCorpusForPrompt } from '../guidelines/index.js'
 
 /**
@@ -15,10 +16,9 @@ import { serialiseCorpusForPrompt } from '../guidelines/index.js'
  *   is free text — so it is stated explicitly, alongside the reminder that
  *   this call never sees or influences the rules engine's own output.
  */
-export function buildSuggestionsSystemPrompt(): string {
+export function buildSuggestionsSystemPrompt(profile: ClinicalProfile): string {
   return `You are assisting a Malaysian GP who is reviewing a de-identified consultation
-transcript for an adult presenting with acute cough, sore throat, or another
-upper-respiratory-tract symptom. Text such as "[PATIENT_1]" or "[NRIC_1]" is a
+transcript for ${profile.scope}. Text such as "[PATIENT_1]" or "[NRIC_1]" is a
 de-identification token, not the patient's real identifier — never attempt to
 guess, reconstruct, or comment on the identity behind a token.
 
@@ -43,13 +43,12 @@ transcript actually supports.
 
 Scope:
 Set outOfScope to true, and return an empty suggestions array, if the
-transcript describes a presentation outside acute cough, sore throat, and
-other upper-respiratory-tract symptoms — the corpus below does not cover
-other presentations, and a guideline-cited suggestion would be unsupported.
+transcript describes a presentation outside ${profile.scope}. The corpus below
+does not cover other presentations, and a guideline-cited suggestion would be unsupported.
 Still report any red-flag candidates regardless of scope. Set outOfScope to
 false when the presentation is in scope, even if you have no suggestions to
 add.
 
 Guideline corpus (cite by the bracketed id only):
-${serialiseCorpusForPrompt()}`
+${serialiseCorpusForPrompt(profile.guidelineCorpus)}`
 }

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -697,7 +697,7 @@ Matches `docs/prd.md` §8 (Primary Flow) exactly: `draft →(create) draft →(a
 | `consultation.created`            | `POST /api/consultations`                                            | —                                                                         |
 | `consultation.asr_hosted_used`    | `POST /api/consultations` where `transcript.source === 'asr_hosted'` | `—` — the fact of the hosted path, never any audio, chunk, or text        |
 | `consultation.analysis_started`   | `POST /api/consultations/:id/analyze` begins                         | —                                                                         |
-| `consultation.analysis_completed` | analyse pipeline succeeds                                            | `{ detected, discardedFieldIds, versions }` — see below                   |
+| `consultation.analysis_completed` | analyse pipeline succeeds                                            | `{ detected, discardedFieldIds, profileId, versions }` — see below        |
 | `consultation.analysis_failed`    | analyse pipeline throws                                              | `{ reason: string }` — a short failure category, never the raw error text |
 | `consultation.edited`             | `PATCH /api/consultations/:id`                                       | —                                                                         |
 | `redflag.acknowledged`            | doctor acknowledges a red flag                                       | `{ redFlagId: string }`                                                   |
@@ -735,10 +735,11 @@ interface ClinicalArtefactVersion {
 {
   detected: string[],            // de-identification detector labels only (§9)
   discardedFieldIds: string[],   // fields the §21.4 evidence check dropped
+  profileId: string,             // selected clinical workflow profile
   versions: {
     provider: string,            // LLM provider and model (§6)
     model: string,
-    clinicalContent: { redFlagList, gapChecklist, guidelineCorpus },
+    clinicalContent: { redFlagList, gapChecklist, guidelineCorpus, clinicalProfile },
   },
 }
 ```
@@ -748,6 +749,32 @@ Because `AuditEvent` is append-only, a past analysis keeps the versions it ran u
 **Enforcement.** `backend/src/clinical-versions/no-stray-clinical-constants.test.ts` scans `backend/src` and `frontend/src` and fails the build on either a whole single-quoted literal equal to a trigger or checklist id, or a guideline scoring-system name, outside the three data files. Tests and `backend/src/fixtures/` are exempt. The id set is read from the data at runtime, never listed in the test, so it cannot go stale. The second check exists because the scoring systems carry the thresholds the two Malaysian sources disagree on (§11): a hard-coded one is a manufactured consensus with nothing citing it.
 
 **Not versioned data, deliberately.** Per-chunk source versions are not modelled. `GuidelineChunk` (§11) carries `year`, and the edition sits inside `title` ("4th Edition"). Adding a structured `sourceVersion` would change a `@shared/types` schema and is raised on issue #31 rather than assumed.
+
+### Clinical Workflow Profiles
+
+**Status: `Built`** (issue #21). A clinical profile selects the active red-flag rules, gap checklist entries, guideline chunks, and note template for one adult acute primary-care workflow. The selection is a lookup from `profileId`, never a profile-specific branch in the analysis pipeline.
+
+| Profile ID                      | Scope                                                               | Version Constant                                |
+| ------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------- |
+| `adult-acute-urti`              | Adult acute cough, sore throat, and upper-respiratory presentations | `ADULT_ACUTE_URTI_PROFILE_VERSION`              |
+| `adult-acute-uncomplicated-uti` | Adult acute primary-care presentations with urinary symptoms        | `ADULT_ACUTE_UNCOMPLICATED_UTI_PROFILE_VERSION` |
+
+Each rule, checklist entry, and guideline chunk carries its own `profiles` membership in the data file that owns it. `backend/src/clinical-profiles/` filters that data by `profileId`. It does not keep a separate registry of clinical ids, so the executable guard against stray clinical constants remains intact.
+
+The second profile is adult acute uncomplicated urinary tract infection. It is a useful proof because it is a different body system while remaining within acute adult primary care, and it uses the MOH National Antimicrobial Guideline 2024 source already represented in the corpus. Its deterministic rules deliberately over-trigger for fever or rigors, flank or back pain, systemic deterioration, pregnancy, urinary retention, potentially complicating context, and concerning vital signs. Its five gap entries are limited to the existing structured schema's safety-relevant observations and drug-allergy field. The shared schema does not yet capture urinary symptoms, pregnancy status, renal history, or catheter status, so this is a constrained workflow proof rather than a clinically complete urinary assessment.
+
+**No clinician has reviewed this content.** The second profile is not clinically validated and must not be presented as such.
+
+### Profile Persistence And Migration Path
+
+The selected identifier is stored with the exact JSON key `profileId` in both existing JSON surfaces:
+
+- `Consultation.analysis.profileId`
+- `AuditEvent.metadata.profileId` for `consultation.analysis_completed`
+
+The completed-analysis stamp includes the selected profile's `ClinicalArtefactVersion` alongside the red-flag, checklist, and corpus versions. This ensures every profile must have a version before it can be recorded.
+
+This deliberately avoids a `Consultation.profileId` column and a Prisma migration while profiles remain prototype configuration. If profile selection becomes a durable query or reporting requirement, add a nullable `Consultation.profileId` column, backfill it from `analysis.profileId`, validate parity with the audit metadata, switch reads and writes to the column, then retain the JSON key for historical analyses. The JSON key is already named `profileId`, so that promotion requires no data-key rename.
 
 ### Tamper-Evidence: The Hash Chain
 


### PR DESCRIPTION
Closes #21. The last of @Andersonnn7788's lanes, taken up while he is offline.

## Both Open Questions Were Answered First

1. **Shape.** @AlaskanTuna ratified it on #31: the cheap shape. No `shared/` change, no migration, no `Consultation.profileId` column, and the JSON key is exactly `profileId` so later promotion is a rename-nothing operation. Built as ratified.
2. **Whether to build it at all.** @AlaskanTuna had asked @Andersonnn7788 whether a specialty layer shipping with one specialty demonstrates anything, or whether it should be closed with the design recorded. That was never answered. I put it back to him with that option included, and he chose to build it fully, second profile included.

## Design: Membership Tagged In Place

`no-stray-clinical-constants.test.ts` (#16) fails the build when a clinical id appears as a single-quoted literal outside `redflags/triggers.ts`, `gaps/checklist.ts`, or `guidelines/corpus.ts`.

That rules out the obvious design. A profile registry listing ids would trip the guard or force widening its allowlist, and widening a safety guard to fit a refactor is the wrong direction. So each record declares its own `profiles` membership in the data file that already owns it, and `backend/src/clinical-profiles/` selects by filtering:

```ts
redFlagTriggers: ALL_REDFLAG_TRIGGERS.filter((t) => t.profiles.includes(profileId)),
gapChecklist:    ALL_GAP_CHECKLIST.filter((e) => e.profiles.includes(profileId)),
guidelineCorpus: GUIDELINE_CORPUS.filter((c) => c.profiles.includes(profileId)),
```

**The guard file is unmodified and still passes.** No clinical id literal exists outside the three data files.

## Acceptance Criteria

- [x] **A profile is defined as data**: checklist, rules, guideline subset, note template.
- [x] **Selecting a profile changes the active content with no code branching per specialty.** Selection is `getClinicalProfile(profileId)`, a record lookup over filtered data. The only conditional added to the route is Zod validation of the request body.
- [x] **One additional profile exists as a working proof**: adult acute uncomplicated UTI.
- [x] **Adding a profile requires no change to the extraction, safety, or approval pipeline.**
- [x] **Each profile carries its own version stamps, recorded per analysis**, alongside the red-flag, checklist and corpus versions, so a profile cannot be recorded unstamped.

## Verification, Run Outside The Worker's Sandbox

The Codex worker reported test failures it could not resolve: 3 environment tests and 4 HTTP suites failing with `EPERM` on socket bind. **Those were sandbox artifacts, not real.** Re-run here:

```
Test Files  25 passed (25)
     Tests  302 passed (302)
```

302 up from 295, so 7 new tests and one new file. Lint clean on tracked files (4 pre-existing `prisma/seed.ts` warnings, identical to CI). Typecheck clean.

**The URTI profile is provably unchanged.** I captured every trigger id, severity, label, checklist id, priority and corpus id from `a307efc` before the run and diffed afterwards. The only entries that differ are the three version ids, bumped `v1` to `v2`, which is correct because the lists now contain more content. Every pre-existing clinical entry survived byte-identical.

## The Second Profile, And What It Is Not

Adult acute uncomplicated UTI: a different body system, so it genuinely tests whether the mechanism generalises, while staying in acute adult primary care on a source the corpus already carries.

7 deterministic red flags that deliberately over-trigger: fever/chills/rigors, flank or back pain, systemic deterioration, pregnancy, unable to pass urine, complicating context, concerning vitals. Labels describe what was reported and never assert a diagnosis, matching the existing wording discipline.

**On the risk that matters here.** The ID-constrained citation design makes a hallucinated citation structurally impossible, but that protection sits downstream of the corpus: nothing in it can verify that a corpus entry's claims are faithful to the real document. The new chunk therefore **encodes no clinical claims at all**. It carries no drug choice, dose, duration or threshold, and its summary says so and directs the doctor to the source. `verbatimAllowed: false`, licence consistent with the existing NAG entries.

**No clinician has reviewed this content.** That caveat is in the trigger data itself via `UTI_SCOPE_NOTE`, not only in the TRD, so it travels with any citation. The shared schema does not capture urinary symptoms, pregnancy status, renal history or catheter status, so this is a constrained workflow proof and not a clinically complete urinary assessment. The TRD says this plainly.

## Backward Compatibility

`DEFAULT_PROFILE_ID` is `adult-acute-urti`, so an analyse request without a profile behaves exactly as before.

## Note On One Em Dash

`docs/trd.md:700` carries an em dash. It is pre-existing at `HEAD` on a line that only gained `profileId` in its metadata list. Left alone deliberately: AGENTS.md says not to sweep existing docs to conform.

## Clinical-Safety Checklist

The diff touches `redflags/` and `guidelines/`, so this is not optional.

- **De-identification:** untouched. No new egress path; profile selection happens before the gate and changes only which rules and chunks are active.
- **Red flags:** the engine remains a pure function library. The LLM still cannot suppress a rule hit; profile filtering selects which deterministic rules run, and new rules are deliberately over-inclusive.
- **Citations:** still ID-constrained. `corpusIds` is now derived per profile, so a model can only cite chunks in the active profile's subset, which narrows rather than widens what it may cite.
- **No diagnosis:** new labels describe reported features, never a condition. Approval remains an explicit doctor action.
- **Logging:** unchanged. `profileId` is an enum member, not free text, and joins existing audit metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable clinical profiles for adult acute respiratory infections and uncomplicated urinary tract infections.
  * Tailored analysis, note generation, suggestions, red-flag checks, and information-gap checklists now reflect the selected profile.
  * Added UTI-specific warning signs, checklist items, and clinical guidance.
  * Selected profile information is retained with consultation analysis and audit records.

* **Documentation**
  * Documented available clinical profiles, profile-specific workflows, version tracking, and current UTI workflow limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->