### PR TITLE
ci: treat the root build inputs as deployable paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,8 +174,13 @@ jobs:
 
           # `shared/` is here because the frontend imports @shared/types and the
           # build inlines it. `vercel.json` and this workflow both change how the
-          # deployment is produced.
-          if echo "$changed" | grep -qE '^(frontend/|shared/|vercel\.json$|\.github/workflows/ci\.yml$)'; then
+          # deployment is produced. The three root files are build inputs Vercel
+          # reads even when nothing under `frontend/` moved: `bun.lock` and the
+          # root `package.json` are what `installCommand: bun install` resolves
+          # against, and `frontend/tsconfig.json` extends `../tsconfig.json`, so
+          # `tsc -b` reads the root one. Each alternative is anchored by the
+          # leading `^`, so `backend/package.json` still skips correctly.
+          if echo "$changed" | grep -qE '^(frontend/|shared/|vercel\.json$|bun\.lock$|package\.json$|tsconfig\.json$|\.github/workflows/ci\.yml$)'; then
             echo "deployable=true" >> "$GITHUB_OUTPUT"
             echo "Deployable paths touched."
           else


### PR DESCRIPTION
## What Changed

The deployable-paths filter from #83 now also matches the root `bun.lock`, `package.json`, and `tsconfig.json`. A push touching only those files used to skip its deploy and leave production behind `main`.

Follow-up to #83, reported by @AlaskanTuna in review.

## Why

Three root files are build inputs Vercel reads even when nothing under `frontend/` or `shared/` moved:

| File | Why it reaches the bundle |
| --- | --- |
| `bun.lock` | `vercel.json` sets `installCommand: bun install`, which resolves against it — a transitive resolution change lands in the bundle with no source file moving |
| `package.json` (root) | Declares `workspaces: [shared, backend, frontend]`, so it governs what that install produces |
| `tsconfig.json` (root) | `frontend/tsconfig.json` opens with `extends: "../tsconfig.json"`, and the frontend builds with `tsc -b` |

This is the exact failure mode the filter's fail-open branch was written to avoid: a silent skip is worse than a wasted deploy, because production drifts from `main` with nothing signalling it.

**It has already happened once.** Replaying both filters over the last 40 commits changes two classifications, and one is the case itself — `9a69fee` *("fix(deps): commit the lockfile for the self-hosted font")* touched only `bun.lock` and genuinely changed the frontend bundle. The old filter would have skipped that deploy.

## Verification

- [x] Classifier replayed over the last 40 commits — 2 classifications change, both correctly toward DEPLOY
- [x] 12 synthetic path cases, regex extracted from the workflow itself rather than retyped
- [x] `.github/workflows/ci.yml` parses (`yaml.safe_load`, 3 jobs)

Anchoring is the part worth checking, since it is what keeps the fix from over-firing:

| Path | Result |
| --- | --- |
| `bun.lock`, `package.json`, `tsconfig.json` | DEPLOY |
| `backend/package.json`, `backend/tsconfig.json` | skip |
| `docs/trd.md`, `backend/src/app.ts`, `prisma/schema.prisma`, `render.yaml` | skip |

Each alternative sits under the leading `^`, so only the root copies match.

## Notes For The Reviewer

Clinical-Safety section deleted — CI configuration only, no source paths touched.

Cost is ~5% more deploys (2 in 40), which is the right trade against a silent production/`main` divergence. The filter still cannot catch a Vercel project-setting change made in the dashboard; that is outside the repo and outside what a path filter can see.