### PR TITLE
feat: name the approving clinician, and fix the Urgent rule contrast

### DIFF
--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -167,6 +167,15 @@ vi.mock('../lib/prisma.js', () => ({
         },
       ),
     },
+    // Issue #26: an approved consultation names the clinician who approved it,
+    // so the detail serialiser resolves the owning doctor. Only reached once
+    // `approvedAt` is set, which is why every unapproved-path test passed
+    // before this stub existed.
+    user: {
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) =>
+        where.id === 'doctor-1' ? { name: 'Dr Aminah Yusof' } : null,
+      ),
+    },
     auditEvent,
     // Appends run inside a transaction so the head read and the insert are
     // atomic (issue #27). The stand-in just runs the callback against the same
@@ -467,6 +476,33 @@ describe('state machine — approve', () => {
     expect(store.get('c1')?.status).toBe('approved')
     expect(store.get('c1')?.approvedAt).toBeInstanceOf(Date)
     expect(audits.map((a) => a.action)).toContain('consultation.approved')
+    // Issue #26: the export is a clinical document, and one that cannot say
+    // whose it is undercuts the record the approval gate exists to produce.
+    const { consultation } = (await res.json()) as { consultation: { approvedBy: string | null } }
+    expect(consultation.approvedBy).toBe('Dr Aminah Yusof')
+  })
+
+  it('names the approving clinician on a later read, not only in the approve response', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+    await call('POST', '/api/consultations/c1/approve')
+
+    const res = await call('GET', '/api/consultations/c1')
+
+    expect(res.status).toBe(200)
+    const { consultation } = (await res.json()) as { consultation: { approvedBy: string | null } }
+    expect(consultation.approvedBy).toBe('Dr Aminah Yusof')
+  })
+
+  it('leaves the clinician null until the approval transition has happened', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    const res = await call('GET', '/api/consultations/c1')
+
+    const { consultation } = (await res.json()) as {
+      consultation: { approvedAt: string | null; approvedBy: string | null }
+    }
+    expect(consultation.approvedAt).toBeNull()
+    expect(consultation.approvedBy).toBeNull()
   })
 
   it('refuses to approve a consultation with no analysis', async () => {

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -40,7 +40,7 @@ function doctorId(req: { doctorId?: string }): string {
  * JSON columns are `Json?` to Prisma, so this is the only place their shape is
  * actually checked.
  */
-function toDetail(row: Consultation) {
+function toDetail(row: Consultation, approvedBy: string | null = null) {
   return ConsultationDetailSchema.parse({
     id: row.id,
     status: row.status,
@@ -50,9 +50,32 @@ function toDetail(row: Consultation) {
     analysis: row.analysis ?? null,
     editedNote: row.editedNote ?? null,
     approvedAt: row.approvedAt,
+    approvedBy,
     acknowledgedRedFlagIds: row.acknowledgedRedFlagIds ?? [],
     reviewedGapIds: row.reviewedGapIds ?? [],
   })
+}
+
+/**
+ * Attaches the approving clinician's name (issue #26).
+ *
+ * Resolved from `doctorId` rather than from the approval audit event, because
+ * `assertOwnedConsultation` scopes every read and write on that column, so the
+ * owner is the only account that can reach the approve transition at all. If a
+ * clinic or admin boundary is ever added, that stops being true and the actor
+ * on the `consultation.approved` event becomes the authority instead. The
+ * `AuditEvent` row already records it, so the fix is a join, not a migration.
+ *
+ * Costs a query only on approved consultations; there is nothing to name until
+ * the transition has happened.
+ */
+async function toDetailWithApprover(row: Consultation) {
+  if (row.approvedAt === null) return toDetail(row)
+  const doctor = await prisma.user.findUnique({
+    where: { id: row.doctorId },
+    select: { name: true },
+  })
+  return toDetail(row, doctor?.name ?? null)
 }
 
 /**
@@ -148,12 +171,12 @@ consultationsRouter.post('/', async (req, res) => {
     })
   }
 
-  res.status(201).json({ consultation: toDetail(created) })
+  res.status(201).json({ consultation: await toDetailWithApprover(created) })
 })
 
 consultationsRouter.get('/:id', async (req, res) => {
   const consultation = await assertOwnedConsultation(req.params.id, doctorId(req))
-  res.json({ consultation: toDetail(consultation) })
+  res.json({ consultation: await toDetailWithApprover(consultation) })
 })
 
 /**
@@ -297,7 +320,7 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
       },
     })
 
-    res.json({ consultation: toDetail(updated) })
+    res.json({ consultation: await toDetailWithApprover(updated) })
   } catch (error) {
     // The doctor's only retry path is triggering analysis again — nothing
     // retries autonomously (docs/prd.md CAP-5).
@@ -412,7 +435,7 @@ consultationsRouter.patch('/:id', async (req, res) => {
     })
   }
 
-  res.json({ consultation: toDetail(updated) })
+  res.json({ consultation: await toDetailWithApprover(updated) })
 })
 
 consultationsRouter.post('/:id/approve', async (req, res) => {
@@ -446,5 +469,5 @@ consultationsRouter.post('/:id/approve', async (req, res) => {
     consultationId: consultation.id,
   })
 
-  res.json({ consultation: toDetail(updated) })
+  res.json({ consultation: await toDetailWithApprover(updated) })
 })

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -65,16 +65,26 @@ card, not the page ground.
 | Severity  | Light                             | Dark      | Text ratio on surface (light / dark) |
 | --------- | --------------------------------- | --------- | ------------------------------------ |
 | Emergency | `#B30D16` text, `#D0211F` rule    | `#FB7764` | 7.1:1 / 6.6:1                        |
-| Urgent    | `#A35700` text, `#E58400` rule    | `#F5A843` | 5.4:1 / 8.8:1                        |
+| Urgent    | `#A35700` text, `#D67600` rule    | `#F5A843` | 5.4:1 / 8.8:1                        |
 | Advisory  | `#0752B0` text, `#6FB8F5` rule    | `#6FB8F5` | 7.4:1 / 8.2:1                        |
 | Resolved  | `--color-ink-muted`, neutral rule | same      | de-emphasised, never green           |
 
-**One known weak spot.** The light Urgent _rule_ (`#E58400`) measures 2.8:1 on
-surface, under the 3:1 WCAG 1.4.11 asks of a graphical object that carries
-meaning. It is not the only channel, since every severity card also carries an
-icon and the word "Urgent", so 1.4.1 is satisfied and a colour-blind reader loses
-nothing. But the rule is doing real work at a glance and should be darkened when
-someone next touches the severity ramp. Recorded rather than quietly left.
+**Rule contrast is a separate check from text contrast**, and the one that gets
+missed. A severity rule is a graphical object carrying meaning, so WCAG 1.4.11
+asks 3:1 of it rather than the 4.5:1 its text needs. The light Urgent rule was
+`#E58400` at 2.8:1 against the card and failed that; it is now `#D67600` at
+3.2:1 (issue #77).
+
+`0.66` lightness is the _lightest_ value that clears 3:1, and that is the
+constraint rather than an accident. Darkening further buys contrast but walks
+Urgent toward `--color-emergency-rule` at `0.552` until the two read as one
+orange-red at a glance, and severity being distinguishable is the entire purpose
+of the rule. Contrast and separation pull against each other here; take the
+minimum that passes.
+
+The Urgent _text_ colour is untouched at 5.4:1. Nothing was ever unreadable, and
+1.4.1 always held, because every severity card carries the icon and the word
+alongside the colour.
 
 Green is reserved for Approve. A resolved red flag never turns green, because a doctor scanning for green would then be scanning for two different meanings.
 
@@ -245,4 +255,12 @@ A document, not a screenshot. Chrome, navigation, and controls are hidden; the n
 
 Two things paper needs that the screen does not. A capped, scrolling region is a screen affordance; on paper it silently cuts whatever sits below the fold, and the one region it applies to is the safety rail, so `[data-print="expand"]` makes it static and full-height. And gaps hidden behind the "show all" disclosure are restored by `print:block` rather than sliced out of the array, so paper never carries a truncated list with nothing to say it was truncated.
 
-> **Not yet true:** the approving clinician does not appear, on screen or on paper. `ApproveBar` renders the date and nothing else, so the exported document currently has no attribution. Tracked in issue #26, and it is the substantive gap in the export rather than a detail: the point of the approval gate is that the note becomes the doctor's.
+The approving clinician appears on screen and on paper, stated by the server
+rather than inferred by the client from the session. Today a consultation is
+only visible to the account that owns it, so the viewer and the approver are
+provably the same person, but that is an access-control property rather than a
+fact about the document: the moment a clinic or admin boundary exists, a note
+would start being attributed to whoever opened it.
+
+A name is not an identifier. A production deployment needs an MMC registration
+number, which the schema does not carry.

--- a/frontend/src/demo/HelpButton.tsx
+++ b/frontend/src/demo/HelpButton.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Play, Sparkles, X } from 'lucide-react'
+import { Loader2, Play, X } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { TOUR_STEP_COUNT, useDemoTour } from './DemoTour.js'
 
@@ -29,15 +29,26 @@ export function HelpButton() {
 
   return (
     <>
+      {/* Round, and the one deliberate exception to the rounded-rectangle CTA
+          rule in docs/DESIGN.md. A floating action button is a persistent
+          affordance parked over the content rather than an action inside a
+          layout, and the circle is what separates it from the interface it
+          floats above. A bare glyph rather than lucide's `HelpCircle`, whose
+          own ring would sit inside this one and read as a double border. */}
       <button
         type="button"
         onClick={() => dialog.current?.showModal()}
         data-print="hide"
+        aria-label="Take the guided tour"
+        title="Guided Tour"
         style={{ zIndex: 'var(--z-sticky)' }}
-        className="glass fixed right-4 bottom-20 flex h-12 items-center gap-2 rounded-control px-4 text-sm font-medium text-ink transition-[transform,background-color] duration-150 ease-out-quart hover:text-accent active:scale-[0.97] md:right-6 md:bottom-6"
+        // 7rem clears both pieces of bottom-docked chrome it would otherwise
+        // land on: the mobile dock below md, and the sticky approve bar on the
+        // review screen, which sits at the same right offset and is the primary
+        // action on the one screen where a help button must not compete.
+        className="glass fixed right-4 bottom-28 flex size-12 items-center justify-center rounded-full text-lg font-semibold text-accent transition-[transform,color] duration-150 ease-out-quart hover:text-accent-hover active:scale-[0.94] md:right-6"
       >
-        <Sparkles aria-hidden className="size-4 text-accent" />
-        Guided Tour
+        <span aria-hidden>?</span>
       </button>
 
       <dialog

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -46,7 +46,14 @@
   --color-emergency: oklch(0.486 0.192 27);
   --color-emergency-rule: oklch(0.552 0.208 28);
   --color-urgent: oklch(0.535 0.132 60);
-  --color-urgent-rule: oklch(0.703 0.163 62);
+  /* Darkened from 0.703, which measured 2.76:1 against the card and missed the
+   * 3:1 WCAG 1.4.11 asks of a graphical object carrying meaning (issue #77).
+   * 0.66 measures 3.24:1 and is the lightest value that clears it, which keeps
+   * the widest separation from `--color-emergency-rule` at 0.552: darkening
+   * further to buy contrast converges the two into one orange-red at a glance,
+   * and severity being distinguishable is the point of the rule. The Urgent
+   * *text* colour is untouched; it was already 5.38:1. */
+  --color-urgent-rule: oklch(0.66 0.163 62);
   --color-advisory: oklch(0.457 0.164 258);
   --color-advisory-rule: oklch(0.457 0.164 258);
 

--- a/frontend/src/review/ApproveBar.tsx
+++ b/frontend/src/review/ApproveBar.tsx
@@ -23,12 +23,14 @@ export function ApproveBar({
   consultationId,
   approved,
   approvedAt,
+  approvedBy,
   unacknowledgedCount,
   onApproved,
 }: {
   consultationId: string
   approved: boolean
   approvedAt: Date | null
+  approvedBy: string | null
   unacknowledgedCount: number
   onApproved: (next: ConsultationDetail) => void
 }) {
@@ -46,8 +48,12 @@ export function ApproveBar({
     return (
       <div className="mt-6 flex items-center gap-2 rounded-card border border-accent/30 bg-accent/8 px-4 py-3">
         <CheckCircle2 aria-hidden className="size-5 shrink-0 text-accent" />
+        {/* The attribution is the point of the approval, not decoration on it,
+            so it prints. Issue #26: an exported clinical document that cannot
+            say whose it is undercuts the record it exists to produce. */}
         <p className="text-sm">
           <span className="font-medium text-accent">Approved</span>
+          {approvedBy && <span className="text-ink"> by {approvedBy}</span>}
           {approvedAt && (
             <span className="text-ink-muted">
               {' '}

--- a/frontend/src/routes/ConsultationReview.tsx
+++ b/frontend/src/routes/ConsultationReview.tsx
@@ -288,6 +288,7 @@ export function ConsultationReview() {
           consultationId={id}
           approved={approved}
           approvedAt={detail.approvedAt}
+          approvedBy={detail.approvedBy}
           unacknowledgedCount={unacknowledged.length}
           onApproved={invalidate}
         />

--- a/shared/src/index.test.ts
+++ b/shared/src/index.test.ts
@@ -287,10 +287,33 @@ describe('API envelope schemas', () => {
       analysis: null,
       editedNote: null,
       approvedAt: null,
+      approvedBy: null,
       acknowledgedRedFlagIds: [],
       reviewedGapIds: [],
     })
     expect(result.success).toBe(true)
+  })
+
+  // The pair moves together or the contract is lying: a consultation cannot be
+  // approved by nobody, and cannot be attributed without having been approved.
+  it('carries the approving clinician alongside the approval timestamp', () => {
+    const approved = ConsultationDetailSchema.safeParse({
+      id: 'c1',
+      status: 'approved',
+      createdAt: '2026-08-13T00:00:00.000Z',
+      updatedAt: '2026-08-13T00:00:00.000Z',
+      transcript: null,
+      analysis: null,
+      editedNote: null,
+      approvedAt: '2026-08-13T01:00:00.000Z',
+      approvedBy: 'Dr Siti Rahman',
+      acknowledgedRedFlagIds: [],
+      reviewedGapIds: [],
+    })
+    expect(approved.success).toBe(true)
+    if (approved.success) {
+      expect(approved.data.approvedBy).toBe('Dr Siti Rahman')
+    }
   })
 
   it('shapes every error the same way', () => {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -419,6 +419,22 @@ export const ConsultationListItemSchema = ConsultationSchema.pick({
 export const ConsultationDetailSchema = ConsultationSchema.extend({
   editedNote: SoapNoteSchema.nullable(),
   approvedAt: z.coerce.date().nullable(),
+  /**
+   * The clinician who approved, by name, and `null` until one has.
+   *
+   * Stated by the server rather than inferred by the client from the session.
+   * Today a consultation is only ever visible to the account that owns it, so
+   * the viewer and the approver are provably the same person and the client
+   * could shortcut this. That equivalence is an access-control property, not a
+   * fact about the document: the moment a clinic or admin boundary exists, a
+   * note would start being attributed to whoever opened it. An approval is the
+   * transition that makes the record someone's, so who performed it belongs in
+   * the payload.
+   *
+   * A name is not an identifier. A production deployment needs an MMC
+   * registration number, which the schema does not carry today.
+   */
+  approvedBy: z.string().nullable(),
   acknowledgedRedFlagIds: z.array(z.string()),
   reviewedGapIds: z.array(z.string()),
 })


### PR DESCRIPTION
## What Changed

The approving clinician appears on the note and in the export, the light Urgent severity rule clears WCAG 1.4.11, and the guided-tour button is a round `?`.

Closes #26. Closes #77.

## Why

Adam's three decisions, taken together because they ship in one deploy and the budget is tight (99/100 on the rolling 24-hour cap).

## The Approving Clinician (#26)

**This was the substantive gap in the export, not a detail.** The approval gate exists to make the note the doctor's; a document that cannot say whose it is undercuts the thing it produces.

Adam was asked what identifies a doctor on a medico-legal document and did not have a view, so the assumption is written down rather than buried: **the clinician's name**, and explicitly *a name is not an identifier* — production needs an MMC registration number the schema does not carry.

**Stated by the server, not inferred by the client.** The frontend already knows the session user, and today a consultation is only visible to its owner, so viewer and approver are provably the same person. That is an access-control property rather than a fact about the document: the moment a clinic or admin boundary exists, a note starts being attributed to whoever opened it.

**Resolved from `doctorId`, not from the audit actor.** `assertOwnedConsultation` scopes every read and write on that column, so the owner is the only account that can reach the approve transition. If that ever stops being true, the `consultation.approved` event already records the actor, so the fix is a join rather than a migration.

No schema change and no migration: `User.name` is a required column that already exists, and the lookup only runs once `approvedAt` is set.

## The Urgent Rule (#77)

`oklch(0.703 …)` measured **2.76:1** against the card, under the 3:1 that WCAG 1.4.11 asks of a graphical object carrying meaning. Now `oklch(0.66 …)` at **3.24:1**.

That is the *lightest* value clearing the bar, and deliberately so. Darkening further buys contrast but walks Urgent toward `--color-emergency-rule` at `0.552` until the two read as one orange-red at a glance, and severity being distinguishable is the entire purpose of the rule. Contrast and separation pull against each other here.

The Urgent **text** colour is untouched at 5.4:1, which is the readability Adam's approval was conditioned on. Nothing was ever unreadable and 1.4.1 always held, because every severity card carries the icon and the word alongside the colour.

## The FAB

Round `?`, the one deliberate exception to the rounded-rectangle CTA rule from #76: a floating button is a persistent affordance parked over the content rather than an action inside a layout. A bare glyph rather than lucide's `HelpCircle`, whose own ring would sit inside this one and read as a double border.

**Raised to 7rem, which is a fix rather than a preference.** At `bottom-6` it landed on top of the Approve Note button — same right offset — on the one screen where a help button must not compete with the primary action. Found by measuring both rects, not by eye. 7rem also clears the mobile dock.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manually exercised the affected flow

**375 tests**, up from 372. The three new ones pin behaviour that would otherwise regress silently:

- the approve response names the clinician
- a *later read* names them too, not only the approve response
- the name stays null until the transition has happened

The shared contract test caught the schema change immediately, which is the system working. The backend suite then failed with a 500 because the Prisma mock had no `user` table; that stub is added and commented with why it is only reached on approved consultations.

Driven in a real browser against the local API and the seeded guest account:

```
FAB           48x48  radius=round  glyph="?"
API           approvedBy: "Guest"
rendered      "Approved by Guest on 14 Aug 2026, 6:11 am."
severity      emergency oklch(0.552 0.208 28)
              urgent    oklch(0.66 0.163 62)
FAB collision overlap=false  gap=35px
```

## Notes For The Reviewer

**#80 is not addressed here and deliberately so.** Adam's answer — data wiped when demo mode exits — is a behaviour requirement, not the TRD §19 retention decision the erasure endpoint is gated on. Building erasure against it would mean inventing a retention period he has not given. There is a path that sidesteps the gate entirely (a stateless analyse endpoint, so demo mode persists nothing and there is nothing to wipe), but it trades an unaudited LLM egress for it, which is a call for a human. Left on the issue.
