### PR TITLE
fix(redflags): stop firing on the doctor's screening question

### DIFF
--- a/backend/src/fixtures/rubrics.ts
+++ b/backend/src/fixtures/rubrics.ts
@@ -17,6 +17,17 @@ export interface FixtureRubric {
   failsQaIf: string
   /** Detector classes (docs/trd.md §9) this fixture seeds, if any. */
   identifierClasses: readonly string[]
+  /**
+   * Exactly which deterministic red-flag rules this transcript must raise, by
+   * `RedFlagTrigger.id`, and by exclusion which it must not.
+   *
+   * Derived from reading the transcript against the trigger list, never from
+   * observed output. It exists because the prose above was unenforceable: the
+   * `urti-identifier-dense-routine` rubric had said for weeks that any flag on
+   * it is a false positive, and three were being raised while a full suite
+   * passed, because nothing ran a fixture through the engine (issue #70).
+   */
+  expectedRedFlagIds: readonly string[]
 }
 
 export const FIXTURE_RUBRICS: readonly FixtureRubric[] = [
@@ -32,6 +43,8 @@ export const FIXTURE_RUBRICS: readonly FixtureRubric[] = [
       'dyspnoea, SpO2, respiratory rate) as DENIED/absent rather than NOT_ASSESSED. This is the ' +
       'exact fabrication TRD §21.1 measured in 5 of 5 runs on a sparse transcript.',
     identifierClasses: [],
+    // Cough, sore throat and a resolved fever only. No escalation criterion appears.
+    expectedRedFlagIds: [],
   },
   {
     fixtureId: 'urti-hard-red-flag',
@@ -46,6 +59,8 @@ export const FIXTURE_RUBRICS: readonly FixtureRubric[] = [
       'model output did not corroborate it. The rules engine never sees the model output — a ' +
       'miss here is a patient-safety regression, not a quality issue.',
     identifierClasses: ['PATIENT'],
+    // The patient reports drooling and that she cannot swallow her own saliva.
+    expectedRedFlagIds: ['stridor-airway-compromise', 'swallowing-oral-intake'],
   },
   {
     fixtureId: 'urti-diagnosis-not-assessed',
@@ -59,6 +74,8 @@ export const FIXTURE_RUBRICS: readonly FixtureRubric[] = [
       'system may not produce a diagnosis the doctor did not say, even when the case is ' +
       'clinically obvious to a human reader.',
     identifierClasses: [],
+    // Cough, mild sore throat, fever already resolved, chest clear on examination.
+    expectedRedFlagIds: [],
   },
   {
     fixtureId: 'urti-hard-uncertain',
@@ -72,6 +89,9 @@ export const FIXTURE_RUBRICS: readonly FixtureRubric[] = [
       'The system resolves an ambiguous field to a confident PRESENT or DENIED, or the note ' +
       'presents the encounter with more certainty than the transcript supports.',
     identifierClasses: [],
+    // The doctor screens for chest pain and breathlessness and the patient neither
+    // confirms nor denies. Unresolved is not absent, so both stay raised for review.
+    expectedRedFlagIds: ['significant-dyspnoea', 'chest-pain'],
   },
   {
     fixtureId: 'urti-identifier-dense-routine',
@@ -86,5 +106,7 @@ export const FIXTURE_RUBRICS: readonly FixtureRubric[] = [
       'met, so any flag here is a false positive. Or: any identifier of the seven seeded ' +
       'classes reaches the LLM egress point un-tokenised.',
     identifierClasses: ['PATIENT', 'NRIC', 'PHONE', 'ADDRESS', 'DOB', 'MRN', 'EMAIL'],
+    // The negative control. The patient explicitly denies every symptom screened for.
+    expectedRedFlagIds: [],
   },
 ]

--- a/backend/src/redflags/question-context.test.ts
+++ b/backend/src/redflags/question-context.test.ts
@@ -1,0 +1,143 @@
+import type { Transcript } from '@shared/types'
+import { describe, expect, it } from 'vitest'
+import { FIXTURE_RUBRICS, FIXTURES } from '../fixtures/index.js'
+import { evaluateRedFlags } from './evaluate.js'
+import { REDFLAG_TRIGGERS } from './triggers.js'
+
+/**
+ * GitHub issue #70. The engine matched every turn as if it asserted what it
+ * mentioned, so a doctor running through a review of systems raised a flag for
+ * each symptom she asked about. Three fired on the negative-control fixture,
+ * one of them EMERGENCY, while the patient had denied all three in the next
+ * turn.
+ *
+ * The bias toward over-triggering is deliberate and stays. What follows pins
+ * the boundary between over-triggering and asserting something nobody said.
+ */
+
+const URTI = REDFLAG_TRIGGERS.filter((trigger) => trigger.profiles.includes('adult-acute-urti'))
+
+const transcript = (turns: { speaker: 'doctor' | 'patient'; text: string }[]): Transcript => ({
+  source: 'fixture',
+  turns,
+})
+
+/** `ruleId` is absent on model candidates; this engine only produces rule ones. */
+const ruleIds = (t: Transcript): string[] =>
+  evaluateRedFlags(t, URTI)
+    .map((f) => f.ruleId)
+    .filter((id): id is string => id !== undefined)
+    .sort()
+
+describe('every fixture is graded against its rubric (issue #70)', () => {
+  /**
+   * The rubrics used to be prose. `urti-identifier-dense-routine` had stated
+   * that any flag on it is a false positive for as long as it has existed, and
+   * three were being raised while the whole suite passed, because nothing ever
+   * ran a fixture through the engine. This is what makes `failsQaIf`
+   * executable.
+   */
+  it.each(FIXTURE_RUBRICS.map((r) => [r.fixtureId, r] as const))(
+    '%s raises exactly the rules its rubric names',
+    (fixtureId, rubric) => {
+      const fixture = FIXTURES.find((f) => f.id === fixtureId)
+      if (fixture === undefined) throw new Error(`fixture ${fixtureId} missing`)
+
+      expect(ruleIds(fixture.transcript)).toEqual([...rubric.expectedRedFlagIds].sort())
+    },
+  )
+})
+
+describe('a question is not an assertion, but silence about the answer is not a denial', () => {
+  it('does not fire when the doctor screens and the patient denies', () => {
+    expect(
+      ruleIds(
+        transcript([
+          {
+            speaker: 'doctor',
+            text: 'Any chest pain, difficulty breathing, or coughing up blood?',
+          },
+          {
+            speaker: 'patient',
+            text: 'No, none of that. Breathing is fine, no pain in the chest.',
+          },
+        ]),
+      ),
+    ).toEqual([])
+  })
+
+  /**
+   * The reason the obvious fix was rejected. Discarding every question would
+   * lose this flag outright: the patient never says the words, so the doctor's
+   * question is the only place the symptom is named.
+   */
+  it('fires when the doctor screens and the patient affirms without naming the symptom', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Any chest pain?' },
+          { speaker: 'patient', text: 'Yes, since this morning.' },
+        ]),
+      ),
+    ).toEqual(['chest-pain'])
+  })
+
+  it('fires when the doctor screens and the patient neither confirms nor denies', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Any chest pain?' },
+          { speaker: 'patient', text: 'Hard to say doctor, maybe when I climb stairs.' },
+        ]),
+      ),
+    ).toEqual(['chest-pain'])
+  })
+
+  it('fires on a doctor-observed finding, which is a statement rather than a question', () => {
+    expect(ruleIds(transcript([{ speaker: 'doctor', text: 'I can hear stridor.' }]))).toEqual([
+      'stridor-airway-compromise',
+    ])
+  })
+
+  it('fires when the patient asks about their own symptom', () => {
+    expect(
+      ruleIds(transcript([{ speaker: 'patient', text: 'Is it bad that I am coughing up blood?' }])),
+    ).toEqual(['haemoptysis'])
+  })
+})
+
+describe('a denial that repeats the phrase it denies', () => {
+  it('does not fire on "no pain in the chest"', () => {
+    expect(
+      ruleIds(
+        transcript([{ speaker: 'patient', text: 'Breathing is fine, no pain in the chest.' }]),
+      ),
+    ).toEqual([])
+  })
+
+  it('still fires after "but", which ends the negation\'s reach', () => {
+    expect(
+      ruleIds(transcript([{ speaker: 'patient', text: 'No fever but chest pain since morning.' }])),
+    ).toEqual(['chest-pain'])
+  })
+
+  it('fires on a plain report', () => {
+    expect(ruleIds(transcript([{ speaker: 'patient', text: 'I have chest pain.' }]))).toEqual([
+      'chest-pain',
+    ])
+  })
+})
+
+describe('vocabulary that was missing a genuine escalation', () => {
+  /**
+   * "cannot swallow" matched neither `can't swallow` nor `unable to swallow`,
+   * so the most alarming line in the hard red-flag fixture raised nothing. The
+   * flag it does raise came from "drooling" in the same sentence, which is
+   * luck rather than coverage.
+   */
+  it('fires on "cannot swallow", not only the contracted form', () => {
+    expect(
+      ruleIds(transcript([{ speaker: 'patient', text: 'I cannot swallow anything now.' }])),
+    ).toEqual(['swallowing-oral-intake'])
+  })
+})

--- a/backend/src/redflags/triggers.ts
+++ b/backend/src/redflags/triggers.ts
@@ -14,7 +14,7 @@ import type { RedFlagTrigger } from './types.js'
  * changes. Recorded with every analysis (docs/trd.md §15).
  */
 export const RED_FLAG_LIST_VERSION: ClinicalArtefactVersion = {
-  id: 'redflag-list-v2',
+  id: 'redflag-list-v3',
   effectiveDate: '2026-08-14',
 }
 
@@ -25,11 +25,74 @@ const URTI_AND_UTI_PROFILES: readonly ProfileId[] = [
 ]
 const UTI_PROFILES: readonly ProfileId[] = ['adult-acute-uncomplicated-uti']
 
+/**
+ * A reply that opens by denying the thing just asked about. Deliberately narrow
+ * (GitHub issue #70): it matches only an unambiguous leading negation, in
+ * English and the Malay a Malaysian consultation actually uses, and anything it
+ * is unsure of is not a denial.
+ */
+const LEADING_DENIAL =
+  /^\s*(?:no+|nope|none|nothing|negative|tak|tidak|takde|tak\s+ada|takda|belum)\b/i
+
+/**
+ * Whether a doctor turn asks rather than states. A screening question names the
+ * symptom it is screening for, so the naive matcher fires on the question and
+ * ignores the answer, which is what issue #70 reported.
+ */
+const isQuestion = (text: string): boolean => /\?\s*$/.test(text.trim())
+
+/**
+ * Does this turn's text count as asserting the symptom it mentions?
+ *
+ * Patient turns always do. A doctor's statement always does, so an observed
+ * finding ("I can hear stridor") still fires. A doctor's *question* does only
+ * when the patient's reply does not open with a denial.
+ *
+ * The default is to assert, which is the direction this engine must fail in.
+ * Dropping every question instead would be the obvious fix and a worse one: a
+ * patient answering "Yes, since this morning" to "Any chest pain?" never says
+ * the words, so the question is the only place the symptom appears and
+ * discarding it would lose the flag entirely.
+ */
+const asserts = (transcript: Transcript, index: number): boolean => {
+  const turn = transcript.turns[index]
+  if (turn === undefined || turn.speaker !== 'doctor' || !isQuestion(turn.text)) return true
+
+  const reply = transcript.turns[index + 1]
+  if (reply === undefined || reply.speaker !== 'patient') return true
+
+  return !LEADING_DENIAL.test(reply.text)
+}
+
+/** Words that end the scope of a preceding negation: "no fever but chest pain". */
+const NEGATION_SCOPE_END = /\b(?:but|tapi|however|although|except)\b/i
+
+/** An unambiguous negator sitting immediately before the matched span. */
+const TRAILING_NEGATOR =
+  /\b(?:no|not|none|never|denies|denied|without|tak|tidak|takde|tiada)\b[^.!?;]{0,24}$/i
+
+/**
+ * Is this match negated by the words immediately before it? Scoped tightly on
+ * purpose: only the run of text since the last clause break is considered, and
+ * a "but" ends the negation's reach, so "no fever but chest pain" still fires.
+ *
+ * This exists because a denial often repeats the phrase being denied. "No pain
+ * in the chest" contains "pain in the chest", so suppressing the doctor's
+ * question alone still left the patient's own denial matching (issue #70).
+ */
+const isNegated = (text: string, matchIndex: number): boolean => {
+  const before = text.slice(Math.max(0, matchIndex - 60), matchIndex)
+  const inScope = before.split(NEGATION_SCOPE_END).pop() ?? ''
+  return TRAILING_NEGATOR.test(inScope)
+}
+
 const findSpan = (transcript: Transcript, patterns: readonly RegExp[]): string | null => {
-  for (const turn of transcript.turns) {
+  for (const [index, turn] of transcript.turns.entries()) {
+    if (!asserts(transcript, index)) continue
+
     for (const pattern of patterns) {
       const match = pattern.exec(turn.text)
-      if (match) return match[0]
+      if (match && !isNegated(turn.text, match.index)) return match[0]
     }
   }
   return null
@@ -117,7 +180,7 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
     severity: 'urgent',
     matcher: (transcript) =>
       findSpan(transcript, [
-        /can'?t\s+swallow/i,
+        /(?:can'?t|cannot)\s+swallow/i,
         /unable\s+to\s+swallow/i,
         /can'?t\s+(?:keep|hold)\s+(?:anything|fluids|food|water)\s+down/i,
         /not\s+(?:been\s+)?able\s+to\s+(?:eat|drink)/i,

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -466,6 +466,27 @@ interface RedFlagTrigger {
 - Runs independently of, and is never gated by, the LLM call — `docs/prd.md` §8 (Primary Flow) step 3 states rules run "regardless of model output."
 - Every trigger whose `matcher` returns non-null becomes a `RedFlag` with `source: 'rule'`, `ruleId: trigger.id`, `evidence` set to the matched span.
 
+### Whose Words Assert The Symptom (Issue #70)
+
+**Status: `Built`.** A matcher originally tested every turn as though it asserted whatever it mentioned. A doctor working through a review of systems therefore raised a flag for each symptom she asked about: `urti-identifier-dense-routine` produced three, one of them `EMERGENCY`, while the patient denied all three in the following turn. That fixture's rubric had said for as long as it existed that any flag on it is a false positive.
+
+Two narrow rules now decide whether a matched span asserts anything. Both default to firing, because the direction this engine must fail in is toward too many flags.
+
+| Rule                    | Applies to                  | Effect                                                                                     |
+| ----------------------- | --------------------------- | ------------------------------------------------------------------------------------------ |
+| **Question resolution** | A doctor turn ending in `?` | Contributes a match unless the immediately following patient turn opens with a denial      |
+| **Adjacent negation**   | Any turn                    | A match is skipped when an unambiguous negator sits directly before it, in the same clause |
+
+A patient turn always asserts, including a question of their own ("is it bad that I am coughing up blood?"). A doctor's statement always asserts, so an observed finding ("I can hear stridor") still fires.
+
+**Why questions are not simply discarded**, which was the obvious fix and a worse one: a patient answering "Yes, since this morning" to "Any chest pain?" never says the words. The question is the only place the symptom is named, so dropping it would lose the flag entirely. That case is covered by a test.
+
+**Negation is scoped deliberately tightly.** Only the run of text since the last clause break counts, and a "but" ends the negation's reach, so "no fever but chest pain" still fires. A denial frequently repeats the phrase it denies, which is why "no pain in the chest" needed handling at all.
+
+**Residual false-negative risk, stated rather than implied.** A patient who answers a screening question with a bare denial and then contradicts it later in the same turn is not modelled. So is a negator separated from its subject by more than a clause. Both are judged less likely than the failure they replace, which fired on essentially every consultation, because alert fatigue is a false-negative mechanism wearing a false-positive costume: a flag that is always present is a flag nobody reads.
+
+**The rubrics are now executable.** Each `FixtureRubric` carries `expectedRedFlagIds`, derived by reading the transcript against the trigger list rather than by recording output, and a test asserts exact equality for every fixture. The prose alone could not fail a build, which is how three false flags survived a passing suite.
+
 ### Merge Rule — The Zero-Suppression Invariant
 
 - Assembly is a union, never a filter: `finalRedFlags = ruleFlags.concat(modelCandidates)`.


### PR DESCRIPTION
Closes #70.

## The Obvious Fix Was Wrong, And Here Is The Case That Proves It

The issue reported the engine firing on the doctor's screening question. The tempting fix is to stop matching questions. That introduces a false negative:

> **Doctor:** Any chest pain?
> **Patient:** Yes, since this morning.

The patient never says the words. The question is the only place the symptom is named, so discarding it loses the flag entirely. Today that case is caught, accidentally, by the very bug being fixed. There is a test for it.

## What Was Built

Two narrow rules, both defaulting to firing, because the direction this engine must fail in is toward too many flags.

| Rule                    | Applies to                  | Effect                                                                            |
| ----------------------- | --------------------------- | ----------------------------------------------------------------------------------- |
| **Question resolution** | A doctor turn ending in `?` | Contributes a match unless the next patient turn opens with an unambiguous denial     |
| **Adjacent negation**   | Any turn                    | A match is skipped when a negator sits directly before it, within the same clause     |

A patient turn always asserts, including their own question ("is it bad that I am coughing up blood?"). A doctor's statement always asserts, so an observed finding ("I can hear stridor") still fires.

**The second rule was not in the plan and turned out to be necessary.** Suppressing the question alone still left one flag on the negative control, because the patient's denial repeats the phrase it denies: "no pain in the chest" contains "pain in the chest". Negation scope is deliberately tight, and a "but" ends its reach, so "no fever but chest pain" still fires.

## A Pre-Existing False Negative, Found While Testing

`urti-hard-red-flag` is the fixture whose whole job is to fire. Its most alarming line is:

> "I cannot swallow anything now, even my own saliva I am drooling out."

`swallowing-oral-intake` matched `/can'?t\s+swallow/` and `/unable\s+to\s+swallow/`. **Neither matches "cannot".** That trigger has never fired on this fixture. The flag it does raise comes from "drooling" in the same sentence, which is luck rather than coverage.

Fixed here rather than filed, because it is one strictly additive pattern that can only ever add a flag, and leaving a known miss in a red-flag engine overnight is not a defensible trade. **This was pre-existing, not a regression from this change**, confirmed by measuring before touching anything.

A wider vocabulary audit is worth its own issue. "A bit puffed" for dyspnoea and "sesak" both go unmatched today.

## Results

| Fixture                         | Before | After | Notes                                              |
| ------------------------------- | ------ | ----- | ---------------------------------------------------- |
| `urti-gap-heavy`                | 0      | 0     |                                                      |
| `urti-hard-red-flag`            | 1      | **2** | `cannot swallow` now fires, as it always should have |
| `urti-diagnosis-not-assessed`   | 0      | 0     |                                                      |
| `urti-hard-uncertain`           | 2      | 2     | Patient hedges without denying, so both stay raised  |
| `urti-identifier-dense-routine` | 3      | **0** | The negative control, now actually a control         |

`urti-hard-uncertain` keeps its two flags deliberately. The patient answers "Hard to say doctor" and neither confirms nor denies, and unresolved is not absent.

## The Rubrics Are Now Executable

This is the part that stops the class recurring. `FixtureRubric` gains `expectedRedFlagIds`, and a test asserts exact equality for every fixture.

**Each expected set was derived by reading the transcript against the trigger list, not by recording what the engine produced.** The rubrics file already warned against grading on "a snapshot of whatever the system happens to produce", and encoding current output would have made that warning self-defeating.

The prose could not fail a build, which is exactly how three false flags, one of them EMERGENCY, survived a suite of 302 passing tests, plus lint, typecheck and review.

## Verification

```
Test Files  27 passed (27)
     Tests  319 passed (319)
```

319 up from 305, so 14 new tests. Every pre-existing test passes unmodified. Typecheck clean, lint clean on tracked files.

`RED_FLAG_LIST_VERSION` bumped to `redflag-list-v3`, per that file's own rule that a matcher change bumps the version. Analyses stamped `v2` remain traceable to the behaviour that produced them.

## Residual Risk, Stated Rather Than Implied

Recorded in `docs/trd.md` §10: a patient who denies then contradicts themselves later in the same turn is not modelled, nor is a negator separated from its subject by more than a clause. Both are judged less likely than the failure they replace, which fired on essentially every consultation. Alert fatigue is a false-negative mechanism wearing a false-positive costume: a flag that is always present is a flag nobody reads.

## Clinical-Safety Checklist

The diff touches `redflags/`, so this is not optional.

- **De-identification:** untouched, no new egress path.
- **Red flags:** the zero-suppression invariant holds. The LLM still cannot drop or downgrade a rule hit; this changes only which text the deterministic matcher treats as an assertion, and it now fires on one case it previously missed.
- **Citations:** untouched.
- **No diagnosis:** labels unchanged, still describing reported features.
- **Logging:** unchanged.

## Note For The Demo

Analyses already stored in the guest account keep the flags they were computed with, including the three false ones on the approved consultation. Refreshing that data is a separate step and I have not done it unprompted, since it means erasing and recreating rows in the shared database.
