### PR TITLE
feat(db): erase consultation content by tombstone, keeping the audit chain intact

### DIFF
--- a/backend/src/audit/audit.test.ts
+++ b/backend/src/audit/audit.test.ts
@@ -144,6 +144,7 @@ describe('recordAuditEvent', () => {
       },
       { action: 'consultation.analysis_failed', metadata: { reason: 'internal_error' } },
       { action: 'consultation.edited' },
+      { action: 'consultation.erased' },
       { action: 'redflag.acknowledged', metadata: { redFlagId: 'rf-1' } },
       { action: 'gap.reviewed', metadata: { gapId: 'gap-1' } },
       { action: 'consultation.approved' },

--- a/backend/src/audit/erasure.test.ts
+++ b/backend/src/audit/erasure.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { eraseConsultation } from './erasure.js'
+import { type AuditChainRow, recordAuditEvent, verifyAuditChainFromDatabase } from './index.js'
+
+type ConsultationRow = {
+  id: string
+  doctorId: string
+  transcript: unknown
+  analysis: unknown
+  editedNote: unknown
+  erasedAt: Date | null
+}
+
+const consultations = new Map<string, ConsultationRow>()
+const appended: AuditChainRow[] = []
+
+vi.mock('../lib/prisma.js', () => {
+  const databaseNull = (value: unknown) =>
+    typeof value === 'object' && value !== null && String(value) === 'Prisma.DbNull' ? null : value
+
+  const auditEvent = {
+    create: vi.fn(async ({ data }: { data: AuditChainRow }) => {
+      appended.push(data)
+      return data
+    }),
+    findFirst: vi.fn(async () => {
+      const head = appended.at(-1)
+      return head === undefined ? null : { hash: head.hash }
+    }),
+    findMany: vi.fn(async () => appended),
+  }
+
+  return {
+    prisma: {
+      consultation: {
+        findFirst: vi.fn(
+          async ({ where }: { where: { id: string; doctorId: string; erasedAt: null } }) => {
+            const row = consultations.get(where.id)
+            return row?.doctorId === where.doctorId && row.erasedAt === where.erasedAt
+              ? { ...row }
+              : null
+          },
+        ),
+        update: vi.fn(
+          async ({ where, data }: { where: { id: string }; data: Partial<ConsultationRow> }) => {
+            const row = consultations.get(where.id)
+            if (!row) throw new Error('Consultation not found')
+            const updated = {
+              ...row,
+              ...data,
+              transcript: databaseNull(data.transcript),
+              analysis: databaseNull(data.analysis),
+              editedNote: databaseNull(data.editedNote),
+            }
+            consultations.set(where.id, updated)
+            return { ...updated }
+          },
+        ),
+      },
+      auditEvent,
+      $transaction: vi.fn((run: (tx: { auditEvent: typeof auditEvent }) => unknown) =>
+        run({ auditEvent }),
+      ),
+    },
+  }
+})
+
+beforeEach(() => {
+  consultations.clear()
+  appended.length = 0
+  consultations.set('consult-1', {
+    id: 'consult-1',
+    doctorId: 'doctor-1',
+    transcript: { turns: [{ speaker: 'patient', text: 'I am Ahmad with a cough' }] },
+    analysis: { note: { subjective: 'Ahmad reports cough' } },
+    editedNote: { subjective: 'Doctor note about Ahmad' },
+    erasedAt: null,
+  })
+})
+
+describe('eraseConsultation', () => {
+  it('clears patient-derived content while preserving a verifiable audit chain', async () => {
+    await recordAuditEvent({
+      action: 'consultation.created',
+      actorId: 'doctor-1',
+      consultationId: 'consult-1',
+    })
+    await recordAuditEvent({
+      action: 'consultation.edited',
+      actorId: 'doctor-1',
+      consultationId: 'consult-1',
+    })
+
+    await eraseConsultation('consult-1', 'doctor-1')
+
+    expect(consultations.get('consult-1')).toMatchObject({
+      id: 'consult-1',
+      transcript: null,
+      analysis: null,
+      editedNote: null,
+      erasedAt: expect.any(Date),
+    })
+    expect(appended.at(-1)).toMatchObject({
+      action: 'consultation.erased',
+      actorId: 'doctor-1',
+      consultationId: 'consult-1',
+    })
+    await expect(verifyAuditChainFromDatabase()).resolves.toMatchObject({ ok: true, verified: 3 })
+  })
+})

--- a/backend/src/audit/erasure.ts
+++ b/backend/src/audit/erasure.ts
@@ -1,0 +1,24 @@
+import { Prisma } from '@prisma/client'
+import { assertOwnedConsultation } from '../lib/authz.js'
+import { prisma } from '../lib/prisma.js'
+import { recordAuditEvent } from './index.js'
+
+export async function eraseConsultation(consultationId: string, actorId: string): Promise<void> {
+  await assertOwnedConsultation(consultationId, actorId)
+
+  await prisma.consultation.update({
+    where: { id: consultationId },
+    data: {
+      transcript: Prisma.DbNull,
+      analysis: Prisma.DbNull,
+      editedNote: Prisma.DbNull,
+      erasedAt: new Date(),
+    },
+  })
+
+  await recordAuditEvent({
+    action: 'consultation.erased',
+    actorId,
+    consultationId,
+  })
+}

--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -72,6 +72,7 @@ export type ConsultationAuditEvent =
     }
   | { action: 'consultation.analysis_failed'; metadata: { reason: AnalysisFailureReason } }
   | { action: 'consultation.edited' }
+  | { action: 'consultation.erased' }
   | { action: 'redflag.acknowledged'; metadata: { redFlagId: string } }
   | { action: 'gap.reviewed'; metadata: { gapId: string } }
   | { action: 'consultation.approved' }

--- a/backend/src/lib/authz.test.ts
+++ b/backend/src/lib/authz.test.ts
@@ -13,16 +13,21 @@ vi.mock('./prisma.js', () => ({
  * the `where` clause would pass no matter what the helper did.
  */
 const ROWS = [
-  { id: 'consult-aisyah', doctorId: 'doctor-aisyah' },
-  { id: 'consult-lim', doctorId: 'doctor-lim' },
-  { id: 'consult-guest', doctorId: 'guest' },
+  { id: 'consult-aisyah', doctorId: 'doctor-aisyah', erasedAt: null },
+  { id: 'consult-lim', doctorId: 'doctor-lim', erasedAt: null },
+  { id: 'consult-guest', doctorId: 'guest', erasedAt: null },
+  { id: 'consult-erased', doctorId: 'doctor-aisyah', erasedAt: new Date('2026-08-14T00:00:00Z') },
 ]
 
 beforeEach(() => {
   vi.mocked(prisma.consultation.findFirst).mockImplementation(
-    (async (args: { where: { id: string; doctorId: string } }) =>
-      ROWS.find((r) => r.id === args.where.id && r.doctorId === args.where.doctorId) ??
-      null) as never,
+    (async (args: { where: { id: string; doctorId: string; erasedAt?: null } }) =>
+      ROWS.find(
+        (r) =>
+          r.id === args.where.id &&
+          r.doctorId === args.where.doctorId &&
+          (args.where.erasedAt === undefined || r.erasedAt === args.where.erasedAt),
+      ) ?? null) as never,
   )
 })
 
@@ -37,8 +42,15 @@ describe('assertOwnedConsultation', () => {
     await assertOwnedConsultation('consult-aisyah', 'doctor-aisyah').catch(() => {})
 
     expect(prisma.consultation.findFirst).toHaveBeenCalledWith({
-      where: { id: 'consult-aisyah', doctorId: 'doctor-aisyah' },
+      where: { id: 'consult-aisyah', doctorId: 'doctor-aisyah', erasedAt: null },
     })
+  })
+
+  it('treats an erased consultation as not found', async () => {
+    const error = await assertOwnedConsultation('consult-erased', 'doctor-aisyah').catch((e) => e)
+
+    expect(error).toBeInstanceOf(HttpError)
+    expect(error.status).toBe(404)
   })
 
   it('raises 404 — never 403 — when the consultation belongs to another doctor', async () => {

--- a/backend/src/lib/authz.ts
+++ b/backend/src/lib/authz.ts
@@ -14,7 +14,7 @@ import { prisma } from './prisma.js'
  */
 export async function assertOwnedConsultation(id: string, doctorId: string): Promise<Consultation> {
   const consultation = await prisma.consultation.findFirst({
-    where: { id, doctorId },
+    where: { id, doctorId, erasedAt: null },
   })
 
   if (!consultation) {

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -130,11 +130,19 @@ let chainHead: string | null = null
 vi.mock('../lib/prisma.js', () => ({
   prisma: {
     consultation: {
-      findFirst: vi.fn(async ({ where }: { where: { id: string; doctorId: string } }) => {
-        const row = store.get(where.id)
-        return row && row.doctorId === where.doctorId ? { ...row } : null
-      }),
-      findMany: vi.fn(async () => [...store.values()]),
+      findFirst: vi.fn(
+        async ({ where }: { where: { id: string; doctorId: string; erasedAt: null } }) => {
+          const row = store.get(where.id)
+          return row && row.doctorId === where.doctorId && row.erasedAt === where.erasedAt
+            ? { ...row }
+            : null
+        },
+      ),
+      findMany: vi.fn(async ({ where }: { where: { doctorId: string; erasedAt: null } }) =>
+        [...store.values()].filter(
+          (row) => row.doctorId === where.doctorId && row.erasedAt === where.erasedAt,
+        ),
+      ),
       create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
         const row = {
           id: 'c1',
@@ -145,6 +153,7 @@ vi.mock('../lib/prisma.js', () => ({
           approvedAt: null,
           acknowledgedRedFlagIds: null,
           reviewedGapIds: null,
+          erasedAt: null,
           ...data,
         }
         store.set(row.id as string, row)
@@ -199,6 +208,7 @@ function seed(status: string, extra: Record<string, unknown> = {}) {
     approvedAt: null,
     acknowledgedRedFlagIds: null,
     reviewedGapIds: null,
+    erasedAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...extra,
@@ -504,5 +514,17 @@ describe('ownership', () => {
     )
 
     expect(res.status).toBe(404)
+  })
+})
+
+describe('erased consultations', () => {
+  it('are absent from the list and return 404 on detail', async () => {
+    seed('awaiting_review', { erasedAt: new Date() })
+
+    const list = await call('GET', '/api/consultations')
+    const detail = await call('GET', '/api/consultations/c1')
+
+    expect((await list.json()) as { consultations: unknown[] }).toEqual({ consultations: [] })
+    expect(detail.status).toBe(404)
   })
 })

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -111,7 +111,7 @@ function classifyFailure(error: unknown): AnalysisFailureReason {
 
 consultationsRouter.get('/', async (req, res) => {
   const rows = await prisma.consultation.findMany({
-    where: { doctorId: doctorId(req) },
+    where: { doctorId: doctorId(req), erasedAt: null },
     orderBy: { updatedAt: 'desc' },
     select: { id: true, status: true, createdAt: true, updatedAt: true },
   })

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -700,11 +700,20 @@ Matches `docs/prd.md` §8 (Primary Flow) exactly: `draft →(create) draft →(a
 | `consultation.analysis_completed` | analyse pipeline succeeds                                            | `{ detected, discardedFieldIds, profileId, versions }` — see below        |
 | `consultation.analysis_failed`    | analyse pipeline throws                                              | `{ reason: string }` — a short failure category, never the raw error text |
 | `consultation.edited`             | `PATCH /api/consultations/:id`                                       | —                                                                         |
+| `consultation.erased`             | Retention process invokes the erase mechanism                        | None                                                                      |
 | `redflag.acknowledged`            | doctor acknowledges a red flag                                       | `{ redFlagId: string }`                                                   |
 | `gap.reviewed`                    | doctor marks an information gap reviewed                             | `{ gapId: string }`                                                       |
 | `consultation.approved`           | `POST /api/consultations/:id/approve`                                | —                                                                         |
 
 Every row also carries `actorId` (the authenticated doctor) and `consultationId` — both already `Built` (§4). Together the taxonomy covers every transition in `docs/prd.md` §8 (Primary Flow): create → analyse (start/complete/fail) → edit/acknowledge → approve.
+
+### Consultation Erasure Tombstones
+
+**Status: `Built`** (issue #64). Erasure does not delete the `Consultation` row. It clears `transcript`, `analysis`, and `editedNote`, then sets `erasedAt` and appends `consultation.erased`. The surviving tombstone retains only opaque system identifiers, workflow state, timestamps, and audit relationships. These values are not patient personal data because, after the content columns are cleared, nothing maps the opaque consultation identifier to a patient. The retained `doctorId` remains a staff-account relationship, not a patient identifier.
+
+`AuditEvent.consultationId` is a hash input, so `onDelete: SetNull` was rejected. Nulling that foreign key after an audit row was written would change the row's hash input and turn a deleted consultation into a hash mismatch. The audit relation therefore uses `onDelete: Restrict`, and existing audit rows are never edited, deleted, or re-hashed. The consultation id stays valid through the tombstone, preserving the chain by construction.
+
+The `User → Consultation` relation still uses `onDelete: Cascade`. With the audit relation restricted, a user deletion will now fail if it would cascade to a consultation with audit history. No user-deletion path is currently configured in the application or its better-auth integration. Any future account-deletion feature must make an explicit retention decision rather than bypassing this database constraint.
 
 **Why `consultation.asr_hosted_used` fires at creation rather than at consent.** The doctor's consent to hosted transcription happens in the browser, before a `Consultation` row exists — `docs/prd.md` §8 step 1 creates the row only once a `Transcript` does. An event written at the moment of consent would therefore have no `consultationId` to hang on, which is the one field that makes the audit trail navigable. The event is instead written by `POST /api/consultations` on the declared `source` (§3), which is the first point at which the fact and the consultation id coexist. The consequence is stated plainly: like `source` itself, this row records a **client-asserted** fact.
 

--- a/prisma/migrations/20260814000000_consultation_erasure_tombstone/migration.sql
+++ b/prisma/migrations/20260814000000_consultation_erasure_tombstone/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "consultation" ADD COLUMN "erasedAt" TIMESTAMP(3);
+
+-- DropForeignKey
+ALTER TABLE "audit_event" DROP CONSTRAINT "audit_event_consultationId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "audit_event" ADD CONSTRAINT "audit_event_consultationId_fkey" FOREIGN KEY ("consultationId") REFERENCES "consultation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,6 +105,7 @@ enum ConsultationStatus {
 model Consultation {
   id     String             @id @default(cuid())
   status ConsultationStatus @default(draft)
+  erasedAt DateTime?
 
   /// Owning doctor. Every read path scopes on this; see the authz helper.
   doctorId String
@@ -160,7 +161,7 @@ model AuditEvent {
   actor   User?   @relation(fields: [actorId], references: [id], onDelete: SetNull)
 
   consultationId String?
-  consultation   Consultation? @relation(fields: [consultationId], references: [id], onDelete: Cascade)
+  consultation   Consultation? @relation(fields: [consultationId], references: [id], onDelete: Restrict)
 
   @@index([consultationId, createdAt])
   @@index([actorId, createdAt])


### PR DESCRIPTION
Closes #64.

## The Design, And Why The Obvious Option Was Rejected

`computeAuditHash` (`backend/src/audit/chain.ts:39`) hashes:

```
prevHash | id | action | actorId | consultationId | createdAt
```

**`consultationId` is inside the hash.** That rules out `onDelete: SetNull`, which was the cheapest-looking candidate in the issue: nulling it would make the stored hash disagree with the row, turning an `orphaned` failure into a `hash_mismatch` one. That is strictly worse, because a hash mismatch reads as *this row was edited* rather than *its subject was lawfully erased*.

**`metadata` is not hashed**, so it is the only mutable surface on an audit row. That was not needed.

So the tombstone goes on the **Consultation**, and no audit row is touched at all:

- The `Consultation` row is never deleted. `eraseConsultation` clears `transcript`, `analysis` and `editedNote` to SQL `NULL`, then stamps `erasedAt`.
- The row and its id survive, so every `AuditEvent.consultationId` foreign key stays valid. **The chain is intact by construction, not by repair**, and no hash is recomputed.
- The erasure is itself an append-only `consultation.erased` event, chained like any other.
- `onDelete: Cascade` becomes `onDelete: Restrict`, so a hard delete of a consultation carrying audit history is now impossible at the database level. The invariant holds because the schema enforces it, not because a caller remembered.

## What Is Retained Carries No Personal Data

After erasure the row holds an opaque cuid, a status, a doctor id, timestamps and `erasedAt`. `acknowledgedRedFlagIds` and `reviewedGapIds` are arrays of rule and checklist ids from the versioned clinical content, not patient data. Every patient-derived column is nulled.

## Read Paths

Erased consultations are excluded from the list and behave as not-found on detail, through the existing `assertOwnedConsultation` helper. That keeps the established property that a caller cannot distinguish "not yours" from "does not exist", so no existence oracle is created.

## The User-Deletion Consequence, Investigated Rather Than Assumed

`Consultation.doctor` cascades from `User`, so under `Restrict` a user deletion would fail for any doctor holding consultations with audit history.

**Checked: no application or better-auth account-deletion path exists today.** So nothing breaks now. This is recorded in `docs/trd.md` §15 rather than worked around, because the correct resolution depends on whether a deleted doctor's audit history should survive them, and that is a policy question rather than a code one.

## Verification

The Codex worker's sandbox blocks socket binding, so its own run reported 4 HTTP suites failing with `EPERM` plus 3 environment failures. **Those were artifacts.** Re-run outside the sandbox:

```
Test Files  26 passed (26)
     Tests  305 passed (305)
```

305 up from 302, so 3 new tests and one new file. The regression the issue exists for is asserted directly:

```ts
await expect(verifyAuditChainFromDatabase()).resolves.toMatchObject({ ok: true, verified: 3 })
```

## Migration Already Applied

`20260814000000_consultation_erasure_tombstone` has been applied to the shared Supabase instance, per the flow in `docs/trd.md` §17 where migrations run from a developer machine against `DIRECT_URL` and are live before the API deploys.

**This ordering was deliberate.** The merged code filters on `erasedAt`, so merging before applying would have put production against a schema without that column. Verified against the live database afterwards:

```
audit chain: {"ok":true,"verified":37}
consultations: approved 1 · draft 1 · awaiting_review 3
erased rows: 0
```

The live chain verifies across all 37 events and the seeded demo data is untouched.

The migration is additive and safe: one nullable column, and a foreign key swapped to `ON DELETE RESTRICT`, which only constrains future deletes.

## Non-Goals Respected

No HTTP deletion endpoint. The issue gates that on the retention decision in §19 row 11, which is still open and owner-assigned. This builds the mechanism only.

## Clinical-Safety Checklist

The diff touches audit logging, so this is not optional.

- **De-identification:** untouched. No new egress path.
- **Red flags:** untouched.
- **Citations:** untouched.
- **Audit integrity:** strengthened. Hard deletion of an audited consultation is now impossible at the schema level rather than merely unused, and erasure is itself audited.
- **Logging:** the erasure event carries ids and the event type only, no content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consultation erasure, clearing transcripts, analysis, and edited notes while retaining audit history.
  - Erased consultations are marked and excluded from listings and detail views.
  - Added audit tracking for consultation erasure.

- **Bug Fixes**
  - Erased consultations now return a not-found response when accessed.

- **Documentation**
  - Documented consultation erasure behavior and audit-history retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->