### PR TITLE
test(llm): guard the provider SDK boundary and cover the egress check

### DIFF
--- a/backend/src/lib/llm/no-stray-provider-sdk.test.ts
+++ b/backend/src/lib/llm/no-stray-provider-sdk.test.ts
@@ -1,0 +1,197 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * GitHub issue #81. `backend/src/lib/llm/` is the only egress point to any
+ * provider, and this fails the build when a second SDK import appears.
+ *
+ * The invariant already held when this was written: one provider import exists
+ * repo-wide, `import OpenAI from 'openai'` in `openai-compatible.ts`. This
+ * guards against regression, and it is the only item on the PR Clinical-Safety
+ * Checklist that was previously enforced by nothing but a reviewer noticing.
+ * `biome.json` has no rule that could catch it.
+ *
+ * Four scope choices, all deliberate:
+ *
+ * 1. **`frontend/` and `shared/` are scanned, not just the backend.** A
+ *    provider SDK in the SPA is strictly worse than one in the API, because the
+ *    bundle is public and the key ships with it. Scanning only the tree where
+ *    the rule is easiest to keep would miss the case that costs the most.
+ * 2. **Specifiers are parsed, then compared. The line is not regex-matched.**
+ *    `ai` is a real package name and a substring of half the identifiers in
+ *    this codebase, so matching text would either miss `import { x } from 'ai'`
+ *    or fire on `chai`. Resolving the specifier to its package name and
+ *    comparing exactly is the only version that is both sound and complete.
+ * 3. **Subpaths resolve to their package.** `openai/resources` is the same
+ *    dependency and the same egress.
+ * 4. **The repo-wide count is pinned, not just the absence outside the
+ *    directory.** security.md's wording is that a second provider SDK
+ *    *anywhere* is a critical defect, and the architecture is one adapter
+ *    configured per provider rather than one adapter each. A second SDK added
+ *    inside `lib/llm/` is exactly the hurried change this should catch, and an
+ *    outside-only guard would wave it through.
+ */
+const REPO_ROOT = fileURLToPath(new URL('../../../../', import.meta.url))
+
+/** The one directory allowed to import a provider SDK. */
+const LLM_MODULE = 'backend/src/lib/llm/'
+
+const SCANNED_TREES = [
+  { dir: 'backend/src', extensions: ['.ts'] },
+  { dir: 'frontend/src', extensions: ['.ts', '.tsx'] },
+  { dir: 'shared/src', extensions: ['.ts'] },
+  { dir: 'prisma', extensions: ['.ts'] },
+]
+
+/**
+ * Exact package names. Scoped families that publish one adapter per provider
+ * are matched by prefix below instead, because enumerating them goes stale the
+ * day a new provider ships.
+ */
+const PROVIDER_PACKAGES = new Set([
+  'openai',
+  '@google/genai',
+  '@google/generative-ai',
+  '@anthropic-ai/sdk',
+  'ai',
+  'cohere-ai',
+  'groq-sdk',
+  'replicate',
+])
+
+const PROVIDER_SCOPES = ['@ai-sdk/', '@mistralai/']
+
+/** `import x from 'y'`, `import 'y'`, `require('y')`, `await import('y')`. */
+const SPECIFIER = /(?:\bfrom\s*|\bimport\s*|\bimport\s*\(\s*|\brequire\s*\(\s*)['"]([^'"]+)['"]/g
+
+/** `@scope/pkg/sub` to `@scope/pkg`; `pkg/sub` to `pkg`; `./local` to null. */
+function packageName(specifier: string): string | null {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) return null
+  const segments = specifier.split('/')
+  if (specifier.startsWith('@')) {
+    return segments.length >= 2 ? `${segments[0]}/${segments[1]}` : null
+  }
+  return segments[0] ?? null
+}
+
+function isProviderSdk(specifier: string): boolean {
+  const name = packageName(specifier)
+  if (name === null) return false
+  return PROVIDER_PACKAGES.has(name) || PROVIDER_SCOPES.some((scope) => name.startsWith(scope))
+}
+
+/**
+ * A guard that forbids *naming* the thing it guards against gets worked around.
+ * Prose listing the banned SDKs should not trip it, and no line starting a
+ * comment can execute.
+ */
+function isComment(line: string): boolean {
+  return /^\s*(\/\/|\/\*|\*)/.test(line)
+}
+
+function sourceFiles(): string[] {
+  const found: string[] = []
+
+  for (const { dir, extensions } of SCANNED_TREES) {
+    const walk = (absolute: string) => {
+      for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+        const child = join(absolute, entry.name)
+        if (entry.isDirectory()) {
+          if (entry.name !== 'migrations' && entry.name !== 'node_modules') walk(child)
+        } else if (extensions.some((extension) => entry.name.endsWith(extension))) {
+          found.push(relative(REPO_ROOT, child).replaceAll('\\', '/'))
+        }
+      }
+    }
+
+    walk(join(REPO_ROOT, dir))
+  }
+
+  return found
+}
+
+/** Every provider import in the scanned trees, as `path:line: specifier`. */
+function providerImports(): string[] {
+  const found: string[] = []
+
+  for (const path of sourceFiles()) {
+    readFileSync(join(REPO_ROOT, path), 'utf8')
+      .split('\n')
+      .forEach((line, index) => {
+        if (isComment(line)) return
+
+        for (const match of line.matchAll(SPECIFIER)) {
+          const specifier = match[1]
+          if (specifier !== undefined && isProviderSdk(specifier)) {
+            found.push(`${path}:${index + 1}: ${specifier}`)
+          }
+        }
+      })
+  }
+
+  return found
+}
+
+describe('only lib/llm imports a provider SDK (issue #81)', () => {
+  it('finds source to scan in every tree, so an empty pass means something', () => {
+    const scanned = sourceFiles()
+
+    for (const { dir } of SCANNED_TREES) {
+      expect(
+        scanned.some((path) => path.startsWith(`${dir}/`)),
+        `scanned no files under ${dir}; the walk is broken or the tree moved`,
+      ).toBe(true)
+    }
+  })
+
+  it('recognises provider specifiers without firing on lookalikes', () => {
+    for (const specifier of [
+      'openai',
+      'openai/resources',
+      '@google/genai',
+      '@anthropic-ai/sdk',
+      'ai',
+      '@ai-sdk/openai',
+      '@mistralai/mistralai',
+    ]) {
+      expect(isProviderSdk(specifier), `${specifier} should be caught`).toBe(true)
+    }
+
+    for (const specifier of [
+      'chai',
+      'ai-utils',
+      'zod',
+      './ai.js',
+      '../lib/llm/index.js',
+      'vitest',
+    ]) {
+      expect(isProviderSdk(specifier), `${specifier} should not be caught`).toBe(false)
+    }
+  })
+
+  it('keeps every provider import inside lib/llm', () => {
+    const violations = providerImports().filter((entry) => !entry.startsWith(LLM_MODULE))
+
+    expect(
+      violations,
+      'A provider SDK is imported outside backend/src/lib/llm/. LLMClient is ' +
+        'the only egress point, and a second import is a path around the ' +
+        'de-identification gate. Route the call through LLMClient instead.',
+    ).toEqual([])
+  })
+
+  it('keeps the provider SDK count at exactly one repo-wide', () => {
+    const specifiers = providerImports().map((entry) => entry.split(': ').at(-1))
+
+    expect(
+      specifiers,
+      'The architecture is one OpenAI-compatible adapter configured per ' +
+        'provider, not one adapter each. A second provider SDK anywhere, ' +
+        'including inside lib/llm/, is a critical defect: it is a second ' +
+        'egress path that the deid gate and this guard were built to prevent. ' +
+        'Add configuration to OpenAICompatibleClient instead.',
+    ).toEqual(['openai'])
+  })
+})

--- a/backend/src/lib/llm/openai-compatible.test.ts
+++ b/backend/src/lib/llm/openai-compatible.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { DeidentificationError, deidentify } from '../../deid/index.js'
+import type { Deidentified } from '../../deid/types.js'
+
+/**
+ * GitHub issue #81. The egress guard at the top of `generate()` had no direct
+ * coverage: it was exercised only incidentally through `acceptance/safety.test.ts`
+ * and `deid/deid.test.ts`, neither of which can show that the request never
+ * left the process.
+ *
+ * That is the property worth testing. `assertNoIdentifiers` throwing is not the
+ * same claim as the provider never being called, and only the second one is the
+ * PHI boundary.
+ */
+
+const { completionsCreate, envMock } = vi.hoisted(() => ({
+  completionsCreate: vi.fn(),
+  envMock: { DEID_FAIL_CLOSED: true },
+}))
+
+/**
+ * Standing in for the SDK is what lets this assert on egress rather than on the
+ * exception. If `completionsCreate` is never called, nothing reached the
+ * network, which no amount of asserting on the thrown error can establish.
+ */
+vi.mock('openai', () => ({
+  default: class {
+    chat = { completions: { create: completionsCreate } }
+  },
+}))
+
+vi.mock('../../config/env.js', () => ({ env: envMock }))
+
+const { OpenAICompatibleClient } = await import('./openai-compatible.js')
+
+const Schema = z.object({ ok: z.boolean() })
+
+function client() {
+  return new OpenAICompatibleClient('qwen', 'qwen3.7-flash', {
+    apiKey: 'test-key',
+    baseURL: 'https://example.invalid/v1',
+  })
+}
+
+function request(content: Deidentified) {
+  return {
+    operation: 'test_operation',
+    system: 'system prompt',
+    content,
+    schema: Schema,
+    schemaName: 'test_schema',
+  }
+}
+
+/**
+ * The provenance gap this guard exists to close, reproduced deliberately.
+ *
+ * `markDeidentified` is module-private, so the only way to brand a string that
+ * still carries identifiers is the cast that `deid/types.ts` warns about.
+ * Writing it here is the point: the cast is the attack being simulated, not an
+ * endorsement of it, and a reviewer finding this pattern anywhere outside a
+ * test should treat it as the review-blocking defect the rules call it.
+ */
+const SMUGGLED = 'Patient NRIC is 850523-14-5677' as unknown as Deidentified
+
+beforeEach(() => {
+  completionsCreate.mockReset()
+  envMock.DEID_FAIL_CLOSED = true
+})
+
+describe('the adapter re-scans every payload before it leaves the process', () => {
+  it('throws DeidentificationError when a branded value still carries identifiers', async () => {
+    await expect(client().generate(request(SMUGGLED))).rejects.toBeInstanceOf(DeidentificationError)
+  })
+
+  it('never reaches the provider when the guard fires', async () => {
+    await expect(client().generate(request(SMUGGLED))).rejects.toThrow()
+
+    expect(
+      completionsCreate,
+      'The guard threw but the request still went out. Anything that calls the ' +
+        'SDK before assertNoIdentifiers defeats the PHI boundary.',
+    ).not.toHaveBeenCalled()
+  })
+
+  it('names detector labels in the error and never the matched values', async () => {
+    const error = await client()
+      .generate(request(SMUGGLED))
+      .catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(DeidentificationError)
+    expect((error as Error).message).toContain('NRIC')
+    expect(
+      (error as Error).message,
+      'An exception message is a log line waiting to happen. It carries labels only.',
+    ).not.toContain('850523-14-5677')
+  })
+
+  it('sends payloads that came through the gate', async () => {
+    completionsCreate.mockResolvedValue({
+      choices: [{ message: { content: '{"ok":true}' }, finish_reason: 'stop' }],
+    })
+
+    const { text } = deidentify('Patient NRIC is 850523-14-5677')
+
+    await expect(client().generate(request(text))).resolves.toEqual({ ok: true })
+    expect(completionsCreate).toHaveBeenCalledTimes(1)
+
+    const sent = completionsCreate.mock.calls[0]?.[0] as { messages: { content: string }[] }
+    expect(sent.messages[1]?.content).not.toContain('850523-14-5677')
+  })
+})
+
+/**
+ * `DEID_FAIL_CLOSED=false` is for unit tests only, and production throws at boot
+ * if it is unset or false (`config/env.ts`). Pinning the behaviour here makes
+ * the toggle documented rather than incidental, so a future reader can see what
+ * the flag actually costs.
+ */
+describe('DEID_FAIL_CLOSED=false skips the guard, which is why production forbids it', () => {
+  it('sends a payload the guard would have blocked', async () => {
+    envMock.DEID_FAIL_CLOSED = false
+    completionsCreate.mockResolvedValue({
+      choices: [{ message: { content: '{"ok":true}' }, finish_reason: 'stop' }],
+    })
+
+    await expect(client().generate(request(SMUGGLED))).resolves.toEqual({ ok: true })
+    expect(completionsCreate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/backend/src/lib/llm/openai-compatible.ts
+++ b/backend/src/lib/llm/openai-compatible.ts
@@ -30,10 +30,13 @@ export class OpenAICompatibleClient implements LLMClient {
 
   async generate<T>(request: GenerateRequest<T>): Promise<T> {
     // The egress guard (docs/trd.md §19 row 2). `Deidentified` guarantees the
-    // *shape* of what arrives here, not its *provenance* — `markDeidentified`
-    // is exported, so a value could in principle be branded without ever
-    // passing through detection (§5). This re-scans the payload immediately
-    // before it leaves the process and refuses to send it if anything fires.
+    // *shape* of what arrives here, not its *provenance*, so a value could in
+    // principle be branded without ever passing through detection (§5).
+    // `markDeidentified` has been module-private to `deid/index.ts` since
+    // 13/08/26, which closed the import-it-and-brand-anything route; a
+    // deliberate `as Deidentified` cast remains possible, because TypeScript
+    // cannot prevent one. This re-scans the payload immediately before it
+    // leaves the process and refuses to send it if anything fires.
     //
     // It runs inside the adapter rather than being injected, because a guard a
     // caller can omit by constructing the client differently is not a boundary.


### PR DESCRIPTION
## What Changed

The "no provider SDK outside `backend/src/lib/llm/`" invariant is now enforced by a test instead of by human attention, and the egress guard inside `OpenAICompatibleClient.generate` has direct coverage.

Closes #81.

## Why

It was the only one of the six Clinical-Safety Checklist items enforced by nothing but a reviewer noticing, and `biome.json` has no rule that could catch it. The invariant held before this PR; this prevents regression.

**`no-stray-provider-sdk.test.ts`** scans `backend/`, `frontend/`, `shared/` and `prisma/`. Two design points worth review:

- **It parses the module specifier and compares the resolved package name, rather than matching the line.** `ai` is a real package name and a substring of half the identifiers in this codebase, so a text match would either miss `import { x } from 'ai'` or fire on `chai`. Subpaths resolve to their package, so `openai/resources` is caught.
- **It pins the repo-wide count at one**, not merely the absence outside the directory. `security.md` says a second provider SDK *anywhere* is a critical defect, and the architecture is one adapter configured per provider rather than one adapter each. Suggested by @AlaskanTuna; the probe below shows it catches a case the outside-only check misses.

**`openai-compatible.test.ts`** covers the guard that previously had only indirect coverage. Standing in for the SDK is what lets it assert that **nothing reached the network** — `assertNoIdentifiers` throwing is a weaker claim than the provider never being called, and only the second one is the PHI boundary.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (372 passing)

The guard was verified by breaking it, then reverting (probes not committed):

| Probe | Location | Result |
| --- | --- | --- |
| `import OpenAI from 'openai'` | `backend/src/routes/` | both the location test and the count test fail |
| `import Anthropic from '@anthropic-ai/sdk'` | inside `lib/llm/` | count test fails; location test passes |
| reverted | | 4 pass |

The second row is the case an outside-only guard would have waved through.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider — this adds enforcement, no egress
- [x] No provider SDK imported outside `backend/src/lib/llm/` — now test-enforced repo-wide
- [x] Deterministic red-flag hits remain unsuppressable by the model — untouched
- [x] Citations remain ID-constrained; no free-text references accepted — untouched
- [x] No transcript bodies, note contents, or vault entries written to logs — a test asserts the error names detector labels and never the matched value
- [x] Fixtures added are synthetic — one synthetic NRIC already present in `fixtures/corpus.ts`

## Notes For The Reviewer

**One `as Deidentified` cast, deliberate, in the test only.** `markDeidentified` is module-private, so branding a string that still carries identifiers is the only way to reproduce the provenance gap the guard exists to close. The cast is the attack being simulated. It carries a comment saying so, and the same pattern outside a test should still be treated as the review-blocking defect the rules call it.

Test files are **not** exempt from the SDK guard: a provider SDK imported by a test still pulls the dependency into the tree. `vi.mock('openai', ...)` names the module in a string rather than an import, so mocking stays available.

Also corrects a comment in `openai-compatible.ts` that still claimed `markDeidentified` is exported (module-private since 13/08/26). The issue flagged it; it understated the boundary it was describing.

Backend-only, so the deploy filter skips this and it costs no Vercel deployment slot.