### PR TITLE
feat(ui): make the guideline corpus searchable and give the shell room

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -255,6 +255,16 @@
     color: var(--color-ink-muted);
     opacity: 1;
   }
+
+  /* Chromium paints its own clear affordance inside `type="search"`, in its own
+   * style and at its own position. Every search field here supplies one that
+   * matches the design system, so leaving the native one gives the field two
+   * clear buttons side by side and makes the user work out which is which.
+   * The type stays `search` for the `searchbox` role it carries. */
+  input[type='search']::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    appearance: none;
+  }
 }
 
 @layer components {
@@ -318,7 +328,10 @@
    * scroll to the bottom at the width that broke.
    */
   .reveal-shell {
-    --footer-h: 7.5rem;
+    /* 12rem = 192px, against 109.5px of content inside 40px of padding either
+       side. Measured, not chosen: 11.5rem clipped the content by 5.5px, and the
+       clipping is invisible until someone scrolls to the bottom. */
+    --footer-h: 12rem;
   }
 
   /*

--- a/frontend/src/routes/Guidelines.tsx
+++ b/frontend/src/routes/Guidelines.tsx
@@ -1,9 +1,11 @@
 import type { GuidelineChunk } from '@shared/types'
 import { useQuery } from '@tanstack/react-query'
-import { ExternalLink } from 'lucide-react'
+import { ExternalLink, Search, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
 import { api } from '../lib/api.js'
 import { Card, Skeleton } from '../ui/Card.js'
 import { PageHeader } from '../ui/PageHeader.js'
+import { Select } from '../ui/Select.js'
 
 /**
  * The citation corpus, made browsable.
@@ -31,9 +33,54 @@ function groupByPublisher(guidelines: GuidelineChunk[]) {
   return [...groups.entries()]
 }
 
+const ALL_PUBLISHERS = 'all'
+
+/*
+ * The ID is searchable alongside the prose, and that is the point rather than a
+ * convenience. A suggestion elsewhere in the app cites `nice-ng120-cough` and
+ * nothing else, so the reader arriving from a citation is holding an ID, not a
+ * title. Matching only the title would make the corpus unsearchable by the one
+ * string the rest of the product hands them.
+ */
+function matches(guideline: GuidelineChunk, query: string) {
+  const haystack =
+    `${guideline.id} ${guideline.title} ${guideline.summary} ${guideline.publisher}`.toLowerCase()
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((term) => haystack.includes(term))
+}
+
 export function Guidelines() {
   const guidelines = useQuery({ queryKey: ['guidelines'], queryFn: api.guidelines })
-  const groups = groupByPublisher(guidelines.data ?? [])
+  const [query, setQuery] = useState('')
+  const [publisher, setPublisher] = useState(ALL_PUBLISHERS)
+
+  const all = useMemo(() => guidelines.data ?? [], [guidelines.data])
+
+  const publishers = useMemo(
+    () => [
+      { value: ALL_PUBLISHERS, label: 'All Publishers' },
+      ...[...new Set(all.map((guideline) => guideline.publisher))]
+        .sort()
+        .map((name) => ({ value: name, label: name })),
+    ],
+    [all],
+  )
+
+  const filtered = useMemo(
+    () =>
+      all.filter(
+        (guideline) =>
+          (publisher === ALL_PUBLISHERS || guideline.publisher === publisher) &&
+          matches(guideline, query),
+      ),
+    [all, publisher, query],
+  )
+
+  const groups = groupByPublisher(filtered)
+  const filtering = query.trim() !== '' || publisher !== ALL_PUBLISHERS
 
   return (
     <div className="mx-auto max-w-4xl">
@@ -56,15 +103,73 @@ export function Guidelines() {
           <Card className="mt-6 p-5">
             <p className="text-sm leading-relaxed text-ink-muted">
               A suggestion carries a guideline ID, never free text. The model is given only these{' '}
-              <span className="font-medium text-ink">{guidelines.data.length} entries</span> and can
-              cite nothing else, so a fabricated reference is rejected at parse time rather than
-              caught by review. Summaries below are ours; follow the link for the source document.
+              <span className="font-medium text-ink">{all.length} entries</span> and can cite
+              nothing else, so a fabricated reference is rejected at parse time rather than caught
+              by review. Summaries below are ours; follow the link for the source document.
             </p>
           </Card>
 
-          {groups.map(([publisher, entries]) => (
-            <section key={publisher} className="mt-8">
-              <h2 className="text-sm font-semibold text-ink-muted">{publisher}</h2>
+          {/* Search narrows what is shown, never what the model is given. The
+              count in the card above stays at the full corpus size for that
+              reason: it is a claim about the closed set, and a number that
+              moved with the filter would quietly turn it into a lie. */}
+          <div className="mt-5 flex flex-col gap-2 sm:flex-row">
+            <div className="relative flex-1">
+              <Search
+                aria-hidden
+                className="pointer-events-none absolute top-1/2 left-3.5 size-4 -translate-y-1/2 text-ink-muted"
+              />
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search by title, summary or guideline ID"
+                aria-label="Search the guideline corpus"
+                className="h-11 w-full rounded-control border border-line bg-surface pr-10 pl-10 text-sm text-ink transition-colors duration-150 hover:border-accent focus:border-accent"
+              />
+              {query && (
+                <button
+                  type="button"
+                  onClick={() => setQuery('')}
+                  aria-label="Clear search"
+                  className="absolute top-1/2 right-2 flex size-7 -translate-y-1/2 items-center justify-center rounded-control text-ink-muted transition-colors duration-150 hover:bg-sunken hover:text-ink"
+                >
+                  <X aria-hidden className="size-4" />
+                </button>
+              )}
+            </div>
+
+            <Select
+              label="Filter by publisher"
+              value={publisher}
+              options={publishers}
+              onChange={setPublisher}
+              className="sm:w-56"
+            />
+          </div>
+
+          {/* Announced politely rather than silently re-rendered: a filter that
+              changes the list under a screen-reader user without saying so
+              leaves them reading a page that is no longer the one they heard. */}
+          <p aria-live="polite" className="mt-3 text-sm text-ink-muted">
+            {filtering
+              ? `Showing ${filtered.length} of ${all.length} entries`
+              : `${all.length} entries`}
+          </p>
+
+          {filtering && filtered.length === 0 && (
+            <Card className="mt-4 p-6 text-center">
+              <p className="text-sm text-ink-muted">
+                Nothing in the corpus matches that. The set is deliberately small and narrow, so a
+                miss usually means the topic is outside this prototype&rsquo;s scope rather than
+                that the search failed.
+              </p>
+            </Card>
+          )}
+
+          {groups.map(([groupPublisher, entries]) => (
+            <section key={groupPublisher} className="mt-8">
+              <h2 className="text-sm font-semibold text-ink-muted">{groupPublisher}</h2>
               <div className="mt-3 flex flex-col gap-2">
                 {entries.map((guideline) => (
                   <Card key={guideline.id} className="p-5">

--- a/frontend/src/shell/AppShell.tsx
+++ b/frontend/src/shell/AppShell.tsx
@@ -44,7 +44,12 @@ export function AppShell() {
             when it expands: content shifting under a hover would be worse than
             the dimming it replaces. On small screens the dock is at the bottom,
             so the padding moves there to clear it. */}
-        <main className="px-4 pt-6 pb-28 md:py-6 md:pr-6 md:pl-24">
+        {/* Every signed-in route renders a bare `mx-auto max-w-*` container with
+            no vertical spacing of its own, so this padding is the only thing
+            between a page header and the top of the viewport. The bottom half
+            also has to clear two different things: the mobile dock below md,
+            and the sticky approve bar on the review screen. */}
+        <main className="px-4 pt-8 pb-32 md:py-10 md:pr-6 md:pl-24">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/shell/SiteFooter.tsx
+++ b/frontend/src/shell/SiteFooter.tsx
@@ -17,15 +17,12 @@ import { Wordmark } from '../ui/Wordmark.js'
  */
 
 /*
- * Both destinations are reachable signed out, which is the constraint that
- * decides this list rather than a judgement about what is interesting. The
- * footer renders on the public landing page, and `/guidelines` is auth-gated,
- * so a visitor clicking it was bounced to `/login` with the intent discarded.
+ * Reachable signed out, which is the constraint that decides this list rather
+ * than a judgement about what is interesting. The footer renders on the public
+ * landing page, and `/guidelines` is auth-gated, so a visitor clicking it was
+ * bounced to `/login` with the intent discarded.
  */
-const LINKS = [
-  { to: '/login', label: 'Try the Demo' },
-  { to: '/privacy', label: 'Privacy and Data Protection' },
-]
+const LINKS = [{ to: '/privacy', label: 'Privacy and Data Protection' }]
 
 export function SiteFooter({ className }: { className?: string }) {
   const footer = useRef<HTMLElement>(null)
@@ -52,7 +49,12 @@ export function SiteFooter({ className }: { className?: string }) {
 
   return (
     <footer ref={footer} className={cn('site-footer', className)} data-print="hide">
-      <div className="mx-auto flex h-full max-w-6xl flex-col items-center justify-center gap-4 px-6 text-center">
+      {/* max-w-6xl px-6 is the header's column, repeated here so the footer's
+          right edge lands on the same vertical as the Sign In button rather
+          than near it. Right-aligned to that column, not to the viewport: past
+          about 1400px a viewport-flush footer drifts away from everything else
+          on the page and stops reading as part of the same grid. */}
+      <div className="mx-auto flex h-full max-w-6xl flex-col items-end justify-center gap-3 px-6 py-10 text-right">
         <span className="flex items-center gap-2">
           <Mark className="size-6" />
           <Wordmark tone="inverse" className="text-xl" />
@@ -60,7 +62,7 @@ export function SiteFooter({ className }: { className?: string }) {
 
         <nav
           aria-label="Footer"
-          className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm font-medium text-accent-ink"
+          className="flex flex-wrap items-center justify-end gap-x-6 gap-y-2 text-sm font-medium text-accent-ink"
         >
           {LINKS.map(({ to, label }) => (
             <Link key={to} to={to} className="underline underline-offset-2 hover:no-underline">

--- a/frontend/src/ui/Select.test.tsx
+++ b/frontend/src/ui/Select.test.tsx
@@ -1,0 +1,130 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Select } from './Select.js'
+
+/*
+ * The keyboard contract, not the styling.
+ *
+ * This control is hand-rolled rather than taken from a headless library, which
+ * means every behaviour a native `<select>` would have given for free is now
+ * ours to keep working. Issue #30 requires a complete keyboard path through the
+ * app, so these are the cases that would strand a keyboard user if they broke:
+ * opening without a mouse, moving between options, committing a choice, and
+ * getting focus back afterwards.
+ */
+
+const OPTIONS = [
+  { value: 'all', label: 'All Publishers' },
+  { value: 'moh', label: 'Ministry of Health Malaysia' },
+  { value: 'mfp', label: 'Malaysian Family Physician' },
+]
+
+// vitest runs without `globals`, so RTL's automatic cleanup is not wired up.
+afterEach(cleanup)
+
+function setup(value = 'all') {
+  const onChange = vi.fn()
+  render(<Select label="Filter by publisher" value={value} options={OPTIONS} onChange={onChange} />)
+  return { onChange, trigger: screen.getByRole('button') }
+}
+
+describe('Select', () => {
+  it('names itself and its current value without a visible label', () => {
+    const { trigger } = setup()
+    const labelId = trigger.getAttribute('aria-labelledby')
+    expect(labelId).toBeTruthy()
+    expect(document.getElementById(labelId as string)?.textContent).toBe('Filter by publisher')
+    expect(trigger.textContent).toContain('All Publishers')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('opens on Enter and lands focus on the option already selected', () => {
+    const { trigger } = setup('moh')
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(screen.getAllByRole('option')).toHaveLength(3)
+    // Not the top of the list: the first arrow press should move from where the
+    // user already is.
+    expect(document.activeElement?.textContent).toContain('Ministry of Health Malaysia')
+  })
+
+  it('opens on ArrowDown, so the list is reachable without committing to Enter', () => {
+    const { trigger } = setup()
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('marks exactly one option as selected', () => {
+    setup('mfp')
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' })
+    const selected = screen
+      .getAllByRole('option')
+      .filter((option) => option.getAttribute('aria-selected') === 'true')
+    expect(selected).toHaveLength(1)
+    expect(selected[0]?.textContent).toContain('Malaysian Family Physician')
+  })
+
+  it('moves focus with the arrow keys and wraps at both ends', () => {
+    const { trigger } = setup()
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    const list = screen.getByRole('listbox')
+
+    fireEvent.keyDown(list, { key: 'ArrowDown' })
+    expect(document.activeElement?.textContent).toContain('Ministry of Health Malaysia')
+
+    // Wrapping matters: a list that silently stops moving reads as broken.
+    fireEvent.keyDown(list, { key: 'ArrowUp' })
+    fireEvent.keyDown(list, { key: 'ArrowUp' })
+    expect(document.activeElement?.textContent).toContain('Malaysian Family Physician')
+  })
+
+  it('jumps to the ends with Home and End', () => {
+    const { trigger } = setup()
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    const list = screen.getByRole('listbox')
+
+    fireEvent.keyDown(list, { key: 'End' })
+    expect(document.activeElement?.textContent).toContain('Malaysian Family Physician')
+    fireEvent.keyDown(list, { key: 'Home' })
+    expect(document.activeElement?.textContent).toContain('All Publishers')
+  })
+
+  it('commits a choice on Enter, closes, and hands focus back to the trigger', () => {
+    const { trigger, onChange } = setup()
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    fireEvent.keyDown(screen.getByRole('listbox'), { key: 'ArrowDown' })
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Enter' })
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith('moh')
+    expect(screen.queryByRole('listbox')).toBeNull()
+    // Leaving focus on the body is the failure that strands a keyboard user.
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('abandons on Escape without changing the value', () => {
+    const { trigger, onChange } = setup()
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    fireEvent.keyDown(screen.getByRole('listbox'), { key: 'Escape' })
+
+    expect(screen.queryByRole('listbox')).toBeNull()
+    expect(onChange).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('closes on an outside pointer press', () => {
+    const { trigger } = setup()
+    fireEvent.click(trigger)
+    expect(screen.getByRole('listbox')).toBeTruthy()
+
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+})

--- a/frontend/src/ui/Select.tsx
+++ b/frontend/src/ui/Select.tsx
@@ -1,0 +1,189 @@
+import { Check, ChevronDown } from 'lucide-react'
+import { useEffect, useId, useRef, useState } from 'react'
+import { cn } from '../lib/cn.js'
+
+/**
+ * A listbox, not a `<select>`.
+ *
+ * The native control cannot be styled past its trigger in any engine that
+ * matters, so a filter sitting next to a search input would render as an OS
+ * widget beside a designed one. That is the whole reason this exists; it is not
+ * a general-purpose component and should not grow into one.
+ *
+ * Hand-rolled rather than pulled from Radix because nothing else in this
+ * codebase uses a headless UI library, and a single control is a poor reason to
+ * introduce one. The cost of that choice is that the keyboard contract is ours
+ * to honour, and issue #30 requires a complete keyboard path through the app:
+ *
+ *   - Enter, Space, ArrowUp or ArrowDown on the trigger opens the list
+ *   - the list takes focus, so arrows move between options directly rather than
+ *     through `aria-activedescendant`, which is fewer moving parts and is what
+ *     a screen reader reports most consistently
+ *   - Home and End jump to the ends, Escape closes and returns focus, Tab closes
+ *   - a pointer press anywhere outside closes it
+ *
+ * Focus returns to the trigger on close because the trigger is where the user
+ * was. Leaving focus on the document body is the failure that strands a
+ * keyboard user mid-page.
+ */
+
+export interface SelectOption {
+  value: string
+  label: string
+}
+
+export function Select({
+  value,
+  options,
+  onChange,
+  label,
+  className,
+}: {
+  value: string
+  options: SelectOption[]
+  onChange: (value: string) => void
+  /** Visually hidden, but the control must still say what it filters. */
+  label: string
+  className?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const trigger = useRef<HTMLButtonElement>(null)
+  const list = useRef<HTMLDivElement>(null)
+  const wrap = useRef<HTMLDivElement>(null)
+  const labelId = useId()
+
+  const selected = options.findIndex((option) => option.value === value)
+  const current = options[selected] ?? options[0]
+
+  /* Focus the selected option as the list appears, so the first arrow press
+     moves from where the user already is rather than from the top. */
+  useEffect(() => {
+    if (!open) return
+    const node = list.current?.querySelectorAll<HTMLElement>('[role="option"]')
+    node?.[Math.max(selected, 0)]?.focus()
+  }, [open, selected])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      if (!wrap.current?.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+
+  const close = (returnFocus: boolean) => {
+    setOpen(false)
+    if (returnFocus) trigger.current?.focus()
+  }
+
+  const move = (index: number) => {
+    const nodes = list.current?.querySelectorAll<HTMLElement>('[role="option"]')
+    if (!nodes?.length) return
+    // Wrap at both ends: a list that silently stops moving reads as broken.
+    nodes[(index + nodes.length) % nodes.length]?.focus()
+  }
+
+  return (
+    <div ref={wrap} className={cn('relative', className)}>
+      <span id={labelId} className="sr-only">
+        {label}
+      </span>
+      <button
+        ref={trigger}
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-labelledby={labelId}
+        onClick={() => setOpen((value) => !value)}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter') {
+            event.preventDefault()
+            setOpen(true)
+          }
+        }}
+        className={cn(
+          'flex h-11 w-full items-center justify-between gap-2 rounded-control',
+          'border border-line bg-surface px-3.5 text-sm font-medium text-ink',
+          'transition-colors duration-150 hover:border-accent',
+        )}
+      >
+        <span className="truncate">{current?.label}</span>
+        <ChevronDown
+          aria-hidden
+          className={cn(
+            'size-4 shrink-0 text-ink-muted transition-transform duration-150',
+            open && 'rotate-180',
+          )}
+        />
+      </button>
+
+      {open && (
+        <div
+          ref={list}
+          role="listbox"
+          aria-labelledby={labelId}
+          onKeyDown={(event) => {
+            const nodes = [
+              ...(list.current?.querySelectorAll<HTMLElement>('[role="option"]') ?? []),
+            ]
+            const index = nodes.indexOf(document.activeElement as HTMLElement)
+            if (event.key === 'ArrowDown') {
+              event.preventDefault()
+              move(index + 1)
+            } else if (event.key === 'ArrowUp') {
+              event.preventDefault()
+              move(index - 1)
+            } else if (event.key === 'Home') {
+              event.preventDefault()
+              move(0)
+            } else if (event.key === 'End') {
+              event.preventDefault()
+              move(nodes.length - 1)
+            } else if (event.key === 'Escape') {
+              event.preventDefault()
+              close(true)
+            } else if (event.key === 'Tab') {
+              close(false)
+            }
+          }}
+          className={cn(
+            'absolute right-0 z-20 mt-1.5 max-h-72 min-w-full overflow-y-auto',
+            'rounded-card border border-line bg-surface p-1 shadow-float',
+          )}
+        >
+          {options.map((option) => {
+            const isSelected = option.value === value
+            return (
+              <div
+                key={option.value}
+                role="option"
+                aria-selected={isSelected}
+                tabIndex={-1}
+                onClick={() => {
+                  onChange(option.value)
+                  close(true)
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault()
+                    onChange(option.value)
+                    close(true)
+                  }
+                }}
+                className={cn(
+                  'flex cursor-pointer items-center justify-between gap-3 rounded-control',
+                  'px-3 py-2 text-sm whitespace-nowrap transition-colors duration-150',
+                  isSelected ? 'bg-accent/16 font-medium text-accent' : 'text-ink hover:bg-sunken',
+                )}
+              >
+                {option.label}
+                {isSelected && <Check aria-hidden className="size-4 shrink-0" />}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What Changed

The guideline corpus is searchable and filterable, the footer sits against the
header's column instead of floating in the middle, and the signed-in shell has
vertical spacing of its own.

## Why

A refinement pass driven by review of the running app.

The corpus page had grown past the length where a flat list is browsable, and
it is the page an evaluator uses to check the strongest safety claim the product
makes. Making it searchable is the difference between "here is the closed set"
and "here is the closed set, and you can find the entry a citation pointed you
at".

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manually exercised the affected flow

359 tests pass, 9 of them new. Those 9 are the **first frontend tests in the
repo**. The tooling was already installed and configured and nothing had used
it; the filter is a hand-rolled listbox, so its keyboard contract is now ours to
keep working and is the right thing to spend the first ones on.

Driven end to end in a real browser against the local API and the seeded guest
account, not only in jsdom:

- search `cough` narrows 12 entries to 4
- the dropdown opens on Enter with focus landing on the option already selected,
  not the top of the list
- ArrowDown moves, Enter commits, focus returns to the trigger
- Escape closes without changing the value, focus returns to the trigger
- no console errors on any step

The footer was measured at seven widths from 769 to 1920px rather than eyeballed:
109.5px of content inside 40px of padding either side. `--footer-h` is 12rem
because 11.5rem clipped it by 5.5px, and that clipping is invisible until
someone scrolls to the bottom.

## Notes For The Reviewer

**One defect found by screenshot rather than by test.** `type="search"` makes
Chromium paint its own clear button, so the field shipped two clear affordances
side by side. Suppressed in `index.css` rather than by dropping to `type="text"`,
because the type carries the `searchbox` role.

**The listbox is deliberately not Radix.** `AGENTS.md` lists Radix in the stack
but it is not installed and nothing imports it, so using it here would have
added a dependency for one control in a codebase where every other primitive is
hand-rolled. The stack list in `AGENTS.md` is stale on that point and is worth
correcting separately.

**Right-aligned to the content column, not the viewport.** Past about 1400px a
viewport-flush footer drifts away from everything else on the page and stops
reading as part of the same grid. Matching `max-w-6xl px-6` puts the footer's
right edge on the same vertical as the Sign In button.

**Two dead dependencies noticed, not touched.**
`@fontsource-variable/inter` and `@fontsource-variable/source-serif-4` are still
in `frontend/package.json` but nothing imports them; the typefaces are Outfit and
Work Sans. Left alone as out of scope for this diff.
