### PR TITLE
chore: seed the guest demo account with a spread of consultations

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:migrate": "bunx prisma migrate dev --schema prisma/schema.prisma",
     "db:migrate:deploy": "bunx prisma migrate deploy --schema prisma/schema.prisma",
     "db:seed": "bun run --cwd shared build && bunx tsx prisma/seed.ts",
+    "db:seed:demo": "bun run --cwd shared build && bunx tsx prisma/seed-demo.ts",
     "db:studio": "bunx prisma studio --schema prisma/schema.prisma",
     "prisma:generate": "bunx prisma generate --schema prisma/schema.prisma",
     "lint": "biome check .",

--- a/prisma/seed-demo.ts
+++ b/prisma/seed-demo.ts
@@ -1,0 +1,131 @@
+import { FIXTURES } from '../backend/src/fixtures/index.js'
+
+/**
+ * Seeds the shared guest account with a spread of consultations for a live
+ * demo (GitHub issue #29 for the account itself).
+ *
+ * Everything goes through the HTTP API rather than direct database writes. The
+ * consultation lifecycle carries invariants that live in the routes, not the
+ * schema: the append-only audit trail and its hash chain (docs/trd.md §15), the
+ * analysis version stamp, and the approval state transition. Inserting rows by
+ * hand would produce a database that looks right and an audit log that does not
+ * describe it.
+ *
+ * Idempotent by skipping, not by deleting. There is no delete endpoint, and
+ * deleting a consultation directly would cascade to its `AuditEvent` rows and
+ * break the chain (GitHub issue #64). A second run therefore fills in whatever
+ * is missing and leaves existing consultations alone.
+ */
+
+const BASE = process.env.DEMO_SEED_BASE_URL ?? 'http://localhost:3001'
+
+/** Target state per fixture, chosen so the demo list shows every screen path. */
+const DEMO_PLAN = [
+  { fixtureId: 'urti-gap-heavy', target: 'awaiting_review' },
+  { fixtureId: 'urti-hard-red-flag', target: 'awaiting_review' },
+  { fixtureId: 'urti-diagnosis-not-assessed', target: 'awaiting_review' },
+  { fixtureId: 'urti-identifier-dense-routine', target: 'approved' },
+  { fixtureId: 'urti-hard-uncertain', target: 'draft' },
+] as const
+
+type Target = (typeof DEMO_PLAN)[number]['target']
+
+let cookie = ''
+
+async function api(path: string, init?: RequestInit): Promise<Response> {
+  const response = await fetch(`${BASE}/api${path}`, {
+    ...init,
+    headers: {
+      ...(init?.body ? { 'content-type': 'application/json' } : {}),
+      ...(cookie ? { cookie } : {}),
+      ...init?.headers,
+    },
+  })
+
+  const setCookie = response.headers.getSetCookie()
+  if (setCookie.length > 0) {
+    cookie = setCookie.map((c) => c.split(';')[0]).join('; ')
+  }
+
+  return response
+}
+
+async function expectOk(response: Response, what: string): Promise<unknown> {
+  if (!response.ok) {
+    throw new Error(`${what} failed: ${response.status} ${await response.text()}`)
+  }
+  return response.json()
+}
+
+/** The first patient turn is what identifies a fixture in an existing row. */
+function signature(turns: readonly { speaker: string; text: string }[]): string {
+  return turns.find((turn) => turn.speaker === 'patient')?.text ?? turns[0]?.text ?? ''
+}
+
+async function existingSignatures(): Promise<Set<string>> {
+  const list = (await expectOk(await api('/consultations'), 'list consultations')) as {
+    consultations: { id: string }[]
+  }
+
+  const signatures = new Set<string>()
+  for (const row of list.consultations) {
+    const detail = (await expectOk(
+      await api(`/consultations/${row.id}`),
+      `read consultation ${row.id}`,
+    )) as { consultation: { transcript?: { turns?: { speaker: string; text: string }[] } } }
+
+    const turns = detail.consultation.transcript?.turns
+    if (turns) signatures.add(signature(turns))
+  }
+  return signatures
+}
+
+async function seedOne(fixtureId: string, target: Target): Promise<string> {
+  const fixture = FIXTURES.find((f) => f.id === fixtureId)
+  if (!fixture) throw new Error(`fixture ${fixtureId} not found`)
+
+  const created = (await expectOk(
+    await api('/consultations', {
+      method: 'POST',
+      body: JSON.stringify({ transcript: fixture.transcript }),
+    }),
+    `create ${fixtureId}`,
+  )) as { consultation: { id: string } }
+
+  const id = created.consultation.id
+  if (target === 'draft') return `${fixtureId}: draft`
+
+  await expectOk(await api(`/consultations/${id}/analyze`, { method: 'POST' }), `analyze ${id}`)
+  if (target === 'awaiting_review') return `${fixtureId}: analysed`
+
+  await expectOk(await api(`/consultations/${id}/approve`, { method: 'POST' }), `approve ${id}`)
+  return `${fixtureId}: analysed and approved`
+}
+
+async function main() {
+  await expectOk(await api('/auth/guest', { method: 'POST' }), 'guest sign-in')
+
+  const present = await existingSignatures()
+  console.log(`· guest account currently holds ${present.size} consultation(s)`)
+
+  for (const { fixtureId, target } of DEMO_PLAN) {
+    const fixture = FIXTURES.find((f) => f.id === fixtureId)
+    if (!fixture) {
+      console.log(`! ${fixtureId} not in the fixture corpus, skipped`)
+      continue
+    }
+
+    if (present.has(signature(fixture.transcript.turns))) {
+      console.log(`· ${fixtureId} already present, skipped`)
+      continue
+    }
+
+    console.log(`  ${fixtureId}: seeding to ${target} ...`)
+    console.log(`✓ ${await seedOne(fixtureId, target)}`)
+  }
+}
+
+main().catch((err) => {
+  console.error('Demo seed failed:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})


### PR DESCRIPTION
Live-demo prep, requested by @AlaskanTuna. The guest account held one consultation and showed an almost-empty list.

## What This Does

`bun run db:seed:demo` fills the shared guest account with a spread of consultations built from the five bundled fixtures, so every screen path is visible in a demo.

| Fixture                        | Seeded state      | What it shows                                   |
| ------------------------------ | ----------------- | ------------------------------------------------- |
| `urti-gap-heavy`               | `awaiting_review` | Gap-heavy incomplete consultation                 |
| `urti-hard-red-flag`           | `awaiting_review` | Hard red flag (pre-existing, left alone)          |
| `urti-diagnosis-not-assessed`  | `awaiting_review` | Diagnosis `NOT_ASSESSED`                          |
| `urti-identifier-dense-routine`| `approved`        | The Export path, and de-identification under load |
| `urti-hard-uncertain`          | `draft`           | An unanalysed draft                               |

**Already run.** Production now serves 5 consultations: 3 awaiting review, 1 approved, 1 draft.

## Two Design Choices Worth Stating

**It goes through the HTTP API, not direct database writes.** The consultation lifecycle carries invariants that live in the routes rather than the schema: the append-only audit trail and its hash chain (§15), the analysis version stamp, and the approval transition. Inserting rows by hand would produce a database that looks right next to an audit log that does not describe it.

**Idempotent by skipping, never by deleting.** There is no delete endpoint, and deleting a consultation would cascade to its `AuditEvent` rows and break the chain, which is exactly #64. A second run fills in what is missing and leaves everything else alone. Verified: the first run skipped the pre-existing red-flag consultation, and an immediate re-run skipped all five and created nothing.

## A Finding That Cancels A Suspected Bug

A concern was raised that the gap detector over-generates, from one consultation showing 27 missing-information items. Measured across all four analyses:

| Fixture                         | Gaps | Red flags |
| ------------------------------- | ---- | --------- |
| `urti-hard-red-flag`            | 27   | 4         |
| `urti-gap-heavy`                | 24   | 0         |
| `urti-diagnosis-not-assessed`   | 26   | 2         |
| `urti-identifier-dense-routine` | **7**| 3         |

The last row is the answer. That fixture is labelled "Routine **complete** URTI consult", and it produces 7 gaps where the sparse ones produce 24 to 27. **The detector discriminates correctly.** It measures completeness against a fixed 29-field checklist, and 27 is a property of a sparse transcript rather than a defect.

I also checked the other candidate explanation, that missing evidence spans were downgrading assertions to `NOT_ASSESSED` and inflating the count. The audit trail records `discardedFieldIds`, and it was **empty** for that consultation, so nothing was downgraded. The gaps are genuine.

That contrast is arguably the demo's strongest moment: a sparse consultation surfacing 27 missing items beside a thorough one surfacing 7 is the product's value proposition on one screen.

## Clinical-Safety Checklist

Not applicable. This adds a development seeding script and one `package.json` entry. It changes no application code, touches no `deid/`, `lib/llm/`, `redflags/` or `guidelines/`, and writes only synthetic fixture transcripts that already ship in the repository.
