### PR TITLE
feat(api): analyse a transcript without persisting it, for Demo Mode

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,7 +4,7 @@ import express from 'express'
 import helmet from 'helmet'
 import { env } from './config/env.js'
 import { errorHandler } from './middleware/error-handler.js'
-import { analyzeRateLimit } from './middleware/rate-limit.js'
+import { analyzeRateLimit, ephemeralAnalyzeRateLimit } from './middleware/rate-limit.js'
 import { requestContext } from './middleware/request-context.js'
 import { requireSession } from './middleware/require-session.js'
 import { authRouter } from './routes/auth.js'
@@ -46,6 +46,10 @@ export function createApp() {
   // Registered ahead of the consultation routes themselves so the limiter runs
   // whichever router later owns this path.
   app.post('/api/consultations/:id/analyze', analyzeRateLimit)
+  // Separate bucket, and tighter: this one is guest-reachable and takes its
+  // transcript from the body, so it spends an LLM call without the caller
+  // having stored anything first (#80).
+  app.post('/api/consultations/analyze-ephemeral', ephemeralAnalyzeRateLimit)
 
   // ── Clinical routers ─────────────────────────────────────────────────────
   // These inherit the session guard and the analyze limiter above, and must

--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -85,7 +85,33 @@ export type ConsultationAuditEvent =
  */
 export type AuthAuditEvent = { action: 'auth.session.created' }
 
-export type AuditEventInput = ConsultationAuditEvent | AuthAuditEvent
+/**
+ * Demo Mode's ephemeral analysis (#80). It spends a real LLM call and writes no
+ * `Consultation`, so it belongs to an actor and to no consultation for the same
+ * structural reason auth events do.
+ *
+ * It is audited despite persisting nothing. The endpoint cannot tell demo
+ * content from real content, so "it is only synthetic" is a property of intent
+ * rather than of the system, and an unaudited egress would be a hole in the one
+ * property the PHI boundary rests on. The row records **that** an analysis
+ * happened, never what was in it: the same labels-only rule as everything above.
+ */
+export type EphemeralAuditEvent =
+  | {
+      action: 'consultation.ephemeral_analyzed'
+      metadata: {
+        detected: readonly string[]
+        discardedFieldIds: readonly string[]
+        profileId: ProfileId
+        versions: AnalysisVersions
+      }
+    }
+  | {
+      action: 'consultation.ephemeral_analysis_failed'
+      metadata: { reason: AnalysisFailureReason }
+    }
+
+export type AuditEventInput = ConsultationAuditEvent | AuthAuditEvent | EphemeralAuditEvent
 
 /**
  * How many times an append may lose the race for the chain head before giving
@@ -128,7 +154,8 @@ function isChainHeadRace(error: unknown): boolean {
 export async function recordAuditEvent(
   event:
     | (ConsultationAuditEvent & { actorId: string; consultationId: string })
-    | (AuthAuditEvent & { actorId: string }),
+    | (AuthAuditEvent & { actorId: string })
+    | (EphemeralAuditEvent & { actorId: string }),
 ): Promise<void> {
   const { action, actorId } = event
   const consultationId = 'consultationId' in event ? event.consultationId : undefined

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -38,3 +38,28 @@ export const analyzeRateLimit = rateLimit({
     error: { code: 'rate_limited', message: 'Too many analysis requests. Please retry shortly.' },
   },
 })
+
+/**
+ * Per-IP limiter for `POST /api/consultations/analyze-ephemeral` (#80).
+ *
+ * Tighter than `analyzeRateLimit`, and on its own bucket rather than sharing
+ * that one, for two reasons. The route is reachable from a guest session, and
+ * `POST /api/auth/guest` is limited by neither `express-rate-limit` nor
+ * better-auth, so anyone can mint an actor for free. And it takes a transcript
+ * in the request body instead of resolving one the caller already owns, so
+ * unlike every other clinical route it spends an LLM call without the caller
+ * having created anything first.
+ *
+ * A shared bucket would also let demo traffic exhaust a real doctor's analysis
+ * budget, which is the wrong way round.
+ */
+export const ephemeralAnalyzeRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 5,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  keyGenerator: clientKey,
+  message: {
+    error: { code: 'rate_limited', message: 'Too many analysis requests. Please retry shortly.' },
+  },
+})

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -564,3 +564,98 @@ describe('erased consultations', () => {
     expect(detail.status).toBe(404)
   })
 })
+
+/**
+ * Demo Mode's ephemeral analysis (#80). The property under test is not that it
+ * returns an analysis, it is that it returns one **without persisting
+ * anything** while still leaving an audit trail. Those two pull in opposite
+ * directions, which is why the endpoint needed a decision before it was built.
+ */
+describe('POST /api/consultations/analyze-ephemeral', () => {
+  const body = (turns: { speaker: string; text: string }[]) => ({
+    transcript: { source: 'paste', turns },
+  })
+
+  it('returns an analysis and writes no consultation', async () => {
+    const res = await call('POST', '/api/consultations/analyze-ephemeral', body(TRANSCRIPT.turns))
+    const json = (await res.json()) as { analysis: { note: { subjective: string } } }
+
+    expect(res.status).toBe(200)
+    expect(json.analysis.note.subjective).toContain('Ahmad')
+    expect(store.size, 'the ephemeral route must persist nothing').toBe(0)
+  })
+
+  it('audits the egress with an actor and no consultation', async () => {
+    await call('POST', '/api/consultations/analyze-ephemeral', body(TRANSCRIPT.turns))
+
+    expect(audits).toHaveLength(1)
+    expect(audits[0]?.action).toBe('consultation.ephemeral_analyzed')
+    // Stored as an explicit null rather than omitted: `recordAuditEvent`
+    // normalises it for Prisma, and `computeAuditHash` folds it in as ''.
+    expect(
+      audits[0]?.consultationId ?? null,
+      'nothing was persisted, so there is no consultation to point at',
+    ).toBeNull()
+  })
+
+  /**
+   * The row exists to record that an egress happened, never what was in it.
+   * Detector labels are the whole of what may be written.
+   */
+  it('records detector labels and never the values that fired them', async () => {
+    await call('POST', '/api/consultations/analyze-ephemeral', body(TRANSCRIPT.turns))
+
+    const metadata = audits[0]?.metadata as { detected: string[] }
+    expect(metadata.detected).toContain('PATIENT')
+    expect(JSON.stringify(metadata)).not.toContain('Ahmad')
+  })
+
+  /**
+   * It is the same pipeline as the stored route, so the safety invariant that
+   * matters most has to survive it: a model response can add candidates and can
+   * never suppress a deterministic hit.
+   */
+  it('still merges rule flags as a union with model candidates', async () => {
+    const res = await call('POST', '/api/consultations/analyze-ephemeral', body(TRANSCRIPT.turns))
+    const { analysis } = (await res.json()) as {
+      analysis: { redFlags: { ruleId?: string; source: string }[] }
+    }
+
+    expect(analysis.redFlags.map((f) => f.source).sort()).toEqual(['model', 'rule'])
+    expect(analysis.redFlags.find((f) => f.source === 'rule')?.ruleId).toBe('r1')
+  })
+
+  it('rejects a transcript with too many turns', async () => {
+    const turns = Array.from({ length: 301 }, () => ({ speaker: 'patient', text: 'cough' }))
+
+    const res = await call('POST', '/api/consultations/analyze-ephemeral', body(turns))
+
+    expect(res.status).toBe(400)
+    expect(store.size).toBe(0)
+  })
+
+  it('rejects a single turn over the character cap', async () => {
+    const turns = [{ speaker: 'patient', text: 'x'.repeat(4001) }]
+
+    const res = await call('POST', '/api/consultations/analyze-ephemeral', body(turns))
+
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a transcript over the total character cap', async () => {
+    const turns = Array.from({ length: 20 }, () => ({
+      speaker: 'patient',
+      text: 'x'.repeat(3_500),
+    }))
+
+    const res = await call('POST', '/api/consultations/analyze-ephemeral', body(turns))
+
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects an empty transcript, which TranscriptSchema already bounded', async () => {
+    const res = await call('POST', '/api/consultations/analyze-ephemeral', body([]))
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -1,10 +1,13 @@
 import type { Consultation } from '@prisma/client'
 import {
+  type ConsultationAnalysis,
+  ConsultationAnalysisSchema,
   ConsultationDetailSchema,
   ConsultationListItemSchema,
   type InformationGap,
   type SoapNote,
   SoapNoteSchema,
+  type Transcript,
   TranscriptSchema,
 } from '@shared/types'
 import { Router } from 'express'
@@ -12,6 +15,7 @@ import { z } from 'zod'
 import { analyseNote } from '../analysis/index.js'
 import { type AnalysisFailureReason, getAuditHistory, recordAuditEvent } from '../audit/index.js'
 import {
+  type ClinicalProfile,
   DEFAULT_PROFILE_ID,
   getClinicalProfile,
   ProfileIdSchema,
@@ -200,7 +204,83 @@ consultationsRouter.get('/:id/history', async (req, res) => {
  * de-identify first, run the deterministic rules on the raw transcript
  * in-process, send only de-identified content to the model, then merge as a
  * union so a model response can never suppress a rule hit.
+ *
+ * Shared by the stored route below and the ephemeral one (#80) so the two
+ * cannot drift. Demo Mode's claim is that it narrates the real pipeline, and
+ * that claim is only worth making while there is literally one pipeline.
+ *
+ * It persists nothing and writes no audit row: both are the caller's job,
+ * because that is exactly where the two routes legitimately differ.
  */
+async function runAnalysis(
+  transcript: Transcript,
+  profile: ClinicalProfile,
+  consultationId?: string,
+): Promise<{
+  analysis: ConsultationAnalysis
+  detected: readonly string[]
+  discardedFieldIds: readonly string[]
+}> {
+  const { text, vault, detected } = await timeStage('deidentification', () =>
+    deidentifyTranscript(transcript),
+  )
+
+  // Labels and a count, never the matched values (GitHub issue #15).
+  logger.info('de-identification complete', {
+    ...(consultationId === undefined ? {} : { consultationId }),
+    detectorLabels: detected,
+    detectorCount: detected.length,
+  })
+
+  // Runs on the raw transcript, in-process, regardless of model output. It
+  // never leaves the API, so it needs no gate.
+  const ruleFlags = await timeStage('rules', () =>
+    evaluateRedFlags(transcript, profile.redFlagTriggers),
+  )
+
+  const [noteResult, suggestionResult] = await Promise.all([
+    timeStage('note_generation', () => analyseNote(text, text, profile)),
+    timeStage('retrieval', () => generateSuggestions(text, profile)),
+  ])
+
+  const rehydrate = (value: string) => vault.rehydrate(value)
+
+  const analysis = {
+    note: {
+      subjective: rehydrate(noteResult.note.subjective),
+      objective: rehydrate(noteResult.note.objective),
+      assessment: rehydrate(noteResult.note.assessment),
+      plan: rehydrate(noteResult.note.plan),
+    },
+    profileId: profile.id,
+    gaps: mergeGaps(
+      deriveGaps(noteResult.clinicalFacts, noteResult.operational, profile.gapChecklist),
+      noteResult.gaps,
+    ).map((gap) => ({
+      ...gap,
+      question: rehydrate(gap.question),
+      rationale: rehydrate(gap.rationale),
+    })),
+    redFlags: mergeRedFlags(ruleFlags, suggestionResult.redFlags).map((flag) => ({
+      ...flag,
+      label: rehydrate(flag.label),
+      evidence: rehydrate(flag.evidence),
+    })),
+    // The reviewed checklist, surfaced rather than discarded. Without these
+    // the UI cannot render a `NOT_ASSESSED` it was never sent, and docs/prd.md
+    // §10's "unestablished, never absent" requirement has nothing to display
+    // (Demo Script step 5).
+    clinicalFacts: rehydrateAssertions(noteResult.clinicalFacts, rehydrate),
+    operational: rehydrateAssertions(noteResult.operational, rehydrate),
+    suggestions: suggestionResult.suggestions.map((suggestion) => ({
+      ...suggestion,
+      text: rehydrate(suggestion.text),
+    })),
+  }
+
+  return { analysis, detected, discardedFieldIds: noteResult.discardedFieldIds }
+}
+
 consultationsRouter.post('/:id/analyze', async (req, res) => {
   const actor = doctorId(req)
   const consultation = await assertOwnedConsultation(req.params.id, actor)
@@ -239,62 +319,11 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
   })
 
   try {
-    const { text, vault, detected } = await timeStage('deidentification', () =>
-      deidentifyTranscript(transcript.data),
+    const { analysis, detected, discardedFieldIds } = await runAnalysis(
+      transcript.data,
+      profile,
+      consultation.id,
     )
-
-    // Labels and a count, never the matched values (GitHub issue #15).
-    logger.info('de-identification complete', {
-      consultationId: consultation.id,
-      detectorLabels: detected,
-      detectorCount: detected.length,
-    })
-
-    // Runs on the raw transcript, in-process, regardless of model output. It
-    // never leaves the API, so it needs no gate.
-    const ruleFlags = await timeStage('rules', () =>
-      evaluateRedFlags(transcript.data, profile.redFlagTriggers),
-    )
-
-    const [noteResult, suggestionResult] = await Promise.all([
-      timeStage('note_generation', () => analyseNote(text, text, profile)),
-      timeStage('retrieval', () => generateSuggestions(text, profile)),
-    ])
-
-    const rehydrate = (value: string) => vault.rehydrate(value)
-
-    const analysis = {
-      note: {
-        subjective: rehydrate(noteResult.note.subjective),
-        objective: rehydrate(noteResult.note.objective),
-        assessment: rehydrate(noteResult.note.assessment),
-        plan: rehydrate(noteResult.note.plan),
-      },
-      profileId: profile.id,
-      gaps: mergeGaps(
-        deriveGaps(noteResult.clinicalFacts, noteResult.operational, profile.gapChecklist),
-        noteResult.gaps,
-      ).map((gap) => ({
-        ...gap,
-        question: rehydrate(gap.question),
-        rationale: rehydrate(gap.rationale),
-      })),
-      redFlags: mergeRedFlags(ruleFlags, suggestionResult.redFlags).map((flag) => ({
-        ...flag,
-        label: rehydrate(flag.label),
-        evidence: rehydrate(flag.evidence),
-      })),
-      // The reviewed checklist, surfaced rather than discarded. Without these
-      // the UI cannot render a `NOT_ASSESSED` it was never sent, and docs/prd.md
-      // §10's "unestablished, never absent" requirement has nothing to display
-      // (Demo Script step 5).
-      clinicalFacts: rehydrateAssertions(noteResult.clinicalFacts, rehydrate),
-      operational: rehydrateAssertions(noteResult.operational, rehydrate),
-      suggestions: suggestionResult.suggestions.map((suggestion) => ({
-        ...suggestion,
-        text: rehydrate(suggestion.text),
-      })),
-    }
 
     const updated = await timeStage('persistence', () =>
       prisma.consultation.update({
@@ -310,7 +339,7 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
       consultationId: consultation.id,
       metadata: {
         detected,
-        discardedFieldIds: noteResult.discardedFieldIds,
+        discardedFieldIds,
         profileId: profile.id,
         versions: {
           provider: llm.provider,
@@ -332,6 +361,111 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
       action: 'consultation.analysis_failed',
       actorId: actor,
       consultationId: consultation.id,
+      metadata: { reason: classifyFailure(error) },
+    })
+
+    throw new HttpError(500, 'analysis_failed', 'Analysis could not be completed.')
+  }
+})
+
+/**
+ * Bounds on a transcript that arrives in the request body (#80).
+ *
+ * Every other clinical route analyses a transcript the caller already stored,
+ * so the create route bounded it. This one takes it directly, and
+ * `TranscriptSchema` has `.min(1)` on turns and no upper bound at all, which
+ * would leave `express.json({ limit: '1mb' })` as the only thing between a
+ * guest session and an arbitrarily large prompt.
+ *
+ * Sized well above a real consultation rather than tightly: the longest
+ * fixture is a few thousand characters, so these bound abuse without being
+ * reachable by clinical use.
+ */
+const MAX_TURNS = 300
+const MAX_TURN_CHARS = 4_000
+const MAX_TRANSCRIPT_CHARS = 60_000
+
+const EphemeralBodySchema = z.object({
+  transcript: TranscriptSchema.superRefine((transcript, ctx) => {
+    if (transcript.turns.length > MAX_TURNS) {
+      ctx.addIssue({ code: 'custom', message: `A transcript may have at most ${MAX_TURNS} turns.` })
+    }
+    if (transcript.turns.some((turn) => turn.text.length > MAX_TURN_CHARS)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `A turn may be at most ${MAX_TURN_CHARS} characters.`,
+      })
+    }
+    const total = transcript.turns.reduce((sum, turn) => sum + turn.text.length, 0)
+    if (total > MAX_TRANSCRIPT_CHARS) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `A transcript may be at most ${MAX_TRANSCRIPT_CHARS} characters.`,
+      })
+    }
+  }),
+  profileId: ProfileIdSchema.optional(),
+})
+
+/**
+ * Demo Mode's ephemeral analysis (#80), authorised by the owner on 14/08/26.
+ *
+ * It runs the same pipeline as the stored route above and writes **no
+ * `Consultation`**, which is the whole point: Demo Mode has to be
+ * self-contained and wiped the moment it is exited, and if nothing is
+ * persisted there is nothing to wipe. That sidesteps the retention decision in
+ * docs/trd.md §19 rather than pre-empting it, and it avoids adding an erasure
+ * endpoint to serve a demo, which would route around a control that exists for
+ * audit integrity.
+ *
+ * **It is audited even though it persists nothing.** The endpoint cannot
+ * distinguish demo content from real content, so "it is only synthetic" is a
+ * property of intent rather than of the system, and an unaudited LLM egress
+ * would be a hole in the property the whole PHI boundary rests on. The row
+ * carries an actor and no consultation, which the hash chain already supports.
+ *
+ * No `:id`, so `assertOwnedConsultation` has nothing to scope. Authentication
+ * still applies: `/api/consultations` is in `PROTECTED_PREFIXES`, so
+ * `requireSession` runs before this. A tidier-looking `/api/analyze` would have
+ * been unauthenticated by default.
+ */
+consultationsRouter.post('/analyze-ephemeral', async (req, res) => {
+  const actor = doctorId(req)
+
+  const body = EphemeralBodySchema.safeParse(req.body)
+  if (!body.success) {
+    throw new HttpError(400, 'invalid_body', 'A valid transcript is required.')
+  }
+
+  const profile = getClinicalProfile(body.data.profileId ?? DEFAULT_PROFILE_ID)
+
+  try {
+    const { analysis, detected, discardedFieldIds } = await runAnalysis(
+      body.data.transcript,
+      profile,
+    )
+
+    const llm = getLLMDescriptor()
+    await recordAuditEvent({
+      action: 'consultation.ephemeral_analyzed',
+      actorId: actor,
+      metadata: {
+        detected,
+        discardedFieldIds,
+        profileId: profile.id,
+        versions: {
+          provider: llm.provider,
+          model: llm.model,
+          clinicalContent: getActiveClinicalVersions(profile),
+        },
+      },
+    })
+
+    res.json({ analysis: ConsultationAnalysisSchema.parse(analysis) })
+  } catch (error) {
+    await recordAuditEvent({
+      action: 'consultation.ephemeral_analysis_failed',
+      actorId: actor,
       metadata: { reason: classifyFailure(error) },
     })
 


### PR DESCRIPTION
## What Changed

`POST /api/consultations/analyze-ephemeral` runs the full analyse pipeline and writes **no `Consultation`**.

Closes #80.

```
body     { transcript: Transcript, profileId?: ProfileId }
returns  { analysis: ConsultationAnalysis }
persists nothing but an actor-only AuditEvent
```

## Why This Shape

Demo Mode has to be self-contained and wiped the moment it is exited, and it could not clean up after itself. #64 moved the `AuditEvent` relation to `onDelete: Restrict`, so a consultation cannot be hard-deleted, and the tombstone erasure that replaced it has no HTTP endpoint on purpose, gated on the retention decision in TRD §19.

**If nothing is persisted, there is nothing to wipe.** That sidesteps the retention decision rather than pre-empting it, and avoids adding an erasure endpoint to serve a demo, which would route around a control that exists for audit integrity. **§19 is untouched and still open.**

## The Pipeline Is Extracted, Not Duplicated

`runAnalysis` is now shared with `POST /:id/analyze`. Demo Mode's claim to an evaluator is that it narrates the real pipeline, and that claim is only worth making while there is exactly one pipeline. The stored route's behaviour is unchanged and its existing tests cover the extraction.

## It Is Audited Despite Persisting Nothing

This was the design question, and it is not the trade-off it first looks like.

**The endpoint cannot distinguish demo content from real content.** "It is only synthetic" is a property of intent, not of the system, so an unaudited LLM egress would be a hole in the property the whole PHI boundary rests on.

The row costs nothing, verified before building rather than assumed:

| Fact | Evidence |
| --- | --- |
| The chain already tolerates a null consultation | `computeAuditHash` folds it in as `''` (`audit/chain.ts:47`) |
| `recordAuditEvent` already had an actor-only arm | The `AuthAuditEvent` union member |
| Columns already nullable | `consultationId`, `actorId` are `String?` |

**No schema change and no migration.** The row records *that* an egress happened, never what was in it: the same labels-only rule as every other event.

## Two Controls Ship With It

1. **Its own rate limiter**, tighter (5/min vs 10) and on a separate bucket. The route is guest-reachable and `POST /api/auth/guest` is limited by neither `express-rate-limit` nor better-auth, so anyone can mint an actor for free. A shared bucket would also let demo traffic exhaust a real doctor's analysis budget.
2. **Explicit transcript bounds** (300 turns, 4k chars/turn, 60k total). `TranscriptSchema` has `.min(1)` and no upper bound, so `express.json({ limit: '1mb' })` would otherwise be the only thing between a guest session and an arbitrarily large prompt. Sized well above any real consultation.

## Route Placement Is Deliberate

It sits under `/api/consultations` because `PROTECTED_PREFIXES` mounts `requireSession` per prefix (`app.ts:16,42`). The tidier-looking `/api/analyze` would have been **unauthenticated by default**. No `:id`, so `assertOwnedConsultation` has nothing to scope, and authentication is what stands in for ownership here.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (387 passing, 8 new)

New tests assert the properties that pull against each other:

| Test | Property |
| --- | --- |
| returns an analysis and writes no consultation | `store.size === 0` after a successful call |
| audits the egress with an actor and no consultation | one row, `consultationId` null |
| records detector labels, never the values | metadata contains `PATIENT`, not `Ahmad` |
| still merges rule flags as a union | rule hit survives alongside the model candidate |
| four rejection cases | turn count, per-turn chars, total chars, empty |

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider — the new route calls the same `runAnalysis`, which de-identifies before the model and runs rules on the raw transcript in-process
- [x] No provider SDK imported outside `backend/src/lib/llm/` — guarded by #81, still one import repo-wide
- [x] Deterministic red-flag hits remain unsuppressable — `mergeRedFlags` untouched, and a test pins the union on the new route
- [x] Citations remain ID-constrained — untouched
- [x] No transcript bodies, note contents, or vault entries logged — the audit row carries labels only, pinned by a test
- [x] Fixtures added are synthetic

## Notes For The Reviewer

**Sign-off provenance.** security.md requires explicit human sign-off for "any new path from raw transcript text toward a provider". I refused to build this earlier on exactly that rule. Adam has since signed off ("yes, it can persist nothing"), but **it reached me relayed through the other session rather than directly**, and that is recorded on #80 rather than only here so it is cheap to correct if he reads it differently.

**What this does not solve.** Demo Mode now makes a real LLM call at demo time, where it previously walked seeded consultations and could not fail on bad wifi. That is inherent to what was asked for. The frontend keeps the seeded walk as a fallback, and it should be a *visible* one: a silent substitution would have the demo assert it ran the real pipeline at the moment it did not, which is worse than an error.

Backend-only, so the deploy filter skips this and it costs no Vercel slot.