### PR TITLE
ci: pin actions to commit SHAs and audit dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,21 @@ jobs:
       DEID_FAIL_CLOSED: 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - run: bun install --frozen-lockfile
+
+      - name: Audit dependencies for known vulnerabilities
+        # OWASP A03:2025 Software Supply Chain Failures. Gated at `high` rather
+        # than `low` so a moderate advisory in a transitive dev dependency does
+        # not block clinical work, while the severities that would actually
+        # matter in a PHI-handling service still fail the build. Clean at the
+        # time this was added, so it starts enforcing rather than warning.
+        run: bun audit --audit-level=high
 
       - name: Generate Prisma client and apply migrations to the throwaway database
         run: |
@@ -151,7 +159,7 @@ jobs:
       deployable: ${{ steps.filter.outputs.deployable }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -206,9 +214,9 @@ jobs:
       PRODUCTION_DOMAIN: catatmd.vercel.app
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 


### PR DESCRIPTION
## What Changed

All five `uses:` in `ci.yml` are pinned to commit SHAs, and `verify` now runs `bun audit --audit-level=high`.

## Why

`.claude/rules/security.md` names supply chain as **"this repo's largest genuine gap"** (OWASP A03:2025) and asks for both of these specifically:

> **Pin GitHub Actions to commit SHAs.** `ci.yml` currently uses floating major tags (`actions/checkout@v4`, `oven-sh/setup-bun@v2`); convert them when you next touch the workflow.

> **Not built today:** no `bun audit`, no Dependabot or Renovate, no secret scanning, no SAST.

A floating major tag is a mutable reference to code that runs with repository credentials. `@v4` can be retagged to point at anything, so a compromised action executes in CI without a single change landing in this repo, and nothing in a diff would show it.

| Action | Pin |
| --- | --- |
| `actions/checkout` | `11d5960a326750d5838078e36cf38b85af677262` (v4) |
| `oven-sh/setup-bun` | `0c5077e51419868618aeaa5fe8019c62421857d6` (v2) |

The tag is kept in a trailing comment so the pin stays readable and a future upgrade knows what it was.

**`bun audit` is gated at `high`**, not `low`. A moderate advisory in a transitive dev dependency should not block clinical work, while the severities that would actually matter in a service handling PHI still fail the build. It reports clean today, so it starts enforcing rather than warning.

## Verification

- [x] `.github/workflows/ci.yml` parses (`yaml.safe_load`, 3 jobs)
- [x] No floating tag remains (`uses: …@vN` matches nothing)
- [x] `bun audit --audit-level=high` passes locally: "No vulnerabilities found"
- [x] SHAs resolved from the live GitHub API, dereferencing annotated tags to their commit
- [x] The deploy path filter is byte-identical after the edit

## Notes For The Reviewer

Clinical-Safety section deleted: CI configuration only, no source paths touched.

**Merge timing matters here.** `ci.yml` is a deployable path, so merging this spends a Vercel deployment slot. The 24h window was at 100/100 when this was opened, and a merge in that state would produce a BLOCKED deployment and a red `main`. Holding the merge until the window has headroom, and re-checking the count immediately before rather than assuming it drained.

This does not close the rest of the gap. There is still no Dependabot or Renovate, no secret scanning, and no SAST, and `bun audit` covers only advisories in the lockfile's dependency graph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and deployment workflow security by pinning automation actions to immutable versions.
  * Added a high-severity dependency vulnerability audit to verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->