### PR TITLE
fix(ui): restore the frosted glass and extend the shell into the app

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -50,6 +50,10 @@
   --color-advisory: oklch(0.457 0.164 258);
   --color-advisory-rule: oklch(0.457 0.164 258);
 
+  /* Faint enough to disappear against the ground until the eye looks for it. */
+  --color-scrollbar: oklch(0.245 0.008 160 / 0.22);
+  --color-scrollbar-hover: oklch(0.245 0.008 160 / 0.38);
+
   /* Chrome only. Never behind text a doctor acts on. */
   --color-glass: oklch(1 0 0 / 0.72);
   --color-glass-line: oklch(1 0 0 / 0.55);
@@ -150,6 +154,9 @@
     --color-advisory: oklch(0.76 0.115 245);
     --color-advisory-rule: oklch(0.76 0.115 245);
 
+    --color-scrollbar: oklch(0.945 0.004 160 / 0.2);
+    --color-scrollbar-hover: oklch(0.945 0.004 160 / 0.34);
+
     --color-glass: oklch(0.225 0.007 160 / 0.72);
     --color-glass-line: oklch(1 0 0 / 0.1);
     --color-scrim: oklch(0.12 0.005 160 / 0.5);
@@ -196,6 +203,53 @@
     border-radius: 4px;
   }
 
+  /*
+   * One scrollbar vocabulary, everywhere, in both engines.
+   *
+   * `scrollbar-width: thin` is the standard property and is all Firefox needs;
+   * the `::-webkit-scrollbar` block is what Chromium reads. Both are declared
+   * because neither alone covers the browsers this is judged in.
+   *
+   * The track is transparent rather than tinted, so the bar sits on whatever
+   * surface it happens to overlay (ground, card, or the sunken transcript
+   * panel) instead of cutting a grey channel through it. The thumb is the ink
+   * hue at low alpha, which makes it theme-aware without a second declaration:
+   * it darkens on the light ground and lightens on the dark one because the ink
+   * token already flipped.
+   */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-scrollbar) transparent;
+  }
+
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--color-scrollbar);
+    /* Inset via a transparent border so the thumb reads as a slim capsule with
+     * breathing room, rather than a bar wedged against the content edge. */
+    background-clip: padding-box;
+    border: 3px solid transparent;
+    border-radius: var(--radius-pill);
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: var(--color-scrollbar-hover);
+  }
+
+  /* The corner where two scrollbars meet, which otherwise paints an opaque
+   * light square on the dark theme. */
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
   ::placeholder {
     /* Not the muted default: placeholder text needs the same 4.5:1 as body. */
     color: var(--color-ink-muted);
@@ -212,8 +266,15 @@
    */
   .glass {
     background-color: var(--color-glass);
-    backdrop-filter: blur(20px) saturate(150%);
+    /*
+     * Prefix FIRST, standard LAST, and that order is load-bearing rather than
+     * cosmetic. Written the other way round the minifier treats the pair as one
+     * property declared twice, keeps the last, and ships `-webkit-` alone: the
+     * frost silently degrades to flat translucency in the production build
+     * while dev, which does not minify, looks perfect. Do not reorder these.
+     */
     -webkit-backdrop-filter: blur(20px) saturate(150%);
+    backdrop-filter: blur(20px) saturate(150%);
     border: 1px solid var(--color-glass-line);
     box-shadow:
       0 1px 2px oklch(0 0 0 / 0.04),
@@ -227,8 +288,9 @@
     inset: 0;
     z-index: var(--z-scrim);
     background-color: var(--color-scrim);
-    backdrop-filter: blur(8px);
+    /* Prefix first, standard last. See the note on `.glass`. */
     -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
     opacity: 0;
     pointer-events: none;
     transition:
@@ -255,11 +317,26 @@
    * footer's top row hidden behind the page, which nobody sees unless they
    * scroll to the bottom at the width that broke.
    */
-  .marketing-shell {
+  .reveal-shell {
     --footer-h: 23rem;
   }
 
-  .marketing-page {
+  /*
+   * The paper the whole product is printed on, public and signed-in alike.
+   *
+   * It also does load-bearing work for the glass. `backdrop-filter` blurs
+   * whatever is behind it, so over a flat fill it has nothing to operate on and
+   * the chrome reads as merely translucent no matter how large the blur radius
+   * is. The grid gives the blur something to smear, which is what makes frost
+   * look like frost.
+   */
+  .dot-grid {
+    background-color: var(--color-ground);
+    background-image: radial-gradient(circle at 1px 1px, var(--grid-dot) 1px, transparent 0);
+    background-size: 18px 18px;
+  }
+
+  .reveal-page {
     position: relative;
     z-index: var(--z-sticky);
     min-height: 100vh;
@@ -267,12 +344,9 @@
     /* Opaque, and that is the whole mechanism. A translucent page would show
      * the footer through itself from the first paint and the reveal would
      * never happen. */
-    background-color: var(--color-ground);
-    background-image: radial-gradient(circle at 1px 1px, var(--grid-dot) 1px, transparent 0);
-    background-size: 18px 18px;
   }
 
-  .marketing-footer {
+  .site-footer {
     position: fixed;
     right: 0;
     bottom: 0;
@@ -287,7 +361,7 @@
    * The pointer trail, painted between the page's own background and its
    * content.
    *
-   * `z-index: -1` inside `.marketing-page` is doing precise work. A negative
+   * `z-index: -1` inside `.reveal-page` is doing precise work. A negative
    * index paints after the ancestor's background and before its in-flow
    * descendants, so the glow washes over the dot grid and passes behind every
    * word. `z-index: 0` looks like a near-miss of the same thing and is not:
@@ -330,11 +404,11 @@
    * and the reserve is not a number anyone has to keep correct.
    */
   @media (width < 48rem) {
-    .marketing-page {
+    .reveal-page {
       margin-bottom: 0;
     }
 
-    .marketing-footer {
+    .site-footer {
       position: static;
       height: auto;
     }

--- a/frontend/src/routes/ConsultationList.tsx
+++ b/frontend/src/routes/ConsultationList.tsx
@@ -34,7 +34,7 @@ export function ConsultationList() {
   })
 
   return (
-    <div className="mx-auto max-w-3xl">
+    <div className="mx-auto max-w-4xl">
       <PageHeader
         title="Consultations"
         subtitle="Simulated consultations, scoped to you."

--- a/frontend/src/routes/ConsultationNew.tsx
+++ b/frontend/src/routes/ConsultationNew.tsx
@@ -92,7 +92,7 @@ export function ConsultationNew() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl">
+    <div className="mx-auto max-w-4xl">
       <PageHeader
         title="New Consultation"
         subtitle="Every bundled case is synthetic. No real patient data enters this system."

--- a/frontend/src/routes/Guidelines.tsx
+++ b/frontend/src/routes/Guidelines.tsx
@@ -36,7 +36,7 @@ export function Guidelines() {
   const groups = groupByPublisher(guidelines.data ?? [])
 
   return (
-    <div className="mx-auto max-w-3xl">
+    <div className="mx-auto max-w-4xl">
       <PageHeader
         title="Guideline Corpus"
         subtitle="The closed set of sources the model may cite. Anything outside it fails validation."

--- a/frontend/src/shell/AppShell.tsx
+++ b/frontend/src/shell/AppShell.tsx
@@ -1,40 +1,47 @@
 import { useCallback, useState } from 'react'
 import { Outlet } from 'react-router-dom'
+import { CursorGlow } from '../ui/CursorGlow.js'
 import { MobileDock } from './MobileDock.js'
 import { SidebarIsland } from './SidebarIsland.js'
+import { SiteFooter } from './SiteFooter.js'
 
 /**
- * The one scrim for the whole app.
+ * The signed-in shell, now built on the same two layers as the public one.
  *
- * A single fixed compositor layer carries the blur and dim while the sidebar is
- * expanded. The alternative, filtering the content subtree, repaints the entire
- * review screen on every hover and is what makes this effect feel cheap.
+ * It shares three things it used to lack: the dot grid, the pointer trail, and
+ * the footer. The grid is not decoration here. `backdrop-filter` blurs what is
+ * behind it, so over the flat fill this used to have, the sidebar's glass had
+ * nothing to blur and read as plain translucency however large the radius was.
+ * Texture behind the chrome is what makes frost look like frost.
  *
- * Reduced motion no longer touches the blur. A static blurred layer does not
- * move, so it is not what the preference is about; only the transition that
- * fades it in is, and that is handled in CSS. Dropping the filter here is what
- * previously made the effect vanish entirely for anyone whose OS animations
- * were off, which is a common default rather than an edge case.
+ * The scrim stays outside the page layer. It has to cover the sidebar as well
+ * as the content, so it cannot be a child of the thing it is dimming.
  */
 export function AppShell() {
   const [dimmed, setDimmed] = useState(false)
   const onExpandedChange = useCallback((expanded: boolean) => setDimmed(expanded), [])
 
   return (
-    <div className="min-h-dvh">
-      <SidebarIsland onExpandedChange={onExpandedChange} />
+    <div className="reveal-shell">
+      <div className="reveal-page dot-grid">
+        <CursorGlow />
 
-      <div className="scrim" data-visible={dimmed} data-print="hide" aria-hidden />
+        <SidebarIsland onExpandedChange={onExpandedChange} />
 
-      <MobileDock />
+        <div className="scrim" data-visible={dimmed} data-print="hide" aria-hidden />
 
-      {/* On md+ the left offset clears the collapsed island and never reflows
-          when it expands: content shifting under a hover would be worse than
-          the dimming it replaces. On small screens the dock is at the bottom,
-          so the padding moves there to clear it. */}
-      <main className="px-4 pt-6 pb-28 md:py-6 md:pr-6 md:pl-24">
-        <Outlet />
-      </main>
+        <MobileDock />
+
+        {/* On md+ the left offset clears the collapsed island and never reflows
+            when it expands: content shifting under a hover would be worse than
+            the dimming it replaces. On small screens the dock is at the bottom,
+            so the padding moves there to clear it. */}
+        <main className="px-4 pt-6 pb-28 md:py-6 md:pr-6 md:pl-24">
+          <Outlet />
+        </main>
+      </div>
+
+      <SiteFooter />
     </div>
   )
 }

--- a/frontend/src/shell/MarketingShell.tsx
+++ b/frontend/src/shell/MarketingShell.tsx
@@ -1,72 +1,25 @@
-import { ArrowRight } from 'lucide-react'
-import { useEffect, useRef } from 'react'
 import { Link, Outlet } from 'react-router-dom'
 import { CursorGlow } from '../ui/CursorGlow.js'
 import { Mark } from '../ui/Mark.js'
 import { ThemeToggle } from '../ui/ThemeToggle.js'
 import { Wordmark } from '../ui/Wordmark.js'
+import { SiteFooter } from './SiteFooter.js'
 
 /**
  * The public shell: everything an evaluator sees before signing in.
  *
- * Its one structural idea is the footer. The page is an opaque sheet and the
- * footer is a fixed layer underneath it, so reaching the bottom slides the
- * sheet off something that was there all along rather than scrolling a panel
- * into view. The mechanics live in `.marketing-page` / `.marketing-footer`
- * because they are two rules that have to agree about one number, and that
- * agreement is easier to see and to keep in CSS than spread across class
- * strings on two elements.
- *
- * The footer is deliberately the loudest surface in the product. It is the one
- * place where the three residency claims and the three safeguards can be
- * stated together as plain facts, and a reviewer who scrolls to the end of the
- * landing page is exactly the reader those facts are for.
+ * Its one structural idea is the footer, and that now belongs to both shells,
+ * so it lives in `SiteFooter`. What is left here is the top bar and the layer
+ * that occludes the footer until the page is scrolled off it.
  */
-
-const SAFEGUARDS = [
-  'Identifiers are tokenised before any model call',
-  'Red-flag rules run as code, never as a prompt',
-  'The treating doctor approves every note',
-]
-
-const RESIDENCY = [
-  ['Application', 'Vercel · Singapore'],
-  ['API', 'Render · Singapore'],
-  ['Database', 'Supabase · Singapore'],
-]
-
 export function MarketingShell() {
-  const footer = useRef<HTMLElement>(null)
-
-  /*
-   * The one thing the layering gets wrong on its own.
-   *
-   * A fixed element's rect is always inside the viewport, so the browser sees
-   * no reason to scroll when focus reaches a footer link, and a keyboard user
-   * lands on a focus ring the page is currently covering. Scrolling to the end
-   * puts the focused link where it can be seen.
-   *
-   * Guarded on `fixed`: below md the footer is in normal flow and the
-   * browser's own scroll-into-view is already right.
-   */
-  useEffect(() => {
-    const node = footer.current
-    if (!node) return
-    const reveal = () => {
-      if (getComputedStyle(node).position !== 'fixed') return
-      window.scrollTo({ top: document.documentElement.scrollHeight })
-    }
-    node.addEventListener('focusin', reveal)
-    return () => node.removeEventListener('focusin', reveal)
-  }, [])
-
   return (
-    <div className="marketing-shell">
-      <div className="marketing-page">
+    <div className="reveal-shell">
+      <div className="reveal-page dot-grid">
         <CursorGlow />
 
-        <header className="sticky top-0 z-10 glass border-x-0 border-t-0 rounded-none">
-          <div className="mx-auto flex h-16 max-w-5xl items-center justify-between px-6">
+        <header className="sticky top-0 z-10 glass rounded-none border-x-0 border-t-0">
+          <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
             <Link to="/" className="flex items-center gap-2" aria-label="CatatMD home">
               <Mark className="size-6 text-accent" />
               <Wordmark className="text-xl" />
@@ -86,59 +39,7 @@ export function MarketingShell() {
         <Outlet />
       </div>
 
-      <footer ref={footer} className="marketing-footer">
-        <div className="mx-auto flex h-full max-w-5xl flex-col justify-center px-6 py-10">
-          <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-[1.6fr_1fr_1fr] md:gap-10">
-            <div className="sm:col-span-2 md:col-span-1">
-              <span className="flex items-center gap-2">
-                <Mark className="size-6" />
-                <Wordmark tone="inverse" className="text-xl" />
-              </span>
-              <p className="mt-3 max-w-xs text-sm leading-relaxed text-accent-ink">
-                A GP consultation transcript becomes a structured note you review, edit and approve.
-                It does not diagnose.
-              </p>
-              <Link
-                to="/login"
-                className="mt-5 inline-flex h-10 items-center gap-2 rounded-pill border border-accent-ink/35 px-5 text-sm font-medium text-accent-ink transition-[background-color,transform] duration-150 ease-out-quart hover:bg-accent-ink/12 active:scale-[0.97]"
-              >
-                Try the Demo
-                <ArrowRight aria-hidden className="size-4" />
-              </Link>
-            </div>
-
-            <div>
-              <h2 className="text-sm font-semibold text-accent-ink">Safeguards</h2>
-              <ul className="mt-3 flex flex-col gap-2 text-sm leading-snug text-accent-ink">
-                {SAFEGUARDS.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
-            </div>
-
-            <div>
-              <h2 className="text-sm font-semibold text-accent-ink">Hosted in Singapore</h2>
-              <dl className="mt-3 flex flex-col gap-2 text-sm leading-snug text-accent-ink">
-                {RESIDENCY.map(([tier, where]) => (
-                  <div key={tier} className="flex flex-wrap gap-x-2">
-                    <dt className="font-medium">{tier}</dt>
-                    <dd>{where}</dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-          </div>
-
-          <div className="mt-8 flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-t border-accent-ink/20 pt-5 text-xs text-accent-ink">
-            <span>
-              Prototype for evaluation. Not a registered medical device. Simulated data only.
-            </span>
-            <Link to="/privacy" className="underline underline-offset-2">
-              Privacy and Data Protection
-            </Link>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   )
 }

--- a/frontend/src/shell/SiteFooter.tsx
+++ b/frontend/src/shell/SiteFooter.tsx
@@ -1,0 +1,111 @@
+import { ArrowRight } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { cn } from '../lib/cn.js'
+import { Mark } from '../ui/Mark.js'
+import { Wordmark } from '../ui/Wordmark.js'
+
+/**
+ * The layer the page is lying on top of, shared by both shells.
+ *
+ * It is fixed to the bottom of the viewport for the whole session while the
+ * page above it is opaque, so scrolling to the end uncovers something that was
+ * always there rather than scrolling a panel into view. Nothing animates; the
+ * occluder simply moves. See `.reveal-page` / `.site-footer`.
+ *
+ * Signed-in pages get it too. The safeguards and the residency claims are not
+ * marketing copy that stops being true after login, and a product whose every
+ * screen just ends is the "skeleton" feeling this redesign is answering.
+ */
+
+const SAFEGUARDS = [
+  'Identifiers are tokenised before any model call',
+  'Red-flag rules run as code, never as a prompt',
+  'The treating doctor approves every note',
+]
+
+const RESIDENCY = [
+  ['Application', 'Vercel · Singapore'],
+  ['API', 'Render · Singapore'],
+  ['Database', 'Supabase · Singapore'],
+]
+
+export function SiteFooter({ className }: { className?: string }) {
+  const footer = useRef<HTMLElement>(null)
+
+  /*
+   * A fixed element's rect is always inside the viewport, so the browser sees
+   * no reason to scroll when focus reaches a footer link, and a keyboard user
+   * lands on a focus ring the page is currently covering. Scrolling to the end
+   * puts the focused link where it can be seen.
+   *
+   * Guarded on `fixed`: below md the footer is in normal flow and the browser's
+   * own scroll-into-view is already right.
+   */
+  useEffect(() => {
+    const node = footer.current
+    if (!node) return
+    const reveal = () => {
+      if (getComputedStyle(node).position !== 'fixed') return
+      window.scrollTo({ top: document.documentElement.scrollHeight })
+    }
+    node.addEventListener('focusin', reveal)
+    return () => node.removeEventListener('focusin', reveal)
+  }, [])
+
+  return (
+    <footer ref={footer} className={cn('site-footer', className)} data-print="hide">
+      <div className="mx-auto flex h-full max-w-6xl flex-col justify-center px-6 py-10">
+        <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-[1.6fr_1fr_1fr] md:gap-10">
+          <div className="sm:col-span-2 md:col-span-1">
+            <span className="flex items-center gap-2">
+              <Mark className="size-6" />
+              <Wordmark tone="inverse" className="text-xl" />
+            </span>
+            <p className="mt-3 max-w-xs text-sm leading-relaxed text-accent-ink">
+              A GP consultation transcript becomes a structured note you review, edit and approve.
+              It does not diagnose.
+            </p>
+            <Link
+              to="/login"
+              className="mt-5 inline-flex h-10 items-center gap-2 rounded-pill border border-accent-ink/35 px-5 text-sm font-medium text-accent-ink transition-[background-color,transform] duration-150 ease-out-quart hover:bg-accent-ink/12 active:scale-[0.97]"
+            >
+              Try the Demo
+              <ArrowRight aria-hidden className="size-4" />
+            </Link>
+          </div>
+
+          <div>
+            <h2 className="text-sm font-semibold text-accent-ink">Safeguards</h2>
+            <ul className="mt-3 flex flex-col gap-2 text-sm leading-snug text-accent-ink">
+              {SAFEGUARDS.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h2 className="text-sm font-semibold text-accent-ink">Hosted in Singapore</h2>
+            <dl className="mt-3 flex flex-col gap-2 text-sm leading-snug text-accent-ink">
+              {RESIDENCY.map(([tier, where]) => (
+                <div key={tier} className="flex flex-wrap gap-x-2">
+                  <dt className="font-medium">{tier}</dt>
+                  <dd>{where}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </div>
+
+        <div className="mt-8 flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-t border-accent-ink/20 pt-5 text-xs text-accent-ink">
+          <span>
+            Prototype for evaluation. Not a registered medical device. Simulated data only.
+          </span>
+          <Link to="/privacy" className="underline underline-offset-2">
+            Privacy and Data Protection
+          </Link>
+        </div>
+      </div>
+    </footer>
+  )
+}


### PR DESCRIPTION
## The Glass Bug

Glassmorphism was shipping broken, **and only in production**.

`.glass` and `.scrim` each declared `backdrop-filter` before its `-webkit-` prefixed twin. The minifier treats that pair as one property declared twice, keeps the last, and the standard property never reaches the bundle:

```css
/* shipped before */
.glass{ -webkit-backdrop-filter:blur(20px)saturate(150%); ... }   /* standard property gone */
```

Chromium computed `backdrop-filter: none`, so the chrome read as flat 72%-opaque white and the sidebar never blurred what sat behind it. **Dev looked correct throughout, because dev does not minify** — which is why this survived a previous round of verification that was done against the dev server.

Fix is ordering: prefix first, standard last. Verified by grepping the built CSS, then by computed style against `vite preview` on the production bundle:

| | before | after |
| --- | --- | --- |
| `.glass` | `none` | `blur(20px) saturate(1.5)` |
| `.scrim` | `none` | `blur(8px)` |

## Texture Is the Other Half

A blur has nothing to operate on over a flat fill. The signed-in shell had no pattern behind its chrome, so even a working `backdrop-filter` would have looked like plain translucency. The dot grid now backs both shells.

## The Rest

- **Pointer trail and footer extended into the app shell.** The safeguards and residency claims do not stop being true after login, and a screen that simply ends is the emptiness this redesign is answering.
- Both shells share one reveal mechanism and one `SiteFooter`, so the classes drop their `marketing-` prefix (`reveal-shell`, `reveal-page`, `site-footer`).
- **Thin theme-aware scrollbar** in both engines: `scrollbar-width`/`scrollbar-color` for Firefox, `::-webkit-scrollbar-*` for Chromium. Transparent track, ink-hue thumb at low alpha, inset via a transparent border.
- Content columns widened `max-w-3xl` → `max-w-4xl`, shells `max-w-5xl` → `max-w-6xl`.

## Clinical-Safety Checklist

- [x] No egress path touched. No change under `deid/`, `lib/llm/`, `redflags/` or `guidelines/`.
- [x] No PHI in logs or new surfaces. Presentation only.
- [x] Nothing auto-approves; approval remains explicit.
- [x] Glass remains chrome-only. No clinical text sits on a translucent surface.
- [x] Print unaffected: footer carries `data-print="hide"`, scrim already hidden.

## Verification

All checks run against the **production build**, not dev:

- Built CSS greps: `backdrop-filter:blur(20px)`, `scrollbar-width:thin`, `::-webkit-scrollbar-thumb`, `.dot-grid`, `.site-footer`, `.reveal-page` all present
- `vite preview` + real API, signed in as guest: glass and scrim backdrops confirmed by computed style, sidebar expansion blurs the content behind it, dot grid and trail present in the app shell, footer fixed
- Lint, typecheck, build clean

## Known Gap

`/consultations/:id` still needs a further layout and content-delivery pass; not attempted here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared site footer with demo and privacy links, safeguards, hosting details, and medical-device information.
  * Added consistent cursor-glow and dot-grid visual treatments across application and marketing pages.
  * Added themed scrollbar styling for light and dark modes.

* **Improvements**
  * Expanded the content area on consultation and guidelines pages for improved readability.
  * Improved responsive layouts and keyboard accessibility for page footers.
  * Refined backdrop effects and mobile reveal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->