### PR TITLE
test(redflags): pin fail-open behaviour on interleaved turns

### DIFF
--- a/backend/src/redflags/question-context.test.ts
+++ b/backend/src/redflags/question-context.test.ts
@@ -106,6 +106,56 @@ describe('a question is not an assertion, but silence about the answer is not a 
   })
 })
 
+/**
+ * Suppression binds a question to the turn immediately after it. Real
+ * consultations interleave, so every other shape must fail open: a spurious
+ * flag costs a doctor one dismissal, a suppressed one costs the thing this
+ * engine exists to prevent.
+ */
+describe('interleaved turns fail open', () => {
+  it('fires when the patient asks a clarifying question before answering', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Any chest pain?' },
+          { speaker: 'patient', text: 'Which one doctor, the front or the side?' },
+          { speaker: 'patient', text: 'No, none of that.' },
+        ]),
+      ),
+    ).toEqual(['chest-pain'])
+  })
+
+  it('fires for the earlier question when two are answered at once', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Any chest pain?' },
+          { speaker: 'doctor', text: 'And any coughing up blood?' },
+          { speaker: 'patient', text: 'No, none of that.' },
+        ]),
+      ),
+    ).toEqual(['chest-pain'])
+  })
+
+  it('fires when the doctor speaks again before the patient replies', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Any chest pain?' },
+          { speaker: 'doctor', text: 'Take your time.' },
+          { speaker: 'patient', text: 'No, none of that.' },
+        ]),
+      ),
+    ).toEqual(['chest-pain'])
+  })
+
+  it('fires when the question is the last turn and nothing answers it', () => {
+    expect(ruleIds(transcript([{ speaker: 'doctor', text: 'Any chest pain?' }]))).toEqual([
+      'chest-pain',
+    ])
+  })
+})
+
 describe('a denial that repeats the phrase it denies', () => {
   it('does not fire on "no pain in the chest"', () => {
     expect(

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -923,6 +923,19 @@ Source: `render.yaml` (repo root).
 
 `QWEN_MODEL` pins the same untested default flagged in Open #6 below — the value is already committed to the deploy config before the exact model id has been confirmed against a live Model Studio account.
 
+#### `render.yaml` Is Not Authoritative For Env Vars On A Live Service
+
+**Learned the hard way on 14/08/26.** A Blueprint seeds environment variables when the service is created. After that the service's own values win, and editing `render.yaml` in the repository changes nothing on a service that already exists.
+
+The failure this produced: `QWEN_MODEL` was corrected in `render.yaml`, merged, and deployed, while production carried on running the old value. The repository asserted a pin that production did not honour, and nothing anywhere reported a disagreement.
+
+Two rules follow, both of which cost time to discover:
+
+- **Changing a `value:` env var in `render.yaml` requires setting it on the service as well.** The CLI has no command for this; use the API (`PUT /v1/services/{id}/env-vars/{key}`) or the dashboard.
+- **Setting an env var does not redeploy.** The API accepts the change and the running instance keeps the old value until a deploy is triggered (`POST /v1/services/{id}/deploys`). A verification run immediately after setting the variable will still exercise the old one, which is exactly what happened here.
+
+Treat `render.yaml` as the definition used at creation and as documentation thereafter. It is not a control surface for a running service, and a reader cannot tell the difference from the file alone.
+
 ### Pooled Versus Direct URL Split
 
 `DATABASE_URL` (Supavisor pooler, `:6543`, `pgbouncer=true`) is used by the running app; `DIRECT_URL` (`:5432`) is used only by `prisma migrate` — both already `Built` in `EnvSchema` (§7), `.env.example`, and `render.yaml`.


### PR DESCRIPTION
Follow-up to #70 and #75. Two things, both recording behaviour that already exists rather than changing any.

## Interleaved Turns Fail Open

#70's suppression binds a doctor's question to the turn immediately after it. Real consultations interleave, so the question is what happens when that adjacency does not hold. Raised by @Andersonnn7788 as a question rather than a claim, which was the right instinct.

Measured, not reasoned about:

| Shape                                                | Result |
| ---------------------------------------------------- | -------- |
| Question, then a leading denial                      | silent   |
| Patient asks a clarifying question before answering  | **fires** |
| Two screening questions answered at once             | **fires** on the earlier one |
| Doctor speaks again before the patient replies       | **fires** |
| Question is the final turn, nothing answers it       | **fires** |

Every non-adjacent shape fails open, which is the correct trade: a spurious flag costs a doctor one dismissal, a suppressed one costs the thing this engine exists to prevent.

The two-questions case is the interesting one. The first question fires even though the patient denied both, and that is deliberate.

**No behaviour changed here.** These are four tests pinning what the implementation already does, because this is precisely the kind of property a later refactor breaks while every existing test still passes.

## `render.yaml` Is Not Authoritative For Env Vars

Documented in §17 after it cost real time during #75.

A Blueprint seeds environment variables at service creation. Afterwards the service's own values win, so editing `render.yaml` and merging changes nothing on a service that already exists. `QWEN_MODEL` was corrected in the repository, merged and deployed while production carried on running the old value, and nothing anywhere reported the disagreement.

Two rules recorded, both discovered the expensive way:

- Changing a `value:` env var in `render.yaml` also requires setting it on the service. The CLI has no command for it; the API or dashboard does.
- Setting an env var does **not** redeploy. The running instance keeps the old value until a deploy is triggered, so a verification run straight after setting the variable still exercises the old one. That is exactly what happened, and it is why the first post-merge check still returned 500.

## Verification

`bun run test`: 323 passed, up from 319. Typecheck clean. No behaviour change, so every pre-existing test passes untouched.

## Clinical-Safety Checklist

The diff touches `redflags/`, so this is not optional. It adds tests and documentation only: no matcher, trigger, severity or engine behaviour is modified. The tests assert the existing fail-open property, which is the safe direction.
