### PR TITLE
ci: deploy only when the push can change the deployed bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,76 @@ jobs:
   #     deployment Ready while catatmd.vercel.app kept serving the previous
   #     build. That is why this job asserts what the domain actually serves
   #     rather than trusting the deploy step's exit code.
-  deploy:
-    name: Deploy to Vercel
+  # A deployment is a metered resource on this plan (100 per rolling 24 hours),
+  # and exceeding it does not fail loudly: Vercel returns `BLOCKED` with a null
+  # `errorCode`, a null `errorMessage` and a 0ms build, while the CLI prints
+  # "Your deployment failed. Please retry later." That reads like a build
+  # failure, so the natural response is to retry, which spends another slot and
+  # cannot succeed. Observed 14/08/26 at 97 of 100 (GitHub issue #82).
+  #
+  # Most of that budget went on commits that could not change the bundle. A
+  # docs-only change ran `vercel pull`, `build` and `deploy` to ship a
+  # byte-identical frontend. This job decides whether the push touched anything
+  # the deployed artefact is built from.
+  #
+  # It fails OPEN. If the previous commit cannot be resolved, which happens on a
+  # first push, a force push, or a re-run after history moved, it deploys. A
+  # wasted deployment costs one slot; a skipped one silently leaves production
+  # behind `main`, which is the failure the assertions further down exist to
+  # catch and is far more expensive.
+  #
+  # Expected consequence, so it is not later misread as drift: after a skipped
+  # deploy the production alias points at the deployment built from the last
+  # commit that touched these paths, not at `main`'s tip. The bundle it serves
+  # is byte-identical either way, which is the whole reason the deploy was
+  # skipped. Only the commit stamp differs. The backend is unaffected: Render
+  # deploys the API from its own trigger on every push, independently of this.
+  changes:
+    name: Detect deployable changes
     needs: verify
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      deployable: ${{ steps.filter.outputs.deployable }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether this push can change the deployed bundle
+        id: filter
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$BEFORE" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "Previous commit unavailable; deploying rather than guessing."
+            echo "deployable=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed="$(git diff --name-only "$BEFORE" "$GITHUB_SHA")"
+          echo "Changed files:"
+          echo "$changed" | sed 's/^/  /'
+
+          # `shared/` is here because the frontend imports @shared/types and the
+          # build inlines it. `vercel.json` and this workflow both change how the
+          # deployment is produced.
+          if echo "$changed" | grep -qE '^(frontend/|shared/|vercel\.json$|\.github/workflows/ci\.yml$)'; then
+            echo "deployable=true" >> "$GITHUB_OUTPUT"
+            echo "Deployable paths touched."
+          else
+            echo "deployable=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No deployable paths changed; skipping the Vercel deployment."
+          fi
+
+  deploy:
+    name: Deploy to Vercel
+    needs: [verify, changes]
+    if: needs.changes.outputs.deployable == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
Closes #82. Diagnosis by @Andersonnn7788, who counted it from the API rather than guessing and then stopped rather than retrying into the wall.

## The Failure Mode Is Designed To Be Misread

Exceeding the plan's rolling 24 hour deployment cap does not fail loudly. Vercel returns:

```
readyState:    BLOCKED
errorCode:     null
errorMessage:  null
build:         0ms
```

while the CLI prints **"Your deployment failed. Please retry later."** That reads like a build failure, so the natural response is to retry, and each retry spends another slot and cannot succeed. That happened once here before it was caught.

## I Checked The Count Before Filtering It

@Andersonnn7788 asked whether 97 deployments in a day for two people indicated a loop, which was the right question: a filter that hides a runaway is worse than no filter.

**It is not a loop.** Broken down by source:

| Source | Count | Status                                             |
| ------ | ----- | ---------------------------------------------------- |
| `git`  | 62    | Git-integration, **already stopped**, none since 16:49Z |
| `cli`  | 35    | This workflow, one per push to `main`                 |

The Git-integration deploys died when `git.deploymentEnabled` landed, `main` first and then all branches with #60. They dominate the window purely as history and age out on their own. The live rate is one CLI deployment per merge, which is expected.

So the cap was reached by legitimate work plus a large tail of deployments that no longer happen. The remaining waste is real but smaller than the raw number suggests.

## The Change

A `changes` job resolves what the push touched; `deploy` gates on it. `verify` stays unfiltered, because typecheck and tests should run on every push regardless.

Deployable paths are `frontend/**`, `shared/**`, `vercel.json`, and this workflow. `shared/` is included because the frontend imports `@shared/types` and the build inlines it.

**It fails open.** If the previous commit cannot be resolved (first push, force push, re-run after history moved) it deploys. A wasted deployment costs one slot; a skipped one leaves production behind `main`, which is the exact failure the alias assertions exist to catch and is far more expensive.

## Verified Against Real History

The classifier run over the last eight commits on `main`:

```
DEPLOY  feat(ui): Demo Mode walkthrough
DEPLOY  style(ui): rounded rectangle CTAs
DEPLOY  feat(ui): searchable guideline corpus
DEPLOY  style(ui): strengthen the glass
skip    docs(security): replace the imported rules
skip    test(redflags): pin fail-open behaviour
skip    fix(llm): pin QWEN_MODEL to qwen3.7-flash
skip    fix(redflags): stop firing on the doctor's question
```

Half. `f46ec97`, the docs commit whose deployment was `BLOCKED` and prompted this issue, correctly skips.

**Backend-only commits skipping is correct, not a regression.** The Vercel deployment ships the SPA only; Render deploys the API from its own trigger on every push and is untouched by this filter.

## One Expected Consequence, Documented In The Workflow

After a skipped deploy the production alias points at the deployment built from the last commit that touched a deployable path, not at `main`'s tip. The bundle it serves is byte-identical, which is precisely why the deploy was skipped, and only the commit stamp differs. Written into the comment so a later reader does not diagnose it as the alias drift this job was built to detect.

## Not Done Deliberately

The failed run on `f46ec97` has **not** been retried. Each attempt spends a deployment that cannot succeed until the window frees. `main` returns to green on its own as deployments age out; this PR stops the recurrence.

## Clinical-Safety Checklist

Not applicable. CI configuration only. No application code, no `deid/`, `lib/llm/`, `redflags/`, `guidelines/` or logging. The deployment assertions, the concurrency policy and the readiness check are all unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow decision-making by detecting whether deployable project areas have changed.
  * Deployments now run only when relevant changes are detected, while still deploying safely when commit history is unavailable.
  * Deployment verification remains required before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->