### PR TITLE
style(ui): strengthen the glass, simplify the footer, and unify text casing

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,7 +55,7 @@
   --color-scrollbar-hover: oklch(0.245 0.008 160 / 0.38);
 
   /* Chrome only. Never behind text a doctor acts on. */
-  --color-glass: oklch(1 0 0 / 0.72);
+  --color-glass: oklch(1 0 0 / 0.58);
   --color-glass-line: oklch(1 0 0 / 0.55);
   --color-scrim: oklch(0.245 0.008 160 / 0.32);
 
@@ -157,7 +157,7 @@
     --color-scrollbar: oklch(0.945 0.004 160 / 0.2);
     --color-scrollbar-hover: oklch(0.945 0.004 160 / 0.34);
 
-    --color-glass: oklch(0.225 0.007 160 / 0.72);
+    --color-glass: oklch(0.225 0.007 160 / 0.6);
     --color-glass-line: oklch(1 0 0 / 0.1);
     --color-scrim: oklch(0.12 0.005 160 / 0.5);
   }
@@ -318,7 +318,7 @@
    * scroll to the bottom at the width that broke.
    */
   .reveal-shell {
-    --footer-h: 23rem;
+    --footer-h: 7.5rem;
   }
 
   /*
@@ -344,6 +344,13 @@
     /* Opaque, and that is the whole mechanism. A translucent page would show
      * the footer through itself from the first paint and the reveal would
      * never happen. */
+  }
+
+  /* The consultation review screen has no footer to reveal, so the reserve
+   * that uncovers it must go too, or the page ends in a screen of empty
+   * scroll. */
+  .reveal-page--no-footer {
+    margin-bottom: 0;
   }
 
   .site-footer {

--- a/frontend/src/review/NoteEditor.tsx
+++ b/frontend/src/review/NoteEditor.tsx
@@ -61,7 +61,7 @@ export function NoteEditor({
                     edited ? 'bg-accent/12 text-accent' : 'bg-sunken text-ink-muted',
                   )}
                 >
-                  {edited ? 'You edited this' : 'AI generated'}
+                  {edited ? 'You Edited This' : 'AI Generated'}
                 </span>
                 {!readOnly && !isEditing && (
                   <Button
@@ -85,7 +85,7 @@ export function NoteEditor({
                   value={draft}
                   onChange={(event) => setDraft(event.target.value)}
                   rows={5}
-                  className="w-full rounded-control border border-line bg-surface p-3 text-base leading-relaxed focus:border-accent"
+                  className="w-full rounded-control border border-line bg-surface p-3 text-sm leading-relaxed focus:border-accent"
                 />
                 <div className="mt-2 flex gap-2">
                   <Button
@@ -107,7 +107,7 @@ export function NoteEditor({
             ) : (
               <p
                 data-provenance={edited ? 'edited' : 'ai'}
-                className="mt-2 max-w-[68ch] whitespace-pre-wrap text-base leading-relaxed text-ink"
+                className="mt-2 max-w-[68ch] whitespace-pre-wrap text-sm leading-relaxed text-ink"
               >
                 {value || (
                   <span className="text-ink-muted">

--- a/frontend/src/review/SafetyCards.tsx
+++ b/frontend/src/review/SafetyCards.tsx
@@ -100,7 +100,7 @@ function ProvenanceMark({ source }: { source: RedFlag['source'] }) {
     </span>
   ) : (
     <span className="inline-flex items-center gap-1 rounded-full border border-dashed border-ink-muted/50 px-2 py-0.5 text-2xs font-medium text-ink-muted">
-      AI suggested
+      AI Suggested
     </span>
   )
 }
@@ -128,7 +128,7 @@ export function GapCard({
       data-tour="gap"
       className={cn(
         'rounded-card border border-dashed p-4 page-break-avoid',
-        reviewed ? 'border-line bg-sunken/40' : 'border-ink-muted/40',
+        reviewed ? 'border-line bg-sunken' : 'border-ink-muted/40 bg-surface',
       )}
     >
       <div className="flex items-start gap-2">
@@ -149,7 +149,7 @@ export function GapCard({
           </span>
         ) : (
           <Button size="sm" variant="ghost" onClick={onReview}>
-            Mark reviewed
+            Mark Reviewed
           </Button>
         )}
       </div>
@@ -211,7 +211,7 @@ export function SuggestionCard({
                     rel="noreferrer noopener"
                     className="mt-2 inline-block text-xs font-medium text-accent underline underline-offset-2"
                   >
-                    Open source
+                    Open Source
                   </a>
                 </div>
               )}

--- a/frontend/src/review/SafetyCards.tsx
+++ b/frontend/src/review/SafetyCards.tsx
@@ -211,7 +211,7 @@ export function SuggestionCard({
                     rel="noreferrer noopener"
                     className="mt-2 inline-block text-xs font-medium text-accent underline underline-offset-2"
                   >
-                    Open Source
+                    Open Guideline
                   </a>
                 </div>
               )}

--- a/frontend/src/routes/ConsultationReview.tsx
+++ b/frontend/src/routes/ConsultationReview.tsx
@@ -99,7 +99,7 @@ export function ConsultationReview() {
               onClick={() => setShowTranscript((value) => !value)}
               aria-expanded={showTranscript}
             >
-              {showTranscript ? 'Hide transcript' : 'Transcript'}
+              {showTranscript ? 'Hide Transcript' : 'Transcript'}
             </Button>
             {approved && (
               <Button icon={<Printer className="size-4" />} onClick={() => window.print()}>
@@ -258,7 +258,7 @@ export function ConsultationReview() {
                   aria-expanded={showAllGaps}
                   className="mt-1 self-start rounded-control px-2 py-1.5 text-sm font-medium text-accent transition-colors hover:bg-sunken"
                 >
-                  {showAllGaps ? 'Show fewer' : `Show all ${analysis.gaps.length} missing items`}
+                  {showAllGaps ? 'Show Fewer' : `Show All ${analysis.gaps.length} Missing Items`}
                 </button>
               )}
             </Panel>

--- a/frontend/src/routes/Landing.tsx
+++ b/frontend/src/routes/Landing.tsx
@@ -35,15 +35,15 @@ const CLAIMS = [
 
 const LIMITS = [
   {
-    term: 'Not a registered medical device',
+    term: 'Not a Registered Medical Device',
     body: 'It is a prototype built for evaluation, and no clinician has reviewed its output in a validation study.',
   },
   {
-    term: 'Not real patient data',
+    term: 'Not Real Patient Data',
     body: 'Every consultation in it is simulated and was written for testing. The system is not connected to any clinical record system.',
   },
   {
-    term: 'Not general practice',
+    term: 'Not General Practice',
     body: 'It is scoped to adult cough, sore throat, and related upper respiratory presentations, and it will tell you when a consultation falls outside that.',
   },
 ]

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -175,7 +175,7 @@ export function Login() {
             <p className="mt-8 text-xs text-ink-muted">
               By signing in you accept that this is an evaluation prototype.{' '}
               <Link to="/privacy" className="underline underline-offset-2 hover:text-ink">
-                Privacy and data protection
+                Privacy and Data Protection
               </Link>
             </p>
           </div>

--- a/frontend/src/routes/Privacy.tsx
+++ b/frontend/src/routes/Privacy.tsx
@@ -66,7 +66,7 @@ export function Privacy() {
           </p>
         </Section>
 
-        <Section title="Retention And Access">
+        <Section title="Retention and Access">
           <p>
             A consultation is visible only to the clinician account that created it. Access is
             checked on every request rather than assumed from a session. Actions that touch clinical
@@ -87,7 +87,7 @@ export function Privacy() {
           </p>
         </Section>
 
-        <Section title="Not A Medical Device">
+        <Section title="Not a Medical Device">
           <p>
             CatatMD does not diagnose and does not replace clinical judgement. It is not a
             registered medical device, and no clinician has reviewed its output in a validation

--- a/frontend/src/shell/AppShell.tsx
+++ b/frontend/src/shell/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useMatch } from 'react-router-dom'
+import { cn } from '../lib/cn.js'
 import { CursorGlow } from '../ui/CursorGlow.js'
 import { MobileDock } from './MobileDock.js'
 import { SidebarIsland } from './SidebarIsland.js'
@@ -21,9 +22,16 @@ export function AppShell() {
   const [dimmed, setDimmed] = useState(false)
   const onExpandedChange = useCallback((expanded: boolean) => setDimmed(expanded), [])
 
+  // The review screen is a working surface with a sticky approve bar, not a
+  // page that ends: the reveal footer is wrong there. `/consultations/new`
+  // matches the same pattern, so it is excluded explicitly rather than
+  // caught by the param shape.
+  const reviewMatch = useMatch('/consultations/:id')
+  const suppressFooter = reviewMatch != null && reviewMatch.params.id !== 'new'
+
   return (
     <div className="reveal-shell">
-      <div className="reveal-page dot-grid">
+      <div className={cn('reveal-page dot-grid', suppressFooter && 'reveal-page--no-footer')}>
         <CursorGlow />
 
         <SidebarIsland onExpandedChange={onExpandedChange} />
@@ -41,7 +49,7 @@ export function AppShell() {
         </main>
       </div>
 
-      <SiteFooter />
+      {!suppressFooter && <SiteFooter />}
     </div>
   )
 }

--- a/frontend/src/shell/MobileDock.tsx
+++ b/frontend/src/shell/MobileDock.tsx
@@ -14,8 +14,8 @@ import { ThemeToggle } from '../ui/ThemeToggle.js'
  * it to show four navigation targets would be theatre.
  */
 const ITEMS = [
-  { to: '/consultations', label: 'Consultations', icon: FileText, end: true },
   { to: '/consultations/new', label: 'New', icon: Plus, end: false },
+  { to: '/consultations', label: 'Consultations', icon: FileText, end: true },
   { to: '/guidelines', label: 'Guidelines', icon: BookMarked, end: false },
 ]
 

--- a/frontend/src/shell/SidebarIsland.tsx
+++ b/frontend/src/shell/SidebarIsland.tsx
@@ -113,12 +113,17 @@ export function SidebarIsland({
               to={to}
               end={to === '/consultations'}
               data-tour={tour}
+              // The active tint is /16 where every other active state in the app
+              // is /12. This is the only one painted on glass with the scrim
+              // behind it, and at the lowered glass alpha the /12 tint measured
+              // 4.05:1 with the island expanded. The extra 4% buys back AA
+              // without the accent reading as a filled chip.
               className={({ isActive }) =>
                 cn(
                   'flex h-11 items-center gap-3 rounded-control px-3',
                   'text-sm font-medium transition-colors duration-150',
                   isActive
-                    ? 'bg-accent/12 text-accent'
+                    ? 'bg-accent/16 text-accent'
                     : 'text-ink-muted hover:bg-sunken/60 hover:text-ink',
                 )
               }

--- a/frontend/src/shell/SidebarIsland.tsx
+++ b/frontend/src/shell/SidebarIsland.tsx
@@ -1,6 +1,6 @@
 import { BookMarked, FileText, Moon, PanelLeft, Plus, Sun } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import { NavLink } from 'react-router-dom'
+import { Link, NavLink } from 'react-router-dom'
 import { cn } from '../lib/cn.js'
 import { useTheme } from '../lib/theme.js'
 import { Mark } from '../ui/Mark.js'
@@ -17,8 +17,8 @@ interface Item {
 }
 
 const ITEMS: Item[] = [
+  { to: '/consultations/new', label: 'New Consultation', icon: Plus, tour: 'nav-new' },
   { to: '/consultations', label: 'Consultations', icon: FileText, tour: 'nav-consultations' },
-  { to: '/consultations/new', label: 'New consultation', icon: Plus, tour: 'nav-new' },
   { to: '/guidelines', label: 'Guidelines', icon: BookMarked, tour: 'nav-guidelines' },
 ]
 
@@ -92,7 +92,11 @@ export function SidebarIsland({
         expanded ? 'w-58' : 'w-16',
       )}
     >
-      <div className="flex items-center gap-2 px-2 py-3">
+      <Link
+        to="/"
+        aria-label="CatatMD home"
+        className="flex items-center gap-2 rounded-control px-2 py-3 transition-colors duration-150 hover:bg-sunken/60"
+      >
         <Mark className="size-6 text-accent" />
         <Wordmark
           className={cn(
@@ -100,7 +104,7 @@ export function SidebarIsland({
             expanded ? 'opacity-100' : 'pointer-events-none opacity-0',
           )}
         />
-      </div>
+      </Link>
 
       <ul className="mt-2 flex flex-1 flex-col gap-1">
         {ITEMS.map(({ to, label, icon: Icon, tour }) => (
@@ -150,7 +154,7 @@ export function SidebarIsland({
               expanded ? 'opacity-100' : 'pointer-events-none opacity-0',
             )}
           >
-            {resolved === 'dark' ? 'Light theme' : 'Dark theme'}
+            {resolved === 'dark' ? 'Light Theme' : 'Dark Theme'}
           </span>
         </button>
 
@@ -170,7 +174,7 @@ export function SidebarIsland({
               expanded ? 'opacity-100' : 'pointer-events-none opacity-0',
             )}
           >
-            {pinned ? 'Unpin' : 'Pin open'}
+            {pinned ? 'Unpin' : 'Pin Open'}
           </span>
         </button>
       </div>

--- a/frontend/src/shell/SiteFooter.tsx
+++ b/frontend/src/shell/SiteFooter.tsx
@@ -16,10 +16,15 @@ import { Wordmark } from '../ui/Wordmark.js'
  * "skeleton" feeling this redesign is answering.
  */
 
+/*
+ * Both destinations are reachable signed out, which is the constraint that
+ * decides this list rather than a judgement about what is interesting. The
+ * footer renders on the public landing page, and `/guidelines` is auth-gated,
+ * so a visitor clicking it was bounced to `/login` with the intent discarded.
+ */
 const LINKS = [
   { to: '/login', label: 'Try the Demo' },
   { to: '/privacy', label: 'Privacy and Data Protection' },
-  { to: '/guidelines', label: 'Guidelines' },
 ]
 
 export function SiteFooter({ className }: { className?: string }) {

--- a/frontend/src/shell/SiteFooter.tsx
+++ b/frontend/src/shell/SiteFooter.tsx
@@ -1,4 +1,3 @@
-import { ArrowRight } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { cn } from '../lib/cn.js'
@@ -13,21 +12,14 @@ import { Wordmark } from '../ui/Wordmark.js'
  * always there rather than scrolling a panel into view. Nothing animates; the
  * occluder simply moves. See `.reveal-page` / `.site-footer`.
  *
- * Signed-in pages get it too. The safeguards and the residency claims are not
- * marketing copy that stops being true after login, and a product whose every
- * screen just ends is the "skeleton" feeling this redesign is answering.
+ * Signed-in pages get it too: a product whose every screen just ends is the
+ * "skeleton" feeling this redesign is answering.
  */
 
-const SAFEGUARDS = [
-  'Identifiers are tokenised before any model call',
-  'Red-flag rules run as code, never as a prompt',
-  'The treating doctor approves every note',
-]
-
-const RESIDENCY = [
-  ['Application', 'Vercel · Singapore'],
-  ['API', 'Render · Singapore'],
-  ['Database', 'Supabase · Singapore'],
+const LINKS = [
+  { to: '/login', label: 'Try the Demo' },
+  { to: '/privacy', label: 'Privacy and Data Protection' },
+  { to: '/guidelines', label: 'Guidelines' },
 ]
 
 export function SiteFooter({ className }: { className?: string }) {
@@ -55,56 +47,27 @@ export function SiteFooter({ className }: { className?: string }) {
 
   return (
     <footer ref={footer} className={cn('site-footer', className)} data-print="hide">
-      <div className="mx-auto flex h-full max-w-6xl flex-col justify-center px-6 py-10">
-        <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-[1.6fr_1fr_1fr] md:gap-10">
-          <div className="sm:col-span-2 md:col-span-1">
-            <span className="flex items-center gap-2">
-              <Mark className="size-6" />
-              <Wordmark tone="inverse" className="text-xl" />
-            </span>
-            <p className="mt-3 max-w-xs text-sm leading-relaxed text-accent-ink">
-              A GP consultation transcript becomes a structured note you review, edit and approve.
-              It does not diagnose.
-            </p>
-            <Link
-              to="/login"
-              className="mt-5 inline-flex h-10 items-center gap-2 rounded-pill border border-accent-ink/35 px-5 text-sm font-medium text-accent-ink transition-[background-color,transform] duration-150 ease-out-quart hover:bg-accent-ink/12 active:scale-[0.97]"
-            >
-              Try the Demo
-              <ArrowRight aria-hidden className="size-4" />
+      <div className="mx-auto flex h-full max-w-6xl flex-col items-center justify-center gap-4 px-6 text-center">
+        <span className="flex items-center gap-2">
+          <Mark className="size-6" />
+          <Wordmark tone="inverse" className="text-xl" />
+        </span>
+
+        <nav
+          aria-label="Footer"
+          className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm font-medium text-accent-ink"
+        >
+          {LINKS.map(({ to, label }) => (
+            <Link key={to} to={to} className="underline underline-offset-2 hover:no-underline">
+              {label}
             </Link>
-          </div>
+          ))}
+        </nav>
 
-          <div>
-            <h2 className="text-sm font-semibold text-accent-ink">Safeguards</h2>
-            <ul className="mt-3 flex flex-col gap-2 text-sm leading-snug text-accent-ink">
-              {SAFEGUARDS.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
-          </div>
-
-          <div>
-            <h2 className="text-sm font-semibold text-accent-ink">Hosted in Singapore</h2>
-            <dl className="mt-3 flex flex-col gap-2 text-sm leading-snug text-accent-ink">
-              {RESIDENCY.map(([tier, where]) => (
-                <div key={tier} className="flex flex-wrap gap-x-2">
-                  <dt className="font-medium">{tier}</dt>
-                  <dd>{where}</dd>
-                </div>
-              ))}
-            </dl>
-          </div>
-        </div>
-
-        <div className="mt-8 flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-t border-accent-ink/20 pt-5 text-xs text-accent-ink">
-          <span>
-            Prototype for evaluation. Not a registered medical device. Simulated data only.
-          </span>
-          <Link to="/privacy" className="underline underline-offset-2">
-            Privacy and Data Protection
-          </Link>
-        </div>
+        <p className="max-w-md text-xs text-accent-ink/80">
+          This is a prototype built for evaluation, not a registered medical device, and it uses
+          simulated data only.
+        </p>
       </div>
     </footer>
   )

--- a/frontend/src/ui/AssertionState.tsx
+++ b/frontend/src/ui/AssertionState.tsx
@@ -17,7 +17,7 @@ const LABELS: Record<AssertionState, string> = {
   PRESENT: 'Present',
   DENIED: 'Denied',
   CLINICIAN_OBSERVED: 'Observed',
-  NOT_ASSESSED: 'Not assessed',
+  NOT_ASSESSED: 'Not Assessed',
   UNKNOWN: 'Unknown',
   NOT_APPLICABLE: 'N/A',
 }

--- a/frontend/src/ui/CursorGlow.tsx
+++ b/frontend/src/ui/CursorGlow.tsx
@@ -21,7 +21,7 @@ import { useEffect, useRef } from 'react'
 const TRAIL = 14
 const HEAD_SIZE = 190
 const TAIL_SIZE = 34
-const HEAD_ALPHA = 0.06
+const HEAD_ALPHA = 0.04
 /** How hard each disc chases the one ahead. Lower is a longer, lazier tail. */
 const CHASE = 0.3
 

--- a/frontend/src/ui/ThemeToggle.tsx
+++ b/frontend/src/ui/ThemeToggle.tsx
@@ -20,7 +20,7 @@ export function ThemeToggle({ className }: { className?: string }) {
       type="button"
       onClick={() => setPreference(next)}
       aria-label={next === 'dark' ? 'Switch to dark theme' : 'Switch to light theme'}
-      title={next === 'dark' ? 'Dark theme' : 'Light theme'}
+      title={next === 'dark' ? 'Dark Theme' : 'Light Theme'}
       className={cn(
         'inline-flex size-10 items-center justify-center rounded-control',
         'text-ink-muted transition-colors duration-150 hover:bg-sunken hover:text-ink',


### PR DESCRIPTION
## What Changed

The chrome reads as frost rather than as flat translucency, the footer says three
things instead of nine, `/consultations/:id` no longer ends in a screen of dead
scroll, and the UI copy follows one casing rule instead of two.

## Why

A refinement pass on the fe-v2 shell, driven by review of the running app.

Two of the changes are corrections rather than polish, and both were found by
measurement:

- Lowering the glass alpha took the active sidebar item from 4.48:1 to 4.05:1
  while the island is expanded, which is the only state where its label is
  readable. Under AA, and caused by this branch. Scoped `/16` on that one nav
  item puts it back.
- The `Guidelines` link added to the new footer points at an authenticated
  route, and that footer also renders on the public landing page. A visitor
  clicking it was bounced to `/login` with the intent discarded. That is the
  evaluator-facing surface, so it is worth more than its size suggests.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manually exercised the affected flow

336 tests pass (31 shared, 305 backend and frontend). `npx impeccable detect`
returns 0 findings, confirmed non-vacuous against a control file that returned
`[bounce-easing]`. Nothing waived or suppressed.

Checked against a **production build**, not dev, because this repo has shipped
two bugs that dev could not see:

- The minified `dist` CSS keeps `-webkit-backdrop-filter` first and the standard
  `backdrop-filter` last on both `.glass` and `.scrim`. Written the other way the
  minifier keeps only the last and ships the prefix alone, which silently kills
  the frost in production.
- `bg-accent/16` compiles to `#136a5129`. A Tailwind class that resolves to
  nothing is the other failure this project has already hit.

Two things measured rather than eyeballed:

- The footer renders 117.45px, constant across seven widths from 769 to 1920px,
  so `--footer-h` is 7.5rem. Below `48rem` the footer stays `static`/`auto` with
  the reserve at 0.
- The route matrix was run through the project's own `matchPath`: `/consultations`
  and `/consultations/new` keep their footer, `/consultations/<uuid>` does not.

## Clinical-Safety Checklist

Frontend-only diff, but the review surface renders red flags, so the relevant
rows were checked rather than the section deleted.

- [x] No new path sends un-de-identified text to a provider
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model
- [x] Citations remain ID-constrained; no free-text references accepted
- [x] No transcript bodies, note contents, or vault entries written to logs
- [x] Fixtures added are synthetic (none added)

Red flags are still never collapsed. Only gaps are, and via CSS rather than by
slicing the array, so print restores the full list. The `Rule` versus
`AI Suggested` distinction survives the casing sweep and still carries two
channels beyond the word itself.

## Notes For The Reviewer

**The casing sweep is the part worth reading.** It applies the `AGENTS.md`
Documentation Hygiene rule to UI copy: Title Case for labels, buttons, badges,
headings and nav items; sentence case for anything that is a sentence. Four
strings were reverted after the automated pass over-applied it, including
`12 of 29 Established`, where a mid-phrase capital reads as a defect. Nothing
rendered from model output was touched. `Open source` became `Open Guideline`
rather than `Open Source`, which Title Case had turned into the software term.

**Deliberately not changed.** Dropping the note body to 14px narrows its
`max-w-[68ch]` measure by 85px, from 677 to 592. `ch` tracking the font size is
correct behaviour, not a bug, but the column now sits in a visibly wider card.
Left for a human eye rather than adjusted on a subagent's initiative.

**One pre-existing item, unrelated to this branch.** The generated Prisma client
goes stale against #71's `erasedAt` column, so a fresh checkout fails
`typecheck` until `bun run prisma:generate` runs. The schema and migration are
both correct; only the local artifact lags.
