### PR TITLE
fix(llm): bound provider requests in time instead of inheriting SDK defaults

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -43,7 +43,8 @@ Maps to OWASP LLM01 Prompt Injection, LLM02 Sensitive Information Disclosure, LL
 - **The transcript is untrusted input.** A patient or a dictation can contain text shaped like an instruction. The control is the response schema, not the prompt wording: closed schemas, enums, and no free-text escape hatch. Prompt-level defenses fail silently and do not count as controls.
 - Every model response is validated with `request.schema.safeParse` inside the adapter before it reaches a route. Never act on unparsed model output.
 - Schema failure messages can embed model output. They are currently contained because the route collapses them into a generic `HttpError(500, 'analysis_failed')` and the logger never writes `err.message`. Keep both ends of that.
-- **Not built today:** no request timeout, no `AbortController`, no pinned `maxRetries` on the `OpenAI` constructor. Any new LLM call path should set an explicit timeout rather than inherit SDK defaults.
+- **Request bounds are on the constructor, and belong there** (issue #94). `timeout: 60_000` and `maxRetries: 1` replace SDK defaults of 10 minutes and 2 retries, which compounded to roughly 30 minutes per operation because the SDK retries timeouts. Constructor-level, not per-request, so every call path inherits them. Do not move them to a call site, and do not add a provider that bypasses `OpenAICompatibleClient`. Pinned by `backend/src/lib/llm/openai-compatible.test.ts` (OWASP LLM10 Unbounded Consumption).
+- **Not built today:** no `AbortController`, so a client disconnect does not cancel an in-flight provider call. That is a quota control, not a bound on hang time; the timeout above is what bounds the hang.
 
 ## Clinical Safety Invariants
 

--- a/backend/src/lib/llm/openai-compatible.test.ts
+++ b/backend/src/lib/llm/openai-compatible.test.ts
@@ -14,8 +14,9 @@ import type { Deidentified } from '../../deid/types.js'
  * PHI boundary.
  */
 
-const { completionsCreate, envMock } = vi.hoisted(() => ({
+const { completionsCreate, constructed, envMock } = vi.hoisted(() => ({
   completionsCreate: vi.fn(),
+  constructed: vi.fn(),
   envMock: { DEID_FAIL_CLOSED: true },
 }))
 
@@ -23,10 +24,17 @@ const { completionsCreate, envMock } = vi.hoisted(() => ({
  * Standing in for the SDK is what lets this assert on egress rather than on the
  * exception. If `completionsCreate` is never called, nothing reached the
  * network, which no amount of asserting on the thrown error can establish.
+ *
+ * `constructed` captures the client options for the same reason: the bounds in
+ * issue #94 are only real if they reach the SDK, and the value they replace is
+ * a default that is invisible at the call site.
  */
 vi.mock('openai', () => ({
   default: class {
     chat = { completions: { create: completionsCreate } }
+    constructor(options: unknown) {
+      constructed(options)
+    }
   },
 }))
 
@@ -66,7 +74,52 @@ const SMUGGLED = 'Patient NRIC is 850523-14-5677' as unknown as Deidentified
 
 beforeEach(() => {
   completionsCreate.mockReset()
+  constructed.mockReset()
   envMock.DEID_FAIL_CLOSED = true
+})
+
+/**
+ * GitHub issue #94. Inheriting the SDK defaults costs a 10-minute timeout with
+ * two silent retries, and the SDK retries timeouts, so a provider that stops
+ * responding holds one operation for roughly 30 minutes against CAP-1's
+ * 30-second budget.
+ *
+ * These assert the values rather than merely that something was passed. A
+ * regression here is silent by construction: dropping the options restores a
+ * working client with defaults nobody chose, which no other test would notice.
+ */
+describe('every provider call is bounded in wall-clock time', () => {
+  it('pins the request timeout instead of inheriting the SDK default', () => {
+    client()
+
+    expect(constructed).toHaveBeenCalledTimes(1)
+    expect(
+      constructed.mock.calls[0]?.[0],
+      'Without an explicit timeout the SDK waits 10 minutes per attempt.',
+    ).toMatchObject({ timeout: 60_000 })
+  })
+
+  it('pins maxRetries, which the SDK otherwise defaults to 2', () => {
+    client()
+
+    expect(
+      constructed.mock.calls[0]?.[0],
+      'Retries multiply the timeout, so an unpinned count is what turns ' + '10 minutes into 30.',
+    ).toMatchObject({ maxRetries: 1 })
+  })
+
+  it('applies the bounds to every provider, not just the default one', () => {
+    new OpenAICompatibleClient('deepseek', 'deepseek-v4-flash', {
+      apiKey: 'test-key',
+      baseURL: 'https://example.invalid/v1',
+    })
+
+    expect(
+      constructed.mock.calls[0]?.[0],
+      'The bounds live on the shared adapter precisely so a provider cannot ' +
+        'be added without them.',
+    ).toMatchObject({ maxRetries: 1, timeout: 60_000 })
+  })
 })
 
 describe('the adapter re-scans every payload before it leaves the process', () => {

--- a/backend/src/lib/llm/openai-compatible.ts
+++ b/backend/src/lib/llm/openai-compatible.ts
@@ -10,6 +10,27 @@ import {
 } from './types.js'
 
 /**
+ * Wall-clock bounds on a single provider call (GitHub issue #94).
+ *
+ * The SDK defaults are a 10-minute timeout and two silent retries, and it
+ * retries timeouts, so one operation could occupy roughly 30 minutes against
+ * CAP-1's 30-second budget. `max_tokens` below already bounds the response's
+ * *size*; nothing bounded its *time*.
+ *
+ * 60s is roughly 3x the measured worst case (docs/trd.md §19 row 19: mean
+ * 19.9s, worst 21.6s through the shipped `analyseNote`), so it cannot fire on a
+ * healthy call. One retry is kept because a *fast* transient failure, such as a
+ * refused connection inside the first second, still has room to finish inside
+ * the budget. It caps the pathological case at two minutes rather than thirty.
+ *
+ * Both sit on the constructor rather than on each request, so they cover every
+ * call path without opt-in. Same reasoning as the egress guard below: a bound a
+ * caller can skip by building the client differently is not a bound.
+ */
+const REQUEST_TIMEOUT_MS = 60_000
+const MAX_RETRIES = 1
+
+/**
  * One adapter covers all three providers — Qwen (Model Studio, Singapore),
  * DeepSeek, and Gemini all expose OpenAI-compatible chat completions with
  * JSON-schema structured output.
@@ -25,7 +46,12 @@ export class OpenAICompatibleClient implements LLMClient {
     readonly model: string,
     options: { apiKey: string; baseURL: string },
   ) {
-    this.client = new OpenAI({ apiKey: options.apiKey, baseURL: options.baseURL })
+    this.client = new OpenAI({
+      apiKey: options.apiKey,
+      baseURL: options.baseURL,
+      timeout: REQUEST_TIMEOUT_MS,
+      maxRetries: MAX_RETRIES,
+    })
   }
 
   async generate<T>(request: GenerateRequest<T>): Promise<T> {

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -286,6 +286,22 @@ One adapter class implements `LLMClient` for all three providers — Qwen, Gemin
 3. `temperature` defaults to `0.2` when `request.temperature` is not supplied.
 4. Validates the response with `request.schema.safeParse(parsed)` before returning — a non-conforming response is never returned as partially-trusted data.
 
+### Request Bounds
+
+**Status: `Built`** (issue #94). Both are constructor options on the shared adapter, so every call path inherits them and a new provider cannot be added without them.
+
+| Bound        | Value    | SDK Default | Why                                                                                                                                         |
+| ------------ | -------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `timeout`    | `60_000` | `600_000`   | Roughly 3x the §19 row 19 worst case (21.6s), so it cannot fire on a healthy call while converting a 10-minute stall into a 60-second error |
+| `maxRetries` | `1`      | `2`         | The SDK retries timeouts, so an unpinned count is what compounds 10 minutes into 30. One retry still covers a fast transient failure        |
+
+Two clarifications, because the adjacent bound is easy to confuse with these:
+
+- `max_tokens` (8192) bounds the response's **size**; these bound its **time**. The runaway generation measured in §19 row 19 was already contained by the former.
+- Neither is a CAP-1 enforcement mechanism. Nothing fails a request at 30s; these bound the pathological case only.
+
+**Not built:** no `AbortController`, so a client disconnect does not cancel an in-flight call. That reclaims quota on abandoned requests rather than bounding a hang, and it would have to be threaded per call site.
+
 ### Failure Modes
 
 | Failure                   | Trigger                                                                                                                  |


### PR DESCRIPTION
## What Changed

`OpenAICompatibleClient` now constructs the SDK with `timeout: 60_000` and `maxRetries: 1`. It previously passed credentials only, and inherited whatever the SDK defaulted to.

Closes #94.

## Why

The inherited defaults, read out of the installed `openai@6.49.0` rather than assumed:

| Setting | Source | Value |
| --- | --- | --- |
| `OpenAI.DEFAULT_TIMEOUT` | `client.js:747` | `600000`, ten minutes |
| `maxRetries` | `client.d.ts:105` | `@default 2`, three attempts |

The SDK's own docstring names the compounding: *"request timeouts are retried by default, so in a worst-case scenario you may wait much longer than this timeout."* That is roughly **30 minutes for one operation** against CAP-1's 30-second budget.

**`max_tokens` was already bounding the response's size**, so the runaway generation measured in §19 row 19 was contained. Nothing bounded its *time*. Three things sharpened that:

- `analyseNote` runs two `generate` calls under `Promise.all`, so one stall holds the whole analyse.
- `analyzeRateLimit` admits 10/min onto a single Render free-tier instance.
- A silent retry triples token spend on a call that has already missed its budget.

OWASP LLM10 Unbounded Consumption. `.claude/rules/security.md` already recorded this exact gap under "LLM Egress"; that line is now updated to describe what ships.

## Decision

**The bounds go on the constructor, not on each request.** The egress guard sits inside the adapter on the stated grounds that *"a guard a caller can omit by constructing the client differently is not a boundary"*, and the same argument applies. Constructor-level covers `clinical_facts`, `note_and_gaps`, `suggestions_and_red_flags`, and every future call path without opt-in.

**`maxRetries: 1`, not `0`.** Zero would cap the worst case at 60s instead of 120s, but gives up resilience to a fast transient failure, and a refused connection inside the first second still has room to finish inside CAP-1. I judged a blip failing a live demo to be worse than 60 extra seconds in a case that is already failing. **This is the one number worth arguing about** — say so and I will change it.

**60s for the timeout** is roughly 3x the §19 row 19 measured worst case (mean 19.9s, worst 21.6s through the shipped `analyseNote`), so it cannot fire on a healthy call. Neither value enforces CAP-1; nothing fails a request at 30s, and these bound the pathological case only.

## Verification

- [x] `bun run lint` — 0 errors. The 9 remaining `noConsole` warnings are pre-existing in `prisma/seed*.ts` and untouched here
- [x] `bun run typecheck` — clean across all three workspaces
- [x] `bun run test` — **390 passed** (387 before, 3 added), exit 0

Three tests added, all in `backend/src/lib/llm/openai-compatible.test.ts`. They assert the **values** reach the SDK, not merely that options were passed: dropping them restores a working client with defaults nobody chose, which no other test would notice. The `openai` mock gained a constructor to capture them.

**Confirmed the tests are load-bearing.** Stashing only the source change turns exactly the three new tests red and leaves the five existing ones green:

```
× every provider call is bounded in wall-clock time > pins the request timeout instead of inheriting the SDK default
× every provider call is bounded in wall-clock time > pins maxRetries, which the SDK otherwise defaults to 2
× every provider call is bounded in wall-clock time > applies the bounds to every provider, not just the default one
Tests  3 failed | 5 passed (8)
```

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider — egress still goes through `deid/` then `LLMClient`. The `assertNoIdentifiers` guard is untouched and still runs before the SDK call
- [x] No provider SDK imported outside `backend/src/lib/llm/` — no new imports at all; `no-stray-provider-sdk.test.ts` still passes
- [x] Deterministic red-flag hits remain unsuppressable by the model — `redflags/` not touched
- [x] Citations remain ID-constrained — `guidelines/` not touched
- [x] No transcript bodies, note contents, or vault entries written to logs — no logging change. A timeout surfaces as the existing generic `analysis_failed`
- [x] Fixtures added are synthetic — none added

## Notes For The Reviewer

**An `AbortController` is deliberately not included**, despite `security.md` naming it in the same sentence. It is a different control: it reclaims quota when a doctor closes the tab, and does nothing to bound a hang. It needs an `AbortSignal` threaded through `GenerateRequest` and wired to `req` in the route, which makes it opt-in per call site, the exact property this change avoids. Left recorded as open in the security rules; worth its own issue if wanted.

**Flaky tests observed, unrelated to this diff, worth knowing about.** Across five root `bun run test` runs on this branch, two failed with 5s-timeout overruns (10015ms and 9798ms) in `routes/auth.test.ts` and `routes/consultations.test.ts`. They did not reproduce: three subsequent runs of the same full change were green, and `bun run --cwd backend test` was green every time. `auth.test.ts` is the file from #57, *"making the suite flaky"*. I could not attribute it to this diff, and I would rather flag it than let it look like a clean run every time.

**Unrelated drift noticed, not fixed** (surgical-change rule): the `GenerateRequest<T>` table in `docs/trd.md` §6 is missing the `maxTokens?` row that exists in `types.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 60-second timeout and one retry limit to supported AI provider requests.
  * Reduced the risk of prolonged request stalls and excessive retry delays.

* **Documentation**
  * Documented request time limits, retry behavior, response-size limits, and cancellation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->