### PR TITLE
feat(ui): add the Demo Mode guided walkthrough

### DIFF
--- a/frontend/src/demo/DemoStepBar.tsx
+++ b/frontend/src/demo/DemoStepBar.tsx
@@ -1,0 +1,99 @@
+import { Check, ChevronDown, ChevronUp } from 'lucide-react'
+import { useState } from 'react'
+import { cn } from '../lib/cn.js'
+import { useDemoTour } from './DemoTour.js'
+
+/**
+ * Progress while the tour runs, docked top-centre.
+ *
+ * It collapses rather than closes. During a live demo the presenter needs to
+ * know where they are, but the bar sits over the app and the one thing worse
+ * than losing your place is covering the screen you are talking about.
+ *
+ * Below `sm` only the current step is named: nine labels in a row on a phone
+ * is a scrollbar, not a progress indicator.
+ */
+export function DemoStepBar() {
+  const { active, currentStep, steps, stop } = useDemoTour()
+  const [collapsed, setCollapsed] = useState(false)
+
+  if (!active) return null
+
+  const current = steps[currentStep]
+
+  return (
+    <nav
+      aria-label="Walkthrough progress"
+      data-print="hide"
+      style={{ zIndex: 'var(--z-toast)' }}
+      className="glass fixed top-4 left-1/2 flex max-w-[calc(100vw-2rem)] -translate-x-1/2 items-center gap-3 rounded-float px-3 py-2"
+    >
+      <span className="text-xs font-medium whitespace-nowrap text-ink sm:hidden">
+        {currentStep + 1}/{steps.length} · {current?.label}
+      </span>
+
+      {!collapsed && (
+        <ol className="hidden items-center gap-1 sm:flex">
+          {steps.map((step, index) => {
+            const isCurrent = index === currentStep
+            const isDone = index < currentStep
+            return (
+              <li
+                key={step.label}
+                aria-current={isCurrent ? 'step' : undefined}
+                className={cn(
+                  'flex items-center gap-1.5 rounded-control px-2 py-1 text-xs whitespace-nowrap transition-colors duration-150',
+                  isCurrent && 'bg-accent/16 font-medium text-accent',
+                  isDone && 'text-ink-muted',
+                  !isCurrent && !isDone && 'text-ink-muted/60',
+                )}
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    'flex size-4 shrink-0 items-center justify-center rounded-full text-[0.625rem]',
+                    isCurrent && 'bg-accent text-accent-ink',
+                    isDone && 'text-accent',
+                    !isCurrent && !isDone && 'border border-current',
+                  )}
+                >
+                  {isDone ? <Check className="size-3" /> : index + 1}
+                </span>
+                {step.label}
+              </li>
+            )
+          })}
+        </ol>
+      )}
+
+      {collapsed && (
+        <span className="hidden text-xs font-medium whitespace-nowrap text-ink sm:inline">
+          Step {currentStep + 1} of {steps.length} · {current?.label}
+        </span>
+      )}
+
+      <div className="flex items-center gap-1 border-l border-line/60 pl-2">
+        <button
+          type="button"
+          onClick={() => setCollapsed((value) => !value)}
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? 'Expand the step list' : 'Collapse the step list'}
+          className="hidden size-7 items-center justify-center rounded-control text-ink-muted transition-colors hover:bg-sunken hover:text-ink sm:flex"
+        >
+          {collapsed ? (
+            <ChevronDown aria-hidden className="size-4" />
+          ) : (
+            <ChevronUp aria-hidden className="size-4" />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={stop}
+          className="rounded-control px-2 py-1 text-xs font-medium text-ink-muted transition-colors hover:bg-sunken hover:text-ink"
+        >
+          End
+        </button>
+      </div>
+    </nav>
+  )
+}

--- a/frontend/src/demo/DemoTour.tsx
+++ b/frontend/src/demo/DemoTour.tsx
@@ -1,0 +1,278 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api } from '../lib/api.js'
+
+/**
+ * The guided walkthrough's state machine (#28).
+ *
+ * **It narrates the real pipeline; it never mocks it.** Every note, gap, red
+ * flag and citation the tour points at was produced by the actual
+ * de-identification gate, model call, rules engine and evidence check. There
+ * are no hardcoded analysis payloads here and no stubbed responses.
+ *
+ * It also **creates nothing**. The original ask was for a self-contained mode
+ * that makes its own consultations and deletes them afterwards, and that is not
+ * buildable today: issue #64 moved `AuditEvent` to `onDelete: Restrict` so a
+ * deletion can no longer silently break the tamper-evident hash chain, and the
+ * tombstone erasure that replaced it has no HTTP endpoint on purpose, pending an
+ * open retention decision. A tour that created rows it could not remove would be
+ * worse than one that creates none, so this walks the seeded demo spread
+ * instead. Those consultations came out of the real pipeline, which is what
+ * keeps the no-mocking constraint satisfied.
+ *
+ * The consequence worth knowing: the tour is **read-only**. It navigates and
+ * explains. It never analyses, edits or approves on the user's behalf, which
+ * also means it can never trip the approval gate the product exists to enforce.
+ */
+
+/**
+ * Which consultation a step needs.
+ *
+ * Two, not one, and this is forced by the data rather than chosen. No single
+ * consultation in the seeded spread carries both red flags and cited
+ * suggestions: the flagged one has five flags and zero citations, and the ones
+ * with citations have no flags. A tour pinned to a single consultation
+ * therefore has to point one of its stops at an element that does not exist.
+ */
+type Subject = 'flagged' | 'cited'
+
+export interface TourStep {
+  label: string
+  /** `:id` is substituted with the consultation resolved for `subject`. */
+  route: string
+  subject?: Subject
+  /** A CSS selector, by convention a `data-tour` attribute. */
+  target?: string
+  hint: string
+}
+
+const TOUR_STEPS: TourStep[] = [
+  {
+    label: 'Consultations',
+    route: '/consultations',
+    target: '[data-tour="consultation-list"]',
+    hint: 'Five simulated consultations, each left at a different stage: draft, awaiting review, and approved.',
+  },
+  {
+    label: 'Intake',
+    route: '/consultations/new',
+    target: '[data-tour="intake"]',
+    hint: 'A consultation starts as a transcript. Load a bundled case, paste one, or upload a file. All three feed one parser.',
+  },
+  {
+    label: 'Transcript',
+    route: '/consultations/:id',
+    subject: 'flagged',
+    target: '[data-tour="transcript"]',
+    hint: 'The source, kept beside the output for the whole review. Nothing on this screen is unattributable to it.',
+  },
+  {
+    label: 'Red Flags',
+    route: '/consultations/:id',
+    subject: 'flagged',
+    target: '[data-tour^="flag-"]',
+    hint: 'Escalation triggers. "Rule" means a deterministic rules engine fired; the model may add candidates but can never suppress or downgrade one.',
+  },
+  {
+    label: 'Gaps',
+    route: '/consultations/:id',
+    subject: 'flagged',
+    target: '[data-tour="gap"]',
+    hint: 'What the consultation never established. A sparse transcript yields twenty-five of these; a thorough one yields six. That gap is the product.',
+  },
+  {
+    label: 'Checklist',
+    route: '/consultations/:id',
+    subject: 'flagged',
+    target: '[data-tour="checklist"]',
+    hint: 'A fixed 29-field checklist. A field nobody asked about reads "Not Assessed" rather than vanishing, so a fabricated denial is visible.',
+  },
+  {
+    label: 'Approval',
+    route: '/consultations/:id',
+    subject: 'flagged',
+    target: '[data-tour="approve"]',
+    hint: 'Nothing is final until the doctor approves it, in two deliberate steps. The tour will not press this for you.',
+  },
+  {
+    // A different consultation on purpose: the one with red flags has no cited
+    // suggestions, and this stop needs a real citation to point at.
+    label: 'Citations',
+    route: '/consultations/:id',
+    subject: 'cited',
+    target: '[data-tour="suggestion"]',
+    hint: 'Suggestions cite guideline IDs from a closed corpus. Free text fails schema validation, so a hallucinated reference cannot reach this card.',
+  },
+  {
+    label: 'Corpus',
+    route: '/guidelines',
+    target: '[data-tour="corpus"]',
+    hint: 'The whole closed set the model may cite, browsable. That is what makes the citation claim checkable rather than merely stated.',
+  },
+]
+
+export const TOUR_STEP_COUNT = TOUR_STEPS.length
+
+interface DemoTourValue {
+  active: boolean
+  /** 0-indexed; -1 when inactive. */
+  currentStep: number
+  steps: TourStep[]
+  /** True while the opening consultation is being resolved. */
+  preparing: boolean
+  start: () => void
+  next: () => void
+  back: () => void
+  stop: () => void
+}
+
+const DemoTourContext = createContext<DemoTourValue | null>(null)
+
+/**
+ * Pick the consultation the tour walks.
+ *
+ * **Scored by how many of the tour's stops it can actually show, not by which
+ * is newest.** Six of the nine steps point at something inside one
+ * consultation, and any of those anchors can be legitimately absent: a
+ * consultation with no red flags renders no flag card, one whose findings sit
+ * outside the guideline corpus renders no suggestion. Pointing a coachmark at
+ * an element that does not exist is the failure this scoring prevents, and it
+ * is not hypothetical: the seeded spread contains a consultation with flags but
+ * no citations.
+ *
+ * Red flags are weighted highest because the rule-versus-model distinction is
+ * the single thing this product most needs to demonstrate.
+ *
+ * The list endpoint carries only id, status and timestamps, so details have to
+ * be fetched to score at all. That is one read per analysed consultation
+ * against an account holding five, paid once at start, and it warms the cache
+ * the review screen is about to use anyway.
+ */
+interface ScoredAnalysis {
+  redFlags?: unknown[]
+  suggestions?: unknown[]
+}
+
+export type Subjects = Record<Subject, string | null>
+
+async function pickConsultations(
+  fetchDetail: (id: string) => Promise<{ analysis: unknown }>,
+): Promise<Subjects> {
+  const list = await api.listConsultations()
+  // A draft has no analysis at all, so none of the six anchors exist on it.
+  const analysed = list.filter((item) => item.status !== 'draft')
+  const fallback = analysed[0]?.id ?? list[0]?.id ?? null
+  if (analysed.length === 0) return { flagged: fallback, cited: fallback }
+
+  const details = (
+    await Promise.all(
+      analysed.map((item) =>
+        fetchDetail(item.id)
+          .then((detail) => ({ id: item.id, analysis: detail.analysis as ScoredAnalysis | null }))
+          .catch(() => null),
+      ),
+    )
+  ).filter((entry) => entry !== null)
+
+  // The approval stop needs the *unapproved* bar, which only renders while the
+  // consultation is still awaiting review, so an approved one cannot be the
+  // flagged subject even if it has the most flags.
+  const approvedIds = new Set(
+    list.filter((item) => item.status === 'approved').map((item) => item.id),
+  )
+
+  const flagged =
+    details.find((entry) => entry.analysis?.redFlags?.length && !approvedIds.has(entry.id))?.id ??
+    details.find((entry) => !approvedIds.has(entry.id))?.id ??
+    fallback
+
+  const cited = details.find((entry) => entry.analysis?.suggestions?.length)?.id ?? flagged
+
+  return { flagged, cited }
+}
+
+export function DemoTourProvider({ children }: { children: ReactNode }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [active, setActive] = useState(false)
+  const [currentStep, setCurrentStep] = useState(-1)
+  const [preparing, setPreparing] = useState(false)
+  const [subjects, setSubjects] = useState<Subjects>({ flagged: null, cited: null })
+
+  const routeFor = useCallback((step: TourStep, resolved: Subjects) => {
+    if (!step.route.includes(':id')) return step.route
+    const id = resolved[step.subject ?? 'flagged'] ?? resolved.flagged
+    // Without an id there is nothing to review; the list is the honest
+    // destination rather than a route with a literal ":id" in it.
+    return id ? step.route.replace(':id', id) : '/consultations'
+  }, [])
+
+  const start = useCallback(async () => {
+    setPreparing(true)
+    const resolved = await pickConsultations((consultation) =>
+      queryClient.fetchQuery({
+        queryKey: ['consultation', consultation],
+        queryFn: () => api.getConsultation(consultation),
+      }),
+    ).catch(() => ({ flagged: null, cited: null }) as Subjects)
+
+    setSubjects(resolved)
+    setPreparing(false)
+    setActive(true)
+    setCurrentStep(0)
+    navigate(routeFor(TOUR_STEPS[0] as TourStep, resolved))
+  }, [navigate, queryClient, routeFor])
+
+  const goTo = useCallback(
+    (index: number) => {
+      const step = TOUR_STEPS[index]
+      if (!step) return
+      setCurrentStep(index)
+      navigate(routeFor(step, subjects))
+    },
+    [subjects, navigate, routeFor],
+  )
+
+  const next = useCallback(() => {
+    // The last step closes the tour rather than dead-ending on a disabled
+    // button, so there is always exactly one obvious way forward.
+    if (currentStep >= TOUR_STEPS.length - 1) {
+      setActive(false)
+      setCurrentStep(-1)
+      return
+    }
+    goTo(currentStep + 1)
+  }, [currentStep, goTo])
+
+  const back = useCallback(() => {
+    if (currentStep > 0) goTo(currentStep - 1)
+  }, [currentStep, goTo])
+
+  const stop = useCallback(() => {
+    setActive(false)
+    setCurrentStep(-1)
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      active,
+      currentStep,
+      steps: TOUR_STEPS,
+      preparing,
+      start: () => void start(),
+      next,
+      back,
+      stop,
+    }),
+    [active, currentStep, preparing, start, next, back, stop],
+  )
+
+  return <DemoTourContext.Provider value={value}>{children}</DemoTourContext.Provider>
+}
+
+export function useDemoTour(): DemoTourValue {
+  const context = useContext(DemoTourContext)
+  if (context === null) throw new Error('useDemoTour must be used inside DemoTourProvider')
+  return context
+}

--- a/frontend/src/demo/HelpButton.tsx
+++ b/frontend/src/demo/HelpButton.tsx
@@ -1,0 +1,109 @@
+import { Loader2, Play, Sparkles, X } from 'lucide-react'
+import { useEffect, useRef } from 'react'
+import { TOUR_STEP_COUNT, useDemoTour } from './DemoTour.js'
+
+/**
+ * The way in: a floating button, and a dialog that says what is about to happen
+ * before it happens.
+ *
+ * The confirm step is not ceremony. The tour navigates the app on the user's
+ * behalf, and a control that starts moving someone around their own screens
+ * without warning is hostile. It is also where the honest disclosure lives:
+ * this walks real analysed consultations and changes nothing.
+ *
+ * Hidden while the tour runs, because the button that starts it is meaningless
+ * once it has started and would only compete with the step bar's End control.
+ */
+export function HelpButton() {
+  const { active, preparing, start } = useDemoTour()
+  const dialog = useRef<HTMLDialogElement>(null)
+
+  // A native <dialog> gives focus trapping, Escape, inertness of the page
+  // behind it and the top layer for free. Hand-rolling those is how a modal
+  // ends up half-accessible.
+  useEffect(() => {
+    if (active) dialog.current?.close()
+  }, [active])
+
+  if (active) return null
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => dialog.current?.showModal()}
+        data-print="hide"
+        style={{ zIndex: 'var(--z-sticky)' }}
+        className="glass fixed right-4 bottom-20 flex h-12 items-center gap-2 rounded-control px-4 text-sm font-medium text-ink transition-[transform,background-color] duration-150 ease-out-quart hover:text-accent active:scale-[0.97] md:right-6 md:bottom-6"
+      >
+        <Sparkles aria-hidden className="size-4 text-accent" />
+        Guided Tour
+      </button>
+
+      <dialog
+        ref={dialog}
+        data-print="hide"
+        className="m-auto w-[26rem] max-w-[calc(100vw-2rem)] rounded-card border border-line bg-surface p-0 text-ink backdrop:bg-scrim backdrop:backdrop-blur-sm"
+      >
+        <div className="p-6">
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="text-lg font-semibold">Take the Guided Tour</h2>
+            <button
+              type="button"
+              onClick={() => dialog.current?.close()}
+              aria-label="Close"
+              className="-mt-1 -mr-1 flex size-8 shrink-0 items-center justify-center rounded-control text-ink-muted transition-colors hover:bg-sunken hover:text-ink"
+            >
+              <X aria-hidden className="size-4" />
+            </button>
+          </div>
+
+          <p className="mt-2 text-sm leading-relaxed text-ink-muted">
+            {TOUR_STEP_COUNT} steps through a real consultation: the transcript, the red flags and
+            where they came from, what the consultation never established, and the approval gate.
+          </p>
+
+          {/* The two facts a clinician or an evaluator would otherwise have to
+              take on trust, stated before they agree to anything. */}
+          <ul className="mt-4 flex flex-col gap-2 text-sm text-ink-muted">
+            <li className="flex gap-2">
+              <span aria-hidden className="text-accent">
+                &middot;
+              </span>
+              Everything shown was produced by the real pipeline. Nothing is mocked or replayed.
+            </li>
+            <li className="flex gap-2">
+              <span aria-hidden className="text-accent">
+                &middot;
+              </span>
+              It only navigates and explains. Nothing is created, edited or approved for you.
+            </li>
+          </ul>
+
+          <div className="mt-6 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => dialog.current?.close()}
+              className="flex h-10 items-center rounded-control px-4 text-sm font-medium text-ink-muted transition-colors hover:bg-sunken hover:text-ink"
+            >
+              Not Now
+            </button>
+            <button
+              type="button"
+              disabled={preparing}
+              onClick={start}
+              className="flex h-10 items-center gap-2 rounded-control bg-accent px-5 text-sm font-medium text-accent-ink shadow-raised transition-[background-color,transform] duration-150 ease-out-quart hover:bg-accent-hover active:scale-[0.97] disabled:pointer-events-none disabled:opacity-70"
+            >
+              {preparing ? (
+                <Loader2 aria-hidden className="size-4 animate-spin" />
+              ) : (
+                <Play aria-hidden className="size-4" />
+              )}
+              {preparing ? 'Preparing' : 'Start Tour'}
+            </button>
+          </div>
+        </div>
+      </dialog>
+    </>
+  )
+}

--- a/frontend/src/demo/Spotlight.tsx
+++ b/frontend/src/demo/Spotlight.tsx
@@ -1,0 +1,204 @@
+import { ArrowLeft, ArrowRight, X } from 'lucide-react'
+import { type CSSProperties, useEffect, useState } from 'react'
+import { cn } from '../lib/cn.js'
+import { useDemoTour } from './DemoTour.js'
+
+/**
+ * The coachmark: a ring around the current step's target, and a tooltip beside it.
+ *
+ * The ring is drawn as a positioned box rather than by mutating the target, so
+ * nothing the tour highlights has its own styles touched and no cleanup can
+ * leave a stray class behind on a clinical surface.
+ *
+ * It borrows the target's own `border-radius`, which is what stops a rounded
+ * card from getting a boxy rectangle drawn around it.
+ */
+
+const ROUTE_RENDER_DELAY_MS = 90
+/** Half the tooltip's max width plus a margin, so it never runs off an edge. */
+const TOOLTIP_HALF = 184
+const EDGE = 16
+
+export function Spotlight() {
+  const { active, currentStep, steps, next, back, stop } = useDemoTour()
+  const step = active && currentStep >= 0 ? steps[currentStep] : undefined
+  const [rect, setRect] = useState<DOMRect | null>(null)
+  const [radius, setRadius] = useState<string | null>(null)
+
+  /*
+   * Keyed on the step object, not on its `target` string. Steps come from a
+   * module-level constant, so each index is a stable distinct object, and two
+   * steps that happened to share a selector would still re-run this effect and
+   * re-scroll. Depending on the string alone silently skips that case.
+   */
+  useEffect(() => {
+    const target = step?.target
+    if (!active || !target) {
+      setRect(null)
+      return
+    }
+
+    // `update` is hoisted above the guard above, so the narrowing on `target`
+    // does not reach inside it. Capturing it here does.
+    const selector = target
+    let observed: Element | null = null
+    const observer = new ResizeObserver(() => update())
+
+    function update() {
+      const element = document.querySelector(selector)
+      if (!element) {
+        setRect(null)
+        return
+      }
+      const box = element.getBoundingClientRect()
+      if (box.width <= 0 || box.height <= 0) {
+        setRect(null)
+        return
+      }
+      setRect(box)
+      setRadius(window.getComputedStyle(element).borderRadius || null)
+      if (observed !== element) {
+        if (observed) observer.unobserve(observed)
+        observer.observe(element)
+        observed = element
+      }
+    }
+
+    update()
+
+    /*
+     * Wait for the target to exist rather than checking once and giving up.
+     *
+     * A step that navigates lands on a screen still fetching its consultation,
+     * so the anchor is not in the DOM yet and a single retry on a timer only
+     * works when the network happens to be fast. That is the worst possible
+     * failure mode for this feature: it passes locally and drops the ring
+     * during the live demo it exists for.
+     *
+     * Coalesced through rAF because the subtree observer fires per mutation
+     * and `update` touches layout.
+     */
+    let queued = 0
+    const watcher = new MutationObserver(() => {
+      if (queued) return
+      queued = requestAnimationFrame(() => {
+        queued = 0
+        update()
+      })
+    })
+    watcher.observe(document.body, { childList: true, subtree: true })
+
+    // A target inside a scrolling rail may be out of view even once it exists.
+    const settle = window.setTimeout(() => {
+      document.querySelector(selector)?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+      update()
+    }, ROUTE_RENDER_DELAY_MS)
+
+    window.addEventListener('resize', update)
+    window.addEventListener('scroll', update, true)
+    return () => {
+      observer.disconnect()
+      watcher.disconnect()
+      if (queued) cancelAnimationFrame(queued)
+      window.clearTimeout(settle)
+      window.removeEventListener('resize', update)
+      window.removeEventListener('scroll', update, true)
+    }
+  }, [active, step])
+
+  // Escape leaves the tour from anywhere. A guided mode with no way out is a trap.
+  useEffect(() => {
+    if (!active) return
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') stop()
+      if (event.key === 'ArrowRight') next()
+      if (event.key === 'ArrowLeft') back()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [active, next, back, stop])
+
+  if (!active || !step) return null
+
+  const below = rect ? rect.bottom + 150 < window.innerHeight : false
+  const tooltipStyle: CSSProperties = rect
+    ? {
+        top: below ? rect.bottom + 14 : Math.max(EDGE, rect.top - 14),
+        left: Math.min(
+          Math.max(rect.left + rect.width / 2, TOOLTIP_HALF + EDGE),
+          window.innerWidth - TOOLTIP_HALF - EDGE,
+        ),
+        transform: below ? 'translate(-50%, 0)' : 'translate(-50%, -100%)',
+      }
+    : { bottom: '6rem', left: '50%', transform: 'translateX(-50%)' }
+
+  return (
+    <>
+      {rect && (
+        <div
+          aria-hidden
+          className="pointer-events-none fixed ring-2 ring-accent ring-offset-2 ring-offset-ground transition-[top,left,width,height] duration-200 ease-out-quart"
+          style={{
+            top: rect.top,
+            left: rect.left,
+            width: rect.width,
+            height: rect.height,
+            borderRadius: radius ?? undefined,
+            zIndex: 'var(--z-modal)',
+          }}
+        />
+      )}
+
+      {/* `alert` rather than `status`: the tooltip is the tour's whole voice, and
+          a polite live region would be read after whatever else is speaking. */}
+      <div
+        role="alert"
+        style={{ ...tooltipStyle, zIndex: 'var(--z-tooltip)', position: 'fixed' }}
+        className={cn(
+          'w-[22rem] max-w-[calc(100vw-2rem)] rounded-card border border-line bg-surface p-4 shadow-float',
+        )}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <span className="text-2xs font-semibold tracking-wide text-accent uppercase">
+            {step.label}
+          </span>
+          <button
+            type="button"
+            onClick={stop}
+            aria-label="End the walkthrough"
+            className="-mt-1 -mr-1 flex size-7 shrink-0 items-center justify-center rounded-control text-ink-muted transition-colors hover:bg-sunken hover:text-ink"
+          >
+            <X aria-hidden className="size-4" />
+          </button>
+        </div>
+
+        <p className="mt-1.5 text-sm leading-relaxed text-ink">{step.hint}</p>
+
+        <div className="mt-3 flex items-center justify-between gap-2">
+          <span className="text-2xs text-ink-muted">
+            {currentStep + 1} of {steps.length}
+          </span>
+          <div className="flex gap-1.5">
+            <button
+              type="button"
+              onClick={back}
+              disabled={currentStep === 0}
+              className="flex h-8 items-center gap-1.5 rounded-control px-2.5 text-xs font-medium text-ink-muted transition-colors hover:bg-sunken hover:text-ink disabled:pointer-events-none disabled:opacity-40"
+            >
+              <ArrowLeft aria-hidden className="size-3.5" />
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={next}
+              className="flex h-8 items-center gap-1.5 rounded-control bg-accent px-3 text-xs font-medium text-accent-ink shadow-raised transition-[background-color,transform] duration-150 ease-out-quart hover:bg-accent-hover active:scale-[0.97]"
+            >
+              {currentStep === steps.length - 1 ? 'Finish' : 'Next'}
+              {currentStep < steps.length - 1 && <ArrowRight aria-hidden className="size-3.5" />}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/routes/ConsultationList.tsx
+++ b/frontend/src/routes/ConsultationList.tsx
@@ -50,7 +50,7 @@ export function ConsultationList() {
         }
       />
 
-      <div className="mt-8 flex flex-col gap-2">
+      <div data-tour="consultation-list" className="mt-8 flex flex-col gap-2">
         {isPending &&
           [0, 1, 2].map((key) => <Skeleton key={key} className="h-18 w-full rounded-card" />)}
 

--- a/frontend/src/routes/ConsultationNew.tsx
+++ b/frontend/src/routes/ConsultationNew.tsx
@@ -99,7 +99,12 @@ export function ConsultationNew() {
         art="/art/new-consultation.webp"
       />
 
-      <div role="tablist" aria-label="Transcript source" className="mt-6 flex flex-wrap gap-1">
+      <div
+        role="tablist"
+        aria-label="Transcript source"
+        data-tour="intake"
+        className="mt-6 flex flex-wrap gap-1"
+      >
         {TABS.map(({ id, label, Icon }) => (
           <button
             key={id}

--- a/frontend/src/routes/ConsultationReview.tsx
+++ b/frontend/src/routes/ConsultationReview.tsx
@@ -151,6 +151,7 @@ export function ConsultationReview() {
               showTranscript ? 'block' : 'hidden lg:block',
             )}
             aria-labelledby="transcript-heading"
+            data-tour="transcript"
             data-print="hide"
           >
             <h2 id="transcript-heading" className="mb-2 text-sm font-semibold">

--- a/frontend/src/routes/Guidelines.tsx
+++ b/frontend/src/routes/Guidelines.tsx
@@ -100,7 +100,7 @@ export function Guidelines() {
 
       {guidelines.data && (
         <>
-          <Card className="mt-6 p-5">
+          <Card data-tour="corpus" className="mt-6 p-5">
             <p className="text-sm leading-relaxed text-ink-muted">
               A suggestion carries a guideline ID, never free text. The model is given only these{' '}
               <span className="font-medium text-ink">{all.length} entries</span> and can cite

--- a/frontend/src/shell/AppShell.tsx
+++ b/frontend/src/shell/AppShell.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useState } from 'react'
 import { Outlet, useMatch } from 'react-router-dom'
+import { DemoStepBar } from '../demo/DemoStepBar.js'
+import { DemoTourProvider } from '../demo/DemoTour.js'
+import { HelpButton } from '../demo/HelpButton.js'
+import { Spotlight } from '../demo/Spotlight.js'
 import { cn } from '../lib/cn.js'
 import { CursorGlow } from '../ui/CursorGlow.js'
 import { MobileDock } from './MobileDock.js'
@@ -30,31 +34,43 @@ export function AppShell() {
   const suppressFooter = reviewMatch != null && reviewMatch.params.id !== 'new'
 
   return (
-    <div className="reveal-shell">
-      <div className={cn('reveal-page dot-grid', suppressFooter && 'reveal-page--no-footer')}>
-        <CursorGlow />
+    // The tour provider wraps the shell rather than the app, so it sits inside
+    // the authenticated boundary: it walks real consultations and has nothing
+    // to narrate on the marketing routes.
+    <DemoTourProvider>
+      <div className="reveal-shell">
+        <div className={cn('reveal-page dot-grid', suppressFooter && 'reveal-page--no-footer')}>
+          <CursorGlow />
 
-        <SidebarIsland onExpandedChange={onExpandedChange} />
+          <SidebarIsland onExpandedChange={onExpandedChange} />
 
-        <div className="scrim" data-visible={dimmed} data-print="hide" aria-hidden />
+          <div className="scrim" data-visible={dimmed} data-print="hide" aria-hidden />
 
-        <MobileDock />
+          <MobileDock />
 
-        {/* On md+ the left offset clears the collapsed island and never reflows
-            when it expands: content shifting under a hover would be worse than
-            the dimming it replaces. On small screens the dock is at the bottom,
-            so the padding moves there to clear it. */}
-        {/* Every signed-in route renders a bare `mx-auto max-w-*` container with
-            no vertical spacing of its own, so this padding is the only thing
-            between a page header and the top of the viewport. The bottom half
-            also has to clear two different things: the mobile dock below md,
-            and the sticky approve bar on the review screen. */}
-        <main className="px-4 pt-8 pb-32 md:py-10 md:pr-6 md:pl-24">
-          <Outlet />
-        </main>
+          {/* On md+ the left offset clears the collapsed island and never reflows
+              when it expands: content shifting under a hover would be worse than
+              the dimming it replaces. On small screens the dock is at the bottom,
+              so the padding moves there to clear it. */}
+          {/* Every signed-in route renders a bare `mx-auto max-w-*` container with
+              no vertical spacing of its own, so this padding is the only thing
+              between a page header and the top of the viewport. The bottom half
+              also has to clear two different things: the mobile dock below md,
+              and the sticky approve bar on the review screen. */}
+          <main className="px-4 pt-8 pb-32 md:py-10 md:pr-6 md:pl-24">
+            <Outlet />
+          </main>
+        </div>
+
+        {!suppressFooter && <SiteFooter />}
+
+        {/* Outside the page layer: the spotlight ring and the step bar sit above
+            the sidebar and the scrim, and a coachmark clipped by the surface it
+            is pointing at would defeat itself. */}
+        <HelpButton />
+        <DemoStepBar />
+        <Spotlight />
       </div>
-
-      {!suppressFooter && <SiteFooter />}
-    </div>
+    </DemoTourProvider>
   )
 }


### PR DESCRIPTION
## What Changed

A floating button opens a confirm dialog and starts a nine-step guided
walkthrough that spotlights each stage of the real consultation flow.

Closes #28.

## Why

It doubles as the live-demo driver, and the reconciliation on #28 found the
anchors were already placed but none of the machinery existed.

## The Hard Constraint, And How It Is Met

**The walkthrough narrates the real pipeline. It does not simulate it.** Every
note, gap, red flag and citation it points at was produced by the actual
de-identification gate, model call, rules engine and evidence check. No
hardcoded analysis payloads, no stubbed responses, no synthetic latency.

It is also **read-only**. It navigates and explains; it never analyses, edits or
approves on the user's behalf, so it cannot trip the approval gate the product
exists to enforce. The confirm dialog states both facts before the user agrees
to anything.

## The Departure From The Original Ask, Which Needs A Decision

The ask was for a self-contained mode that creates its own consultations and
deletes them when the demo ends. **That is not buildable today.**

- #64 moved `AuditEvent` to `onDelete: Restrict`, so a consultation can no
  longer be hard-deleted; the point was that a deletion must not silently break
  the tamper-evident hash chain.
- The tombstone erasure that replaced it (`eraseConsultation`) has **no HTTP
  endpoint on purpose**, gated on the retention decision in TRD §19 that is
  still open.

So a self-contained tour has no API-reachable way to clean up after itself, and
creating rows it cannot remove is worse than creating none. Adding an erasure
endpoint to unblock a demo feature would be routing around a control that exists
for audit integrity, which is not a call to make in a UI PR.

**This walks the five seeded consultations instead.** They came out of the real
pipeline, so the no-mocking constraint still holds, and it survives a bad
network. If literal self-containment is still wanted, it is a new issue behind
the erasure endpoint behind the retention decision, in that order.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manually exercised the affected flow

359 tests pass. Driven end to end in a real browser against the local API and the
seeded guest account, walking all nine steps and asserting the spotlight ring
actually resolved its target on each one:

```
step  1  Consultations  /consultations         ring OK 896x402
step  2  Intake         /consultations/new     ring OK 896x40
step  3  Transcript     /consultations/cmsrw…  ring OK 280x573
step  4  Red Flags      /consultations/cmsrw…  ring OK 356x170
step  5  Gaps           /consultations/cmsrw…  ring OK 356x210
step  6  Checklist      /consultations/cmsrw…  ring OK 600x52
step  7  Approval       /consultations/cmsrw…  ring OK 1280x74
step  8  Citations      /consultations/cmss2…  ring OK 356x272
step  9  Corpus         /guidelines            ring OK 896x108
```

Also asserted: Escape ends the tour from any step, Finish clears it and restores
the button, and the tour is absent from the marketing shell entirely. No console
errors on any step.

## Two Bugs Found By Driving It, Not By Reading It

Both would have failed during a live demo and neither is visible from the code.

**The spotlight checked for its target once and gave up.** Any step landing on a
screen still fetching its consultation drew no ring, because the anchor was not
in the DOM yet. It now watches the DOM until the target appears. This only
manifests when the network is slow, which is precisely when someone is
presenting.

**No single seeded consultation has both red flags and cited suggestions.** The
flagged one carries five flags and zero citations; the ones with citations carry
no flags. A tour pinned to one consultation therefore *must* point one stop at
an element that does not exist. Steps now declare which subject they need and
the tour resolves two consultations. The approval stop is also kept off the
approved consultation, since the approve bar only renders while a note is still
awaiting review.

## Notes For The Reviewer

The red-flag stop landed on a consultation showing an `EMERGENCY` airway-
compromise flag marked `Rule` above two `AI Suggested` ones, which is the
rule-versus-model distinction demonstrating itself without narration. Worth
keeping that consultation in the seed.

Anchors added: transcript panel, intake tabs, consultation list, corpus card.
The red-flag anchor is matched as `[data-tour^="flag-"]` since the existing
attribute carries the severity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided demo tour with nine interactive steps covering key workflows and features.
  * Added a floating Help button with tour details, start, cancel, and loading controls.
  * Added responsive tour navigation with progress tracking, collapse controls, and an option to end the tour.
  * Added spotlight highlights, tooltips, keyboard navigation, and automatic scrolling to relevant content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->