### PR TITLE
feat(demo): analyse the tour's own consultation and discard it on exit (#80)

### DIFF
--- a/frontend/src/demo/DemoStepBar.tsx
+++ b/frontend/src/demo/DemoStepBar.tsx
@@ -14,7 +14,7 @@ import { useDemoTour } from './DemoTour.js'
  * is a scrollbar, not a progress indicator.
  */
 export function DemoStepBar() {
-  const { active, currentStep, steps, stop } = useDemoTour()
+  const { active, currentStep, steps, stop, mode, fallbackReason } = useDemoTour()
   const [collapsed, setCollapsed] = useState(false)
 
   if (!active) return null
@@ -22,78 +22,108 @@ export function DemoStepBar() {
   const current = steps[currentStep]
 
   return (
-    <nav
-      aria-label="Walkthrough progress"
-      data-print="hide"
-      style={{ zIndex: 'var(--z-toast)' }}
-      className="glass fixed top-4 left-1/2 flex max-w-[calc(100vw-2rem)] -translate-x-1/2 items-center gap-3 rounded-float px-3 py-2"
-    >
-      <span className="text-xs font-medium whitespace-nowrap text-ink sm:hidden">
-        {currentStep + 1}/{steps.length} · {current?.label}
-      </span>
+    <>
+      {/*
+       * The fallback announces itself, and this notice is the reason the tour
+       * tracks its mode at all.
+       *
+       * The demo's central claim is that it runs the real pipeline rather than
+       * a canned script. If the live analysis fails and prepared consultations
+       * are shown in its place without saying so, the demo asserts something
+       * false at the exact moment an evaluator is judging that claim. Stated
+       * plainly and without alarm: the walkthrough still works, and what is on
+       * screen is still real output from the real pipeline, just produced
+       * earlier rather than now.
+       */}
+      {mode === 'seeded' && (
+        <div
+          role="status"
+          data-print="hide"
+          style={{ zIndex: 'var(--z-toast)' }}
+          className="glass fixed top-20 left-1/2 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-card px-3.5 py-2 text-xs text-ink"
+        >
+          <span className="font-medium">Showing prepared consultations.</span>{' '}
+          <span className="text-ink-muted">
+            {fallbackReason === 'rate_limited'
+              ? 'The tour was started again too soon for the analysis rate limit. Wait a minute and restart it for the live run.'
+              : 'The live analysis did not complete, so the tour is walking earlier results rather than analysing one now.'}
+          </span>
+        </div>
+      )}
 
-      {!collapsed && (
-        <ol className="hidden items-center gap-1 sm:flex">
-          {steps.map((step, index) => {
-            const isCurrent = index === currentStep
-            const isDone = index < currentStep
-            return (
-              <li
-                key={step.label}
-                aria-current={isCurrent ? 'step' : undefined}
-                className={cn(
-                  'flex items-center gap-1.5 rounded-control px-2 py-1 text-xs whitespace-nowrap transition-colors duration-150',
-                  isCurrent && 'bg-accent/16 font-medium text-accent',
-                  isDone && 'text-ink-muted',
-                  !isCurrent && !isDone && 'text-ink-muted/60',
-                )}
-              >
-                <span
-                  aria-hidden
+      <nav
+        aria-label="Walkthrough progress"
+        data-print="hide"
+        style={{ zIndex: 'var(--z-toast)' }}
+        className="glass fixed top-4 left-1/2 flex max-w-[calc(100vw-2rem)] -translate-x-1/2 items-center gap-3 rounded-float px-3 py-2"
+      >
+        <span className="text-xs font-medium whitespace-nowrap text-ink sm:hidden">
+          {currentStep + 1}/{steps.length} · {current?.label}
+        </span>
+
+        {!collapsed && (
+          <ol className="hidden items-center gap-1 sm:flex">
+            {steps.map((step, index) => {
+              const isCurrent = index === currentStep
+              const isDone = index < currentStep
+              return (
+                <li
+                  key={step.label}
+                  aria-current={isCurrent ? 'step' : undefined}
                   className={cn(
-                    'flex size-4 shrink-0 items-center justify-center rounded-full text-[0.625rem]',
-                    isCurrent && 'bg-accent text-accent-ink',
-                    isDone && 'text-accent',
-                    !isCurrent && !isDone && 'border border-current',
+                    'flex items-center gap-1.5 rounded-control px-2 py-1 text-xs whitespace-nowrap transition-colors duration-150',
+                    isCurrent && 'bg-accent/16 font-medium text-accent',
+                    isDone && 'text-ink-muted',
+                    !isCurrent && !isDone && 'text-ink-muted/60',
                   )}
                 >
-                  {isDone ? <Check className="size-3" /> : index + 1}
-                </span>
-                {step.label}
-              </li>
-            )
-          })}
-        </ol>
-      )}
+                  <span
+                    aria-hidden
+                    className={cn(
+                      'flex size-4 shrink-0 items-center justify-center rounded-full text-[0.625rem]',
+                      isCurrent && 'bg-accent text-accent-ink',
+                      isDone && 'text-accent',
+                      !isCurrent && !isDone && 'border border-current',
+                    )}
+                  >
+                    {isDone ? <Check className="size-3" /> : index + 1}
+                  </span>
+                  {step.label}
+                </li>
+              )
+            })}
+          </ol>
+        )}
 
-      {collapsed && (
-        <span className="hidden text-xs font-medium whitespace-nowrap text-ink sm:inline">
-          Step {currentStep + 1} of {steps.length} · {current?.label}
-        </span>
-      )}
+        {collapsed && (
+          <span className="hidden text-xs font-medium whitespace-nowrap text-ink sm:inline">
+            Step {currentStep + 1} of {steps.length} · {current?.label}
+          </span>
+        )}
 
-      <div className="flex items-center gap-1 border-l border-line/60 pl-2">
-        <button
-          type="button"
-          onClick={() => setCollapsed((value) => !value)}
-          aria-expanded={!collapsed}
-          aria-label={collapsed ? 'Expand the step list' : 'Collapse the step list'}
-          className="hidden size-7 items-center justify-center rounded-control text-ink-muted transition-colors hover:bg-sunken hover:text-ink sm:flex"
-        >
-          {collapsed ? (
-            <ChevronDown aria-hidden className="size-4" />
-          ) : (
-            <ChevronUp aria-hidden className="size-4" />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={stop}
-          className="rounded-control px-2 py-1 text-xs font-medium text-ink-muted transition-colors hover:bg-sunken hover:text-ink"
-        >
-          End
-        </button>
-      </div>
-    </nav>
+        <div className="flex items-center gap-1 border-l border-line/60 pl-2">
+          <button
+            type="button"
+            onClick={() => setCollapsed((value) => !value)}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? 'Expand the step list' : 'Collapse the step list'}
+            className="hidden size-7 items-center justify-center rounded-control text-ink-muted transition-colors hover:bg-sunken hover:text-ink sm:flex"
+          >
+            {collapsed ? (
+              <ChevronDown aria-hidden className="size-4" />
+            ) : (
+              <ChevronUp aria-hidden className="size-4" />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={stop}
+            className="rounded-control px-2 py-1 text-xs font-medium text-ink-muted transition-colors hover:bg-sunken hover:text-ink"
+          >
+            End
+          </button>
+        </div>
+      </nav>
+    </>
   )
 }

--- a/frontend/src/demo/DemoTour.tsx
+++ b/frontend/src/demo/DemoTour.tsx
@@ -1,7 +1,27 @@
+import type { ConsultationDetail } from '@shared/types'
 import { useQueryClient } from '@tanstack/react-query'
-import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { api } from '../lib/api.js'
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { ApiError, api } from '../lib/api.js'
+
+/**
+ * The id the tour's own consultation answers to.
+ *
+ * Not a real row and never persisted. `ConsultationReview` recognises it and
+ * reads the detail out of this context instead of fetching, which is what keeps
+ * the demo on the same renderer as the real review screen. A second renderer is
+ * how "it narrates the real pipeline" quietly stops being true.
+ */
+export const DEMO_CONSULTATION_ID = 'demo-ephemeral'
 
 /**
  * The guided walkthrough's state machine (#28).
@@ -11,19 +31,24 @@ import { api } from '../lib/api.js'
  * de-identification gate, model call, rules engine and evidence check. There
  * are no hardcoded analysis payloads here and no stubbed responses.
  *
- * It also **creates nothing**. The original ask was for a self-contained mode
- * that makes its own consultations and deletes them afterwards, and that is not
- * buildable today: issue #64 moved `AuditEvent` to `onDelete: Restrict` so a
- * deletion can no longer silently break the tamper-evident hash chain, and the
- * tombstone erasure that replaced it has no HTTP endpoint on purpose, pending an
- * open retention decision. A tour that created rows it could not remove would be
- * worse than one that creates none, so this walks the seeded demo spread
- * instead. Those consultations came out of the real pipeline, which is what
- * keeps the no-mocking constraint satisfied.
+ * **It is self-contained: it analyses its own transcript and persists nothing**
+ * (issue #80). `analyze-ephemeral` runs the whole pipeline and writes no
+ * `Consultation`, so the analysis exists only in this component's state and
+ * ends when the tour does. "Wiped instantly on exit" is therefore true by
+ * construction rather than by a delete call that could fail or be skipped.
  *
- * The consequence worth knowing: the tour is **read-only**. It navigates and
- * explains. It never analyses, edits or approves on the user's behalf, which
- * also means it can never trip the approval gate the product exists to enforce.
+ * That shape was forced rather than preferred. Issue #64 moved `AuditEvent` to
+ * `onDelete: Restrict` so a deletion cannot silently break the tamper-evident
+ * hash chain, and the tombstone erasure replacing it has no HTTP endpoint
+ * pending a retention decision. There is no way to clean up after creating
+ * rows, so the answer is to create none.
+ *
+ * **The seeded walk survives as a fallback, and it announces itself.** If the
+ * live analysis fails, the tour walks the demo account's stored consultations
+ * instead, and says so on screen. Silently substituting prepared output would
+ * have the demo assert it is running the real pipeline at the exact moment an
+ * evaluator is judging that claim, which is a worse failure than a visible
+ * degradation.
  */
 
 /**
@@ -114,13 +139,67 @@ const TOUR_STEPS: TourStep[] = [
 
 export const TOUR_STEP_COUNT = TOUR_STEPS.length
 
+/**
+ * `live` means the tour analysed its own transcript through the real pipeline
+ * and is showing output that exists only in this browser tab. `seeded` means
+ * that call did not complete and it fell back to walking the demo account's
+ * stored consultations.
+ *
+ * The distinction is surfaced to the viewer rather than kept internal, and that
+ * is the whole point of tracking it. The demo's central claim is that it runs
+ * the real pipeline instead of a canned script; a fallback that stayed silent
+ * would have the tour assert something false at the exact moment it is being
+ * assessed. Failing loudly mid-demo is the wrong answer too. Falling back and
+ * saying so is the only option that is neither fragile nor dishonest.
+ */
+type TourMode = 'live' | 'seeded'
+
+/**
+ * Why the live analysis did not happen, separated because the two causes call
+ * for different actions from whoever is presenting.
+ *
+ * `rate_limited` is a 429 from the endpoint's own 5/min bucket, and it means the
+ * pipeline would have worked and was simply asked too soon, so waiting a minute
+ * restores the live path. `failed` is anything else, where retrying gains
+ * nothing. Collapsing the two would tell a presenter in a rehearsal that their
+ * pipeline is broken when they had only started the tour twice in quick
+ * succession.
+ *
+ * Both still fall back rather than erroring, because a tour that dies on screen
+ * is worse than a tour that degrades and says so.
+ */
+type FallbackReason = 'rate_limited' | 'failed'
+
 interface DemoTourValue {
   active: boolean
   /** 0-indexed; -1 when inactive. */
   currentStep: number
   steps: TourStep[]
-  /** True while the opening consultation is being resolved. */
+  /** True while the opening analysis is running. */
   preparing: boolean
+  mode: TourMode
+  /** Meaningful only while `mode` is `seeded`. */
+  fallbackReason: FallbackReason
+  /**
+   * The tour's own consultation, held only in React state.
+   *
+   * Never written to the database, never to `localStorage`, never to the query
+   * cache. Dropping this reference is the entire cleanup path, which is why
+   * "wiped instantly on exit" is true by construction rather than by a delete
+   * call that could fail or be skipped.
+   */
+  ephemeral: ConsultationDetail | null
+  /**
+   * Applies a review action to the in-memory consultation.
+   *
+   * Acknowledging a flag, marking a gap reviewed, editing the note and
+   * approving all reach the API by id on a stored consultation, and the tour's
+   * consultation has no id to reach. Without this every control on the review
+   * screen would 404 mid-demo, on the screen the demo exists to show. The
+   * transitions are the same ones the real screen performs; only the storage
+   * differs, and it is discarded when the tour ends.
+   */
+  updateEphemeral: (next: ConsultationDetail) => void
   start: () => void
   next: () => void
   back: () => void
@@ -182,8 +261,23 @@ async function pickConsultations(
     list.filter((item) => item.status === 'approved').map((item) => item.id),
   )
 
+  /*
+   * Red flags outrank an unapproved status when the two cannot both be had.
+   *
+   * The stored spread drifts, because approving a consultation during a demo is
+   * permanent and there is no un-approve. Observed exactly that: the only
+   * consultation carrying flags is now approved, which under a
+   * strictly-unapproved rule pushed the Red Flags stop onto a consultation with
+   * none. An approved consultation still renders its flag cards and only loses
+   * the approve bar, so preferring flags costs the Approval stop its ring and
+   * saves the more important one.
+   *
+   * The primary path does not have this problem: it analyses a fixture chosen
+   * for its flags and is never approved.
+   */
   const flagged =
     details.find((entry) => entry.analysis?.redFlags?.length && !approvedIds.has(entry.id))?.id ??
+    details.find((entry) => entry.analysis?.redFlags?.length)?.id ??
     details.find((entry) => !approvedIds.has(entry.id))?.id ??
     fallback
 
@@ -192,36 +286,154 @@ async function pickConsultations(
   return { flagged, cited }
 }
 
+/**
+ * Analyse a bundled fixture without persisting it.
+ *
+ * The fixture corpus is synthetic by mandate (`AGENTS.md`), so the transcript
+ * the demo analyses carries no patient data before de-identification even runs.
+ * The de-identification gate still runs on it, because the endpoint applies the
+ * same pipeline to every caller and a demo-shaped exception to the PHI boundary
+ * is exactly the kind of hole that stops being demo-shaped later.
+ */
+/*
+ * Not `fixtures[0]`, and the difference decides whether the demo works.
+ *
+ * The corpus is ordered for the intake screen, and its first entry is the
+ * gap-heavy case, which yields twenty-four gaps and **no red flags at all**.
+ * The tour's headline stop is the rule-versus-model distinction, so analysing
+ * that fixture would leave the single most important screen empty while every
+ * other step looked fine.
+ *
+ * `urti-hard-red-flag` produces the airway-compromise `EMERGENCY` marked `Rule`
+ * above model-sourced `URGENT` candidates, which is that distinction
+ * demonstrating itself without narration.
+ */
+const DEMO_FIXTURE_ID = 'urti-hard-red-flag'
+
+async function runEphemeral(): Promise<ConsultationDetail> {
+  const fixtures = await api.fixtures()
+  const fixture = fixtures.find((entry) => entry.id === DEMO_FIXTURE_ID) ?? fixtures[0]
+  if (!fixture) throw new Error('no fixtures available')
+
+  const analysis = await api.analyzeEphemeral(fixture.transcript)
+  const now = new Date()
+  return {
+    id: DEMO_CONSULTATION_ID,
+    status: 'awaiting_review',
+    createdAt: now,
+    updatedAt: now,
+    transcript: fixture.transcript,
+    analysis,
+    editedNote: null,
+    approvedAt: null,
+    approvedBy: null,
+    acknowledgedRedFlagIds: [],
+    reviewedGapIds: [],
+  }
+}
+
 export function DemoTourProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate()
+  const location = useLocation()
   const queryClient = useQueryClient()
   const [active, setActive] = useState(false)
   const [currentStep, setCurrentStep] = useState(-1)
   const [preparing, setPreparing] = useState(false)
+  const [mode, setMode] = useState<TourMode>('live')
+  const [fallbackReason, setFallbackReason] = useState<FallbackReason>('failed')
+  const [ephemeral, setEphemeral] = useState<ConsultationDetail | null>(null)
   const [subjects, setSubjects] = useState<Subjects>({ flagged: null, cited: null })
+  /** Where the tour last sent the browser, so a user-driven navigation is
+      distinguishable from the tour's own. */
+  const expectedPath = useRef<string | null>(null)
 
-  const routeFor = useCallback((step: TourStep, resolved: Subjects) => {
-    if (!step.route.includes(':id')) return step.route
-    const id = resolved[step.subject ?? 'flagged'] ?? resolved.flagged
-    // Without an id there is nothing to review; the list is the honest
-    // destination rather than a route with a literal ":id" in it.
-    return id ? step.route.replace(':id', id) : '/consultations'
-  }, [])
+  const routeFor = useCallback(
+    (step: TourStep, resolved: Subjects, live: boolean) => {
+      if (!step.route.includes(':id')) return step.route
+      if (live && ephemeral) {
+        /*
+         * Live mode has one consultation, so every consultation step points at
+         * the same in-memory record, with one measured exception.
+         *
+         * The Citations stop needs a cited suggestion to point at, and whether
+         * the analysis produces one is a property of the transcript rather than
+         * a guarantee. The fixture chosen for its red flags is a severe
+         * presentation whose correct handling is "escalate now", and escalation
+         * is not a guideline-cited recommendation: analysing it against
+         * production returned five red flags and zero suggestions. Sending the
+         * Citations step there would leave the closed-corpus claim pointing at
+         * an element that does not exist.
+         *
+         * So that one step falls back to a stored consultation that does have a
+         * citation. Reading a seeded row persists nothing, so this costs the
+         * ephemeral guarantee nothing; the tour simply stops narrating its own
+         * analysis for the one stop its own analysis cannot illustrate.
+         */
+        const wantsCitation = step.subject === 'cited'
+        const hasCitation = (ephemeral.analysis?.suggestions?.length ?? 0) > 0
+        if (wantsCitation && !hasCitation && resolved.cited) {
+          return step.route.replace(':id', resolved.cited)
+        }
+        return step.route.replace(':id', DEMO_CONSULTATION_ID)
+      }
+      const id = resolved[step.subject ?? 'flagged'] ?? resolved.flagged
+      // Without an id there is nothing to review; the list is the honest
+      // destination rather than a route with a literal ":id" in it.
+      return id ? step.route.replace(':id', id) : '/consultations'
+    },
+    [ephemeral],
+  )
 
   const start = useCallback(async () => {
     setPreparing(true)
-    const resolved = await pickConsultations((consultation) =>
+
+    /*
+     * Both paths are resolved, concurrently, even when the live one succeeds.
+     *
+     * The seeded subjects are needed in live mode too, because the Citations
+     * step falls back to a stored consultation when the analysis produces no
+     * suggestions (see `routeFor`). Running them in sequence would add the
+     * scoring reads to a wait that is already dominated by the analysis, and
+     * running them at all is close to free: the reads finish in well under a
+     * second against a call that took roughly fifty against production, and
+     * they warm the cache the review screen is about to use.
+     */
+    const seeded = pickConsultations((consultation) =>
       queryClient.fetchQuery({
         queryKey: ['consultation', consultation],
         queryFn: () => api.getConsultation(consultation),
       }),
     ).catch(() => ({ flagged: null, cited: null }) as Subjects)
 
+    // Live first. The seeded walk is the fallback, not the plan.
+    //
+    // No automatic retry, deliberately. The endpoint allows 5/min per IP, so a
+    // retry on failure turns one flaky call into a 429 and reports a rate limit
+    // where the real fault was something else.
+    const own = await runEphemeral().catch((error: unknown) => {
+      setFallbackReason(
+        error instanceof ApiError && error.status === 429 ? 'rate_limited' : 'failed',
+      )
+      return null
+    })
+
+    const resolved = await seeded
+
+    setEphemeral(own)
     setSubjects(resolved)
+    setMode(own ? 'live' : 'seeded')
     setPreparing(false)
     setActive(true)
     setCurrentStep(0)
-    navigate(routeFor(TOUR_STEPS[0] as TourStep, resolved))
+
+    const first = TOUR_STEPS[0] as TourStep
+    const path = first.route.includes(':id')
+      ? own
+        ? first.route.replace(':id', DEMO_CONSULTATION_ID)
+        : routeFor(first, resolved, false)
+      : first.route
+    expectedPath.current = path
+    navigate(path)
   }, [navigate, queryClient, routeFor])
 
   const goTo = useCallback(
@@ -229,30 +441,58 @@ export function DemoTourProvider({ children }: { children: ReactNode }) {
       const step = TOUR_STEPS[index]
       if (!step) return
       setCurrentStep(index)
-      navigate(routeFor(step, subjects))
+      const path = routeFor(step, subjects, mode === 'live')
+      expectedPath.current = path
+      navigate(path)
     },
-    [subjects, navigate, routeFor],
+    [subjects, navigate, routeFor, mode],
   )
+
+  /**
+   * Ending the tour is the whole cleanup path.
+   *
+   * Dropping the reference is what "wiped instantly" means here: the analysis
+   * lived in React state and nowhere else, so there is no row to delete, no
+   * cache entry to invalidate and no request that can fail halfway. Exit,
+   * finish and interrupt all land on this one function so none of them can
+   * leave the data behind.
+   */
+  const stop = useCallback(() => {
+    setActive(false)
+    setCurrentStep(-1)
+    setEphemeral(null)
+    setSubjects({ flagged: null, cited: null })
+    expectedPath.current = null
+  }, [])
 
   const next = useCallback(() => {
     // The last step closes the tour rather than dead-ending on a disabled
     // button, so there is always exactly one obvious way forward.
     if (currentStep >= TOUR_STEPS.length - 1) {
-      setActive(false)
-      setCurrentStep(-1)
+      stop()
       return
     }
     goTo(currentStep + 1)
-  }, [currentStep, goTo])
+  }, [currentStep, goTo, stop])
 
   const back = useCallback(() => {
     if (currentStep > 0) goTo(currentStep - 1)
   }, [currentStep, goTo])
 
-  const stop = useCallback(() => {
-    setActive(false)
-    setCurrentStep(-1)
-  }, [])
+  /*
+   * "Interrupted" counts as an exit, per the requirement on issue #80.
+   *
+   * The tour navigates constantly, so a location change is only a user
+   * interruption when it lands somewhere the tour did not send it. Comparing
+   * against the path the tour last requested is what separates the two; a bare
+   * location listener would tear the tour down on its own first step.
+   */
+  useEffect(() => {
+    if (!active) return
+    if (expectedPath.current === null) return
+    if (location.pathname === expectedPath.current) return
+    stop()
+  }, [active, location.pathname, stop])
 
   const value = useMemo(
     () => ({
@@ -260,12 +500,18 @@ export function DemoTourProvider({ children }: { children: ReactNode }) {
       currentStep,
       steps: TOUR_STEPS,
       preparing,
+      mode,
+      fallbackReason,
+      ephemeral,
+      updateEphemeral: setEphemeral,
       start: () => void start(),
       next,
       back,
       stop,
     }),
-    [active, currentStep, preparing, start, next, back, stop],
+    // `setEphemeral` is a useState setter and stable by React contract, so it is
+    // deliberately absent here.
+    [active, currentStep, preparing, mode, fallbackReason, ephemeral, start, next, back, stop],
   )
 
   return <DemoTourContext.Provider value={value}>{children}</DemoTourContext.Provider>

--- a/frontend/src/demo/HelpButton.tsx
+++ b/frontend/src/demo/HelpButton.tsx
@@ -70,24 +70,33 @@ export function HelpButton() {
           </div>
 
           <p className="mt-2 text-sm leading-relaxed text-ink-muted">
-            {TOUR_STEP_COUNT} steps through a real consultation: the transcript, the red flags and
-            where they came from, what the consultation never established, and the approval gate.
+            {TOUR_STEP_COUNT} steps through a consultation the tour analyses for you: the
+            transcript, the red flags and where they came from, what the consultation never
+            established, and the approval gate.
           </p>
 
-          {/* The two facts a clinician or an evaluator would otherwise have to
+          {/* The three facts a clinician or an evaluator would otherwise have to
               take on trust, stated before they agree to anything. */}
           <ul className="mt-4 flex flex-col gap-2 text-sm text-ink-muted">
             <li className="flex gap-2">
               <span aria-hidden className="text-accent">
                 &middot;
               </span>
-              Everything shown was produced by the real pipeline. Nothing is mocked or replayed.
+              It runs the real pipeline on a simulated transcript, which takes up to a minute.
+              Nothing is mocked or replayed.
             </li>
             <li className="flex gap-2">
               <span aria-hidden className="text-accent">
                 &middot;
               </span>
-              It only navigates and explains. Nothing is created, edited or approved for you.
+              Nothing is saved. The analysis exists only in this tab and is discarded when the tour
+              ends.
+            </li>
+            <li className="flex gap-2">
+              <span aria-hidden className="text-accent">
+                &middot;
+              </span>
+              Your own consultations are untouched.
             </li>
           </ul>
 
@@ -110,7 +119,7 @@ export function HelpButton() {
               ) : (
                 <Play aria-hidden className="size-4" />
               )}
-              {preparing ? 'Preparing' : 'Start Tour'}
+              {preparing ? 'Analysing' : 'Start Tour'}
             </button>
           </div>
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,6 @@
 import {
+  type ConsultationAnalysis,
+  ConsultationAnalysisSchema,
   type ConsultationDetail,
   ConsultationDetailSchema,
   type ConsultationListItem,
@@ -123,6 +125,35 @@ export const api = {
     request(`/consultations/${id}/analyze`, ConsultationEnvelope, { method: 'POST' }).then(
       (r) => r.consultation,
     ),
+
+  /**
+   * Runs the real pipeline and persists nothing (issue #80).
+   *
+   * The whole gate runs: de-identification, the model call, the deterministic
+   * rules engine, the evidence check. What it does not do is write a
+   * `Consultation` or an `AuditEvent` carrying one, which is what makes Demo
+   * Mode self-contained: there is no row to wipe when the tour ends, so the
+   * cleanup problem never arises.
+   *
+   * That mattered because cleanup is not available. Issue #64 moved
+   * `AuditEvent` to `onDelete: Restrict` so a delete cannot silently break the
+   * tamper-evident hash chain, and the tombstone erasure replacing it has no
+   * HTTP endpoint pending a retention decision. Creating rows the client could
+   * not remove would have been worse than creating none.
+   *
+   * It sits under `/consultations` rather than at `/analyze` because
+   * `requireSession` is mounted per prefix in `app.ts`: a new top-level prefix
+   * would be unauthenticated by default.
+   */
+  analyzeEphemeral: (transcript: Transcript, profileId?: string): Promise<ConsultationAnalysis> =>
+    request(
+      '/consultations/analyze-ephemeral',
+      z.object({ analysis: ConsultationAnalysisSchema }),
+      {
+        method: 'POST',
+        body: JSON.stringify(profileId ? { transcript, profileId } : { transcript }),
+      },
+    ).then((r) => r.analysis),
 
   patch: (
     id: string,

--- a/frontend/src/review/ApproveBar.tsx
+++ b/frontend/src/review/ApproveBar.tsx
@@ -2,7 +2,7 @@ import type { ConsultationDetail } from '@shared/types'
 import { useMutation } from '@tanstack/react-query'
 import { CheckCircle2 } from 'lucide-react'
 import { useState } from 'react'
-import { ApiError, api } from '../lib/api.js'
+import { ApiError } from '../lib/api.js'
 import { Button } from '../ui/Button.js'
 
 /**
@@ -20,14 +20,23 @@ import { Button } from '../ui/Button.js'
  * prevented.
  */
 export function ApproveBar({
-  consultationId,
+  approve: performApproval,
   approved,
   approvedAt,
   approvedBy,
   unacknowledgedCount,
   onApproved,
 }: {
-  consultationId: string
+  /**
+   * The approval transition itself, supplied by the caller.
+   *
+   * This component owns the *gate*: the two steps, the unacknowledged count,
+   * the wording. It deliberately does not own where the approval lands. Demo
+   * Mode's consultation is never stored (issue #80), so it approves in memory
+   * while a real one approves over the API, and both must pass through this
+   * same gate rather than one of them growing a second path around it.
+   */
+  approve: () => Promise<ConsultationDetail>
   approved: boolean
   approvedAt: Date | null
   approvedBy: string | null
@@ -37,7 +46,7 @@ export function ApproveBar({
   const [confirming, setConfirming] = useState(false)
 
   const approve = useMutation({
-    mutationFn: () => api.approve(consultationId),
+    mutationFn: performApproval,
     onSuccess: (next) => {
       setConfirming(false)
       onApproved(next)

--- a/frontend/src/routes/ConsultationReview.tsx
+++ b/frontend/src/routes/ConsultationReview.tsx
@@ -2,7 +2,8 @@ import type { ClinicalAssertion, ConsultationDetail, SoapNote } from '@shared/ty
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Printer, Sparkles } from 'lucide-react'
 import { useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, Navigate, useParams } from 'react-router-dom'
+import { DEMO_CONSULTATION_ID, useDemoTour } from '../demo/DemoTour.js'
 import { ApiError, api } from '../lib/api.js'
 import { cn } from '../lib/cn.js'
 import { ApproveBar } from '../review/ApproveBar.js'
@@ -24,9 +25,19 @@ export function ConsultationReview() {
   const [showTranscript, setShowTranscript] = useState(false)
   const [showAllGaps, setShowAllGaps] = useState(false)
 
+  /*
+   * Demo Mode's consultation is not stored, so there is nothing to fetch for it
+   * (issue #80). It renders through this component rather than through a
+   * demo-only screen deliberately: a second renderer would drift, and the claim
+   * the tour makes is that an evaluator is looking at the real review surface.
+   */
+  const tour = useDemoTour()
+  const isEphemeral = id === DEMO_CONSULTATION_ID
+
   const consultation = useQuery({
     queryKey: ['consultation', id],
     queryFn: () => api.getConsultation(id),
+    enabled: !isEphemeral,
   })
   const guidelines = useQuery({ queryKey: ['guidelines'], queryFn: api.guidelines })
 
@@ -36,12 +47,37 @@ export function ConsultationReview() {
   }
 
   const analyze = useMutation({ mutationFn: () => api.analyze(id), onSuccess: invalidate })
+
+  /*
+   * The ephemeral consultation has no row to PATCH, so review actions are
+   * applied in memory instead of over the wire. The state transition is
+   * identical to the stored path; only where it lands differs.
+   */
   const patch = useMutation({
-    mutationFn: (body: Parameters<typeof api.patch>[1]) => api.patch(id, body),
-    onSuccess: invalidate,
+    mutationFn: async (body: Parameters<typeof api.patch>[1]) => {
+      if (!isEphemeral) return api.patch(id, body)
+      const current = tour.ephemeral as ConsultationDetail
+      return {
+        ...current,
+        ...(body.editedNote
+          ? { editedNote: { ...current.analysis?.note, ...body.editedNote } }
+          : {}),
+        ...(body.acknowledgedRedFlagIds
+          ? { acknowledgedRedFlagIds: body.acknowledgedRedFlagIds }
+          : {}),
+        ...(body.reviewedGapIds ? { reviewedGapIds: body.reviewedGapIds } : {}),
+        updatedAt: new Date(),
+      } as ConsultationDetail
+    },
+    onSuccess: (next) => (isEphemeral ? tour.updateEphemeral(next) : invalidate(next)),
   })
 
-  if (consultation.isPending) {
+  if (isEphemeral && !tour.ephemeral) {
+    // The tour ended, which wiped it. Nothing to show and nothing to fetch.
+    return <Navigate to="/consultations" replace />
+  }
+
+  if (!isEphemeral && consultation.isPending) {
     return (
       <div className="mx-auto flex max-w-7xl flex-col gap-4">
         <Skeleton className="h-8 w-64" />
@@ -50,11 +86,10 @@ export function ConsultationReview() {
     )
   }
 
-  if (!consultation.data) {
+  const detail = isEphemeral ? tour.ephemeral : consultation.data
+  if (!detail) {
     return <p className="text-sm text-emergency">This consultation could not be loaded.</p>
   }
-
-  const detail = consultation.data
   const analysis = detail.analysis
   const approved = detail.status === 'approved'
   const note = detail.editedNote ?? analysis?.note ?? null
@@ -285,12 +320,24 @@ export function ConsultationReview() {
 
       {analysis && (
         <ApproveBar
-          consultationId={id}
+          approve={async () =>
+            isEphemeral
+              ? ({
+                  ...(tour.ephemeral as ConsultationDetail),
+                  status: 'approved',
+                  approvedAt: new Date(),
+                  // The demo has no signed-in identity distinct from the viewer,
+                  // and inventing a clinician name on a screen that teaches what
+                  // approval means would be the wrong thing to fake.
+                  approvedBy: null,
+                } as ConsultationDetail)
+              : api.approve(id)
+          }
           approved={approved}
           approvedAt={detail.approvedAt}
           approvedBy={detail.approvedBy}
           unacknowledgedCount={unacknowledged.length}
-          onApproved={invalidate}
+          onApproved={isEphemeral ? tour.updateEphemeral : invalidate}
         />
       )}
     </div>


### PR DESCRIPTION
Closes #80.

Frontend half of Demo Mode. The backend endpoint landed in #93; this is the client that uses it.

## The Problem

Demo Mode walked the demo account's **stored** consultations, so the walkthrough mutated the data it was walking. Approving during a demo is permanent and there is no un-approve, and the account had already drifted: its only flagged consultation had become `approved`, so the Red Flags stop pointed at a consultation with **zero flags**.

## What Changed

The tour analyses a bundled fixture through the real pipeline and holds the result in React state alone. Nothing is written, so "wiped instantly on exit" is true by construction rather than by a delete that could fail or be skipped.

That shape was forced rather than preferred: `AuditEvent` is `onDelete: Restrict` since #64, and the tombstone erasure replacing it has no HTTP endpoint pending the §19 retention decision. Rows created here could not have been cleaned up, so the answer is to create none.

Exit, finish and interrupt all land on one `stop()`, which drops the reference. Visiting the tour's id after a wipe redirects to the list.

## Two Anchors Chosen by Measurement

Both of these were caught by measuring rather than assuming, and each would have left a stop pointing at an element that does not exist:

| | Assumed | Measured | Fix |
|---|---|---|---|
| **Fixture** | `fixtures[0]` | That is `urti-gap-heavy`, which yields **0 red flags** | Pin `urti-hard-red-flag`: 2 rule flags above 3 model candidates |
| **Citations** | Ephemeral record serves every step | That analysis returns **0 suggestions** | Citations falls back to a stored consultation |

The second is not a defect in the pipeline. The correct handling of a severe presentation is "escalate now", which is not a guideline-cited recommendation. Reading a seeded row persists nothing, so the ephemeral guarantee is intact.

## Degradation

The seeded walk survives as a fallback and **announces itself on screen**, so a degraded demo never silently asserts it is running the real pipeline at the moment that claim is being judged.

- **429 and 500 are distinguished.** A 429 is recoverable by waiting and says so; a 500 is not.
- **No automatic retry.** With a 5/min bucket, retrying turns one flaky call into a rate-limit error that misreports the cause.

## Also

- Guided-tour control is a round `?` FAB, the one deliberate exception to the rounded-rectangle CTA rule in `docs/DESIGN.md`.
- The dialog states the analysis takes up to a minute and is not saved.

## Verification

Browser-driven against the live endpoint, guest session, all nine stops:

```
3. tour started after 24.9s; POSTs=[{"status":200}]
4. mode=LIVE
    1. Consultations  anchors= 1 OK  -         /consultations
    2. Intake         anchors= 1 OK            /consultations/new
    3. Transcript     anchors= 1 OK  ephemeral /consultations/demo-ephemeral
    4. Red Flags      anchors= 3 OK  ephemeral /consultations/demo-ephemeral
    5. Gaps           anchors=26 OK  ephemeral /consultations/demo-ephemeral
    6. Checklist      anchors= 1 OK  ephemeral /consultations/demo-ephemeral
    7. Approval       anchors= 1 OK  ephemeral /consultations/demo-ephemeral
    8. Citations      anchors=11 OK  stored    /consultations/cmssk9wpb...
    9. Corpus         anchors= 1 OK  -         /guidelines
5. steps with no anchor to point at: 0 (want 0)
6. after interrupt: stepbar=0, FAB=1
7. /consultations/demo-ephemeral -> /consultations
8. console errors: none
```

Gates: typecheck clean, biome clean, 387 tests passing (32 shared + 346 backend + 9 frontend).

## Clinical-Safety Checklist

- [x] No new path from raw transcript text toward a provider. The client sends a **synthetic bundled fixture** to the existing gated endpoint; de-identification runs unchanged on the server.
- [x] No deterministic red-flag hit is suppressed, downgraded or filtered. The client only renders what the pipeline returns.
- [x] Citations stay ID-constrained. No change to citation handling; the Citations stop routes to whichever consultation actually has one.
- [x] Nothing is presented as a diagnosis, and approval remains an explicit doctor action. The tour explicitly does not press Approve.
- [x] No transcript bodies, note contents or vault entries logged.
- [x] No clinical content written to `localStorage` or any web storage. The analysis lives in React state and is dropped on exit.