### PR TITLE
fix(demo): correct the tour's placement, timing, treatment and exit

### DIFF
--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -276,6 +276,10 @@ async function runAnalysis(
       ...suggestion,
       text: rehydrate(suggestion.text),
     })),
+    // Carried rather than dropped. An empty `suggestions` array cannot tell the
+    // reader whether the corpus had nothing to say or was never consulted, which
+    // is the conflation this flag exists to prevent (docs/trd.md §19 row 7).
+    outOfScope: suggestionResult.outOfScope,
   }
 
   return { analysis, detected, discardedFieldIds: noteResult.discardedFieldIds }

--- a/frontend/src/demo/DemoTour.tsx
+++ b/frontend/src/demo/DemoTour.tsx
@@ -332,6 +332,62 @@ async function runEphemeral(): Promise<ConsultationDetail> {
   }
 }
 
+/**
+ * Which consultation a step's route points at.
+ *
+ * A pure function taking the analysis explicitly rather than a closure reading
+ * it from state, because the tour now starts before the analysis finishes. A
+ * step that waits for it resumes with the resolved value in hand, and a closure
+ * captured at render time would still hold the `null` it started with.
+ *
+ * `ephemeral` being non-null is what "live" means; there is no separate flag.
+ */
+function resolveStepRoute(
+  step: TourStep,
+  resolved: Subjects,
+  ephemeral: ConsultationDetail | null,
+): string {
+  if (!step.route.includes(':id')) return step.route
+
+  if (ephemeral) {
+    /*
+     * Live mode has one consultation, so every consultation step points at the
+     * same in-memory record, with one measured exception.
+     *
+     * The Citations stop needs a cited suggestion to point at, and whether the
+     * analysis produces one is a property of the transcript rather than a
+     * guarantee. The fixture chosen for its red flags is a severe presentation
+     * whose correct handling is "escalate now", and escalation is not a
+     * guideline-cited recommendation: analysing it against production returned
+     * five red flags and zero suggestions. Sending the Citations step there
+     * would leave the closed-corpus claim pointing at an element that does not
+     * exist.
+     *
+     * So that one step falls back to a stored consultation that does have a
+     * citation. Reading a seeded row persists nothing, so this costs the
+     * ephemeral guarantee nothing; the tour simply stops narrating its own
+     * analysis for the one stop its own analysis cannot illustrate.
+     */
+    const wantsCitation = step.subject === 'cited'
+    const hasCitation = (ephemeral.analysis?.suggestions?.length ?? 0) > 0
+    if (wantsCitation && !hasCitation && resolved.cited) {
+      return step.route.replace(':id', resolved.cited)
+    }
+    return step.route.replace(':id', DEMO_CONSULTATION_ID)
+  }
+
+  const id = resolved[step.subject ?? 'flagged'] ?? resolved.flagged
+  // Without an id there is nothing to review; the list is the honest
+  // destination rather than a route with a literal ":id" in it.
+  return id ? step.route.replace(':id', id) : '/consultations'
+}
+
+/** What the opening work resolves to, handed to whichever step waits on it. */
+interface TourData {
+  own: ConsultationDetail | null
+  resolved: Subjects
+}
+
 export function DemoTourProvider({ children }: { children: ReactNode }) {
   const navigate = useNavigate()
   const location = useLocation()
@@ -347,105 +403,98 @@ export function DemoTourProvider({ children }: { children: ReactNode }) {
       distinguishable from the tour's own. */
   const expectedPath = useRef<string | null>(null)
 
-  const routeFor = useCallback(
-    (step: TourStep, resolved: Subjects, live: boolean) => {
-      if (!step.route.includes(':id')) return step.route
-      if (live && ephemeral) {
-        /*
-         * Live mode has one consultation, so every consultation step points at
-         * the same in-memory record, with one measured exception.
-         *
-         * The Citations stop needs a cited suggestion to point at, and whether
-         * the analysis produces one is a property of the transcript rather than
-         * a guarantee. The fixture chosen for its red flags is a severe
-         * presentation whose correct handling is "escalate now", and escalation
-         * is not a guideline-cited recommendation: analysing it against
-         * production returned five red flags and zero suggestions. Sending the
-         * Citations step there would leave the closed-corpus claim pointing at
-         * an element that does not exist.
-         *
-         * So that one step falls back to a stored consultation that does have a
-         * citation. Reading a seeded row persists nothing, so this costs the
-         * ephemeral guarantee nothing; the tour simply stops narrating its own
-         * analysis for the one stop its own analysis cannot illustrate.
-         */
-        const wantsCitation = step.subject === 'cited'
-        const hasCitation = (ephemeral.analysis?.suggestions?.length ?? 0) > 0
-        if (wantsCitation && !hasCitation && resolved.cited) {
-          return step.route.replace(':id', resolved.cited)
-        }
-        return step.route.replace(':id', DEMO_CONSULTATION_ID)
-      }
-      const id = resolved[step.subject ?? 'flagged'] ?? resolved.flagged
-      // Without an id there is nothing to review; the list is the honest
-      // destination rather than a route with a literal ":id" in it.
-      return id ? step.route.replace(':id', id) : '/consultations'
-    },
-    [ephemeral],
-  )
+  /**
+   * The opening analysis, in flight.
+   *
+   * Held in a ref rather than state because nothing renders from it directly;
+   * it exists so a step that needs the consultation can await the same promise
+   * instead of racing it or starting a second one.
+   */
+  const data = useRef<Promise<TourData> | null>(null)
 
-  const start = useCallback(async () => {
-    setPreparing(true)
+  /*
+   * The tour opens immediately and the analysis catches up, rather than the
+   * tour waiting for the analysis.
+   *
+   * Running the real pipeline costs about 50 seconds against production, and
+   * blocking on it meant a minute of spinner before anything appeared, which
+   * reads as broken rather than as thorough. The first two stops, the
+   * consultation list and the intake screen, do not touch the analysis at all,
+   * so there is nothing to wait for until the third. By the time a viewer has
+   * read those two the call has usually landed, and if it has not, the wait
+   * happens at the stop that genuinely needs it, with the product on screen
+   * rather than a modal.
+   */
+  const start = useCallback(() => {
+    data.current = (async () => {
+      /*
+       * Both paths resolve concurrently, even when the live one succeeds.
+       *
+       * The seeded subjects are needed in live mode too, because the Citations
+       * step falls back to a stored consultation when the analysis produces no
+       * suggestions. The scoring reads finish in well under a second against a
+       * call taking roughly fifty, and they warm the cache the review screen is
+       * about to use.
+       */
+      const seeded = pickConsultations((consultation) =>
+        queryClient.fetchQuery({
+          queryKey: ['consultation', consultation],
+          queryFn: () => api.getConsultation(consultation),
+        }),
+      ).catch(() => ({ flagged: null, cited: null }) as Subjects)
 
-    /*
-     * Both paths are resolved, concurrently, even when the live one succeeds.
-     *
-     * The seeded subjects are needed in live mode too, because the Citations
-     * step falls back to a stored consultation when the analysis produces no
-     * suggestions (see `routeFor`). Running them in sequence would add the
-     * scoring reads to a wait that is already dominated by the analysis, and
-     * running them at all is close to free: the reads finish in well under a
-     * second against a call that took roughly fifty against production, and
-     * they warm the cache the review screen is about to use.
-     */
-    const seeded = pickConsultations((consultation) =>
-      queryClient.fetchQuery({
-        queryKey: ['consultation', consultation],
-        queryFn: () => api.getConsultation(consultation),
-      }),
-    ).catch(() => ({ flagged: null, cited: null }) as Subjects)
+      // Live first. The seeded walk is the fallback, not the plan.
+      //
+      // No automatic retry, deliberately. The endpoint allows 5/min per IP, so
+      // a retry on failure turns one flaky call into a 429 and reports a rate
+      // limit where the real fault was something else.
+      const own = await runEphemeral().catch((error: unknown) => {
+        setFallbackReason(
+          error instanceof ApiError && error.status === 429 ? 'rate_limited' : 'failed',
+        )
+        return null
+      })
+      const resolved = await seeded
 
-    // Live first. The seeded walk is the fallback, not the plan.
-    //
-    // No automatic retry, deliberately. The endpoint allows 5/min per IP, so a
-    // retry on failure turns one flaky call into a 429 and reports a rate limit
-    // where the real fault was something else.
-    const own = await runEphemeral().catch((error: unknown) => {
-      setFallbackReason(
-        error instanceof ApiError && error.status === 429 ? 'rate_limited' : 'failed',
-      )
-      return null
-    })
+      setEphemeral(own)
+      setSubjects(resolved)
+      setMode(own ? 'live' : 'seeded')
+      return { own, resolved }
+    })()
 
-    const resolved = await seeded
-
-    setEphemeral(own)
-    setSubjects(resolved)
-    setMode(own ? 'live' : 'seeded')
-    setPreparing(false)
     setActive(true)
     setCurrentStep(0)
 
     const first = TOUR_STEPS[0] as TourStep
-    const path = first.route.includes(':id')
-      ? own
-        ? first.route.replace(':id', DEMO_CONSULTATION_ID)
-        : routeFor(first, resolved, false)
-      : first.route
-    expectedPath.current = path
-    navigate(path)
-  }, [navigate, queryClient, routeFor])
+    expectedPath.current = first.route
+    navigate(first.route)
+  }, [navigate, queryClient])
 
   const goTo = useCallback(
-    (index: number) => {
+    async (index: number) => {
       const step = TOUR_STEPS[index]
       if (!step) return
+
+      let target = ephemeral
+      let subject = subjects
+
+      // Only the steps that need a consultation wait for one. Awaiting an
+      // already-settled promise costs a microtask, so this is free once the
+      // analysis has landed.
+      if (step.route.includes(':id') && data.current) {
+        setPreparing(true)
+        const settled = await data.current
+        setPreparing(false)
+        target = settled.own
+        subject = settled.resolved
+      }
+
       setCurrentStep(index)
-      const path = routeFor(step, subjects, mode === 'live')
+      const path = resolveStepRoute(step, subject, target)
       expectedPath.current = path
       navigate(path)
     },
-    [subjects, navigate, routeFor, mode],
+    [subjects, ephemeral, navigate],
   )
 
   /**
@@ -460,23 +509,41 @@ export function DemoTourProvider({ children }: { children: ReactNode }) {
   const stop = useCallback(() => {
     setActive(false)
     setCurrentStep(-1)
+    setPreparing(false)
     setEphemeral(null)
     setSubjects({ flagged: null, cited: null })
     expectedPath.current = null
+    // Dropped so the next tour analyses afresh. Keeping it would hand a second
+    // run the first run's consultation, which is a persisted demo by another
+    // name and undoes the guarantee this whole design exists for.
+    data.current = null
   }, [])
 
   const next = useCallback(() => {
-    // The last step closes the tour rather than dead-ending on a disabled
-    // button, so there is always exactly one obvious way forward.
+    /*
+     * The last step closes the tour rather than dead-ending on a disabled
+     * button, so there is always exactly one obvious way forward, and it hands
+     * the viewer the intake screen on the way out.
+     *
+     * The tour ends on the guideline corpus, which is a reference page and a
+     * dead end. What someone most plausibly wants after being shown how a
+     * consultation is analysed is to run one, so finishing lands there instead
+     * of leaving them where the narration happened to stop.
+     *
+     * Leaving early through End or Escape deliberately does not redirect. That
+     * is someone getting out, not arriving, and sending them somewhere they did
+     * not ask to go would be exactly the interruption the tour avoids elsewhere.
+     */
     if (currentStep >= TOUR_STEPS.length - 1) {
       stop()
+      navigate('/consultations/new')
       return
     }
-    goTo(currentStep + 1)
-  }, [currentStep, goTo, stop])
+    void goTo(currentStep + 1)
+  }, [currentStep, goTo, stop, navigate])
 
   const back = useCallback(() => {
-    if (currentStep > 0) goTo(currentStep - 1)
+    if (currentStep > 0) void goTo(currentStep - 1)
   }, [currentStep, goTo])
 
   /*
@@ -504,7 +571,7 @@ export function DemoTourProvider({ children }: { children: ReactNode }) {
       fallbackReason,
       ephemeral,
       updateEphemeral: setEphemeral,
-      start: () => void start(),
+      start,
       next,
       back,
       stop,

--- a/frontend/src/demo/HelpButton.tsx
+++ b/frontend/src/demo/HelpButton.tsx
@@ -1,5 +1,7 @@
 import { Loader2, Play, X } from 'lucide-react'
 import { useEffect, useRef } from 'react'
+import { useMatch } from 'react-router-dom'
+import { cn } from '../lib/cn.js'
 import { TOUR_STEP_COUNT, useDemoTour } from './DemoTour.js'
 
 /**
@@ -17,6 +19,11 @@ import { TOUR_STEP_COUNT, useDemoTour } from './DemoTour.js'
 export function HelpButton() {
   const { active, preparing, start } = useDemoTour()
   const dialog = useRef<HTMLDialogElement>(null)
+
+  // The review screen is the one place with a sticky bar under this button, and
+  // `new` is excluded because the intake screen shares the route but not the bar.
+  const review = useMatch('/consultations/:id')
+  const overApproveBar = review !== null && review.params.id !== 'new'
 
   // A native <dialog> gives focus trapping, Escape, inertness of the page
   // behind it and the top layer for free. Hand-rolling those is how a modal
@@ -42,11 +49,26 @@ export function HelpButton() {
         aria-label="Take the guided tour"
         title="Guided Tour"
         style={{ zIndex: 'var(--z-sticky)' }}
-        // 7rem clears both pieces of bottom-docked chrome it would otherwise
-        // land on: the mobile dock below md, and the sticky approve bar on the
-        // review screen, which sits at the same right offset and is the primary
-        // action on the one screen where a help button must not compete.
-        className="glass fixed right-4 bottom-28 flex size-12 items-center justify-center rounded-full text-lg font-semibold text-accent transition-[transform,color] duration-150 ease-out-quart hover:text-accent-hover active:scale-[0.94] md:right-6"
+        /*
+         * Bottom-right corner, lifted only where something is genuinely under
+         * it. A single global offset was the previous approach and it parked
+         * the button 7rem up on every screen, which reads as misplaced on the
+         * majority that have no bottom chrome at all.
+         *
+         * The two things it must clear, measured rather than guessed:
+         * the mobile dock below `md` reaches about 4.5rem up (`bottom-3` plus a
+         * `min-h-12` row and padding), and the sticky approve bar on the review
+         * screen reaches about 5rem (`bottom-4` plus `p-3` around an `h-10`
+         * button). `bottom-24` is 6rem and clears both; everywhere else gets
+         * the corner.
+         *
+         * The approve bar shares this right offset and is the primary action on
+         * the one screen where a help button must not compete with it.
+         */
+        className={cn(
+          'glass fixed right-4 flex size-12 items-center justify-center rounded-full text-lg font-semibold text-accent transition-[transform,color] duration-150 ease-out-quart hover:text-accent-hover active:scale-[0.94] md:right-6',
+          overApproveBar ? 'bottom-24' : 'bottom-24 md:bottom-6',
+        )}
       >
         <span aria-hidden>?</span>
       </button>
@@ -82,8 +104,8 @@ export function HelpButton() {
               <span aria-hidden className="text-accent">
                 &middot;
               </span>
-              It runs the real pipeline on a simulated transcript, which takes up to a minute.
-              Nothing is mocked or replayed.
+              It runs the real pipeline on a simulated transcript. The analysis starts now and runs
+              while you walk the first couple of screens. Nothing is mocked or replayed.
             </li>
             <li className="flex gap-2">
               <span aria-hidden className="text-accent">

--- a/frontend/src/demo/Spotlight.tsx
+++ b/frontend/src/demo/Spotlight.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, ArrowRight, X } from 'lucide-react'
+import { ArrowLeft, ArrowRight, Loader2, X } from 'lucide-react'
 import { type CSSProperties, useEffect, useState } from 'react'
 import { cn } from '../lib/cn.js'
 import { useDemoTour } from './DemoTour.js'
@@ -20,7 +20,7 @@ const TOOLTIP_HALF = 184
 const EDGE = 16
 
 export function Spotlight() {
-  const { active, currentStep, steps, next, back, stop } = useDemoTour()
+  const { active, currentStep, steps, next, back, stop, preparing } = useDemoTour()
   const step = active && currentStep >= 0 ? steps[currentStep] : undefined
   const [rect, setRect] = useState<DOMRect | null>(null)
   const [radius, setRadius] = useState<string | null>(null)
@@ -137,12 +137,14 @@ export function Spotlight() {
       {rect && (
         <div
           aria-hidden
-          className="pointer-events-none fixed ring-2 ring-accent ring-offset-2 ring-offset-ground transition-[top,left,width,height] duration-200 ease-out-quart"
+          // Inset by the ring's own 2px so the gradient sits where the old
+          // `ring-2` did, hugging the target rather than eating into it.
+          className="tour-ring pointer-events-none fixed transition-[top,left,width,height] duration-200 ease-out-quart"
           style={{
-            top: rect.top,
-            left: rect.left,
-            width: rect.width,
-            height: rect.height,
+            top: rect.top - 2,
+            left: rect.left - 2,
+            width: rect.width + 4,
+            height: rect.height + 4,
             borderRadius: radius ?? undefined,
             zIndex: 'var(--z-modal)',
           }}
@@ -154,9 +156,12 @@ export function Spotlight() {
       <div
         role="alert"
         style={{ ...tooltipStyle, zIndex: 'var(--z-tooltip)', position: 'fixed' }}
-        className={cn(
-          'w-[22rem] max-w-[calc(100vw-2rem)] rounded-card border border-line bg-surface p-4 shadow-float',
-        )}
+        // `glass` rather than a solid surface: the card sits over the screen it
+        // is describing, and letting that screen show through is what keeps the
+        // tour reading as an overlay on the product rather than a page of its
+        // own. `shadow-float` stays, since glass alone does not lift it off a
+        // busy background.
+        className={cn('glass w-[22rem] max-w-[calc(100vw-2rem)] rounded-card p-4 shadow-float')}
       >
         <div className="flex items-start justify-between gap-3">
           <span className="text-2xs font-semibold tracking-wide text-accent uppercase">
@@ -188,13 +193,28 @@ export function Spotlight() {
               <ArrowLeft aria-hidden className="size-3.5" />
               Back
             </button>
+            {/* Named rather than a bare spinner. If the next stop is waiting on
+                the analysis the viewer should know that is what is happening,
+                since the alternative reading of a stalled button is a bug. */}
             <button
               type="button"
               onClick={next}
-              className="flex h-8 items-center gap-1.5 rounded-control bg-accent px-3 text-xs font-medium text-accent-ink shadow-raised transition-[background-color,transform] duration-150 ease-out-quart hover:bg-accent-hover active:scale-[0.97]"
+              disabled={preparing}
+              className="flex h-8 items-center gap-1.5 rounded-control bg-accent px-3 text-xs font-medium text-accent-ink shadow-raised transition-[background-color,transform] duration-150 ease-out-quart hover:bg-accent-hover active:scale-[0.97] disabled:pointer-events-none disabled:opacity-70"
             >
-              {currentStep === steps.length - 1 ? 'Finish' : 'Next'}
-              {currentStep < steps.length - 1 && <ArrowRight aria-hidden className="size-3.5" />}
+              {preparing ? (
+                <>
+                  <Loader2 aria-hidden className="size-3.5 animate-spin" />
+                  Analysing
+                </>
+              ) : (
+                <>
+                  {currentStep === steps.length - 1 ? 'Finish' : 'Next'}
+                  {currentStep < steps.length - 1 && (
+                    <ArrowRight aria-hidden className="size-3.5" />
+                  )}
+                </>
+              )}
             </button>
           </div>
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,6 +42,12 @@
   --color-accent-hover: oklch(0.405 0.082 168);
   --color-accent-ink: oklch(1 0 0);
 
+  /* The two stops of the coachmark ring's gradient. Same hue as the accent so
+   * the tour reads as part of the product, separated on lightness and chroma
+   * rather than hue so the travelling highlight is legible at 50% opacity. */
+  --color-tour-ring: oklch(0.52 0.096 168);
+  --color-tour-ring-lit: oklch(0.78 0.085 168);
+
   /* Severity. One grammar: solid card, coloured rule, icon, word label. */
   --color-emergency: oklch(0.486 0.192 27);
   --color-emergency-rule: oklch(0.552 0.208 28);
@@ -153,6 +159,11 @@
     --color-accent: oklch(0.72 0.11 168);
     --color-accent-hover: oklch(0.78 0.115 168);
     --color-accent-ink: oklch(0.185 0.006 160);
+
+    /* Inverted against light: the lit stop is the brighter one in both themes,
+     * but on a dark ground the base has to lift to stay visible at 50%. */
+    --color-tour-ring: oklch(0.68 0.1 168);
+    --color-tour-ring-lit: oklch(0.88 0.07 168);
 
     --color-emergency: oklch(0.72 0.165 30);
     --color-emergency-rule: oklch(0.72 0.165 30);
@@ -296,6 +307,49 @@
     box-shadow:
       0 1px 2px oklch(0 0 0 / 0.04),
       0 8px 24px -8px oklch(0 0 0 / 0.12);
+  }
+
+  /*
+   * The coachmark ring: a gradient that travels around the highlighted element.
+   *
+   * Drawn as a gradient-filled box with its own centre masked out, rather than
+   * as a border, because a border cannot carry a gradient that moves. The two
+   * masks composite to "paint the padding, punch out the content box", which
+   * leaves a 2px ring with a fully transparent middle so the element underneath
+   * is never tinted.
+   *
+   * At 50% opacity it marks without obscuring. A solid ring at full strength
+   * competes with the thing it is pointing at, which on this product is
+   * frequently a red flag.
+   */
+  .tour-ring {
+    opacity: 0.5;
+    padding: 2px;
+    background-image: linear-gradient(
+      105deg,
+      var(--color-tour-ring) 0%,
+      var(--color-tour-ring-lit) 25%,
+      var(--color-tour-ring) 50%,
+      var(--color-tour-ring-lit) 75%,
+      var(--color-tour-ring) 100%
+    );
+    background-size: 300% 100%;
+    animation: tour-ring-travel 6s linear infinite;
+    /* Prefix FIRST, standard LAST, for the same minifier reason as `.glass`. */
+    -webkit-mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+  }
+
+  @keyframes tour-ring-travel {
+    to {
+      background-position: -300% 0;
+    }
   }
 
   /* The one scrim. A single fixed layer carries the blur for the whole app;
@@ -476,6 +530,31 @@
 
     :root:not([data-motion='full']) .scrim {
       transition-property: opacity;
+    }
+
+    /*
+     * The coachmark ring keeps travelling, and this exemption is deliberate.
+     *
+     * The blanket rule above collapses every animation to 0.01ms, which is
+     * correct for decoration and wrong here: the travelling gradient is how the
+     * ring reads as the tour's pointer rather than as part of the highlighted
+     * component's own styling. Killing it does not reduce motion, it removes
+     * the affordance. Windows users who switch animations off for performance,
+     * which is the common reason, would silently get a worse tour than everyone
+     * else and no way to tell.
+     *
+     * Safe to exempt on the merits rather than merely convenient: WCAG 2.3.3
+     * targets motion that moves content or the viewport, and a colour stop
+     * sliding along a 2px ring at 50% opacity over six seconds moves neither.
+     * Nothing changes position, nothing parallaxes, nothing flashes.
+     *
+     * The explicit in-app setting below is still honoured. An OS-level flag is
+     * a broad hint; `data-motion="reduced"` is somebody choosing, in this
+     * product, and that choice wins over this exemption.
+     */
+    :root:not([data-motion='full']):not([data-motion='reduced']) .tour-ring {
+      animation-duration: 6s !important;
+      animation-iteration-count: infinite !important;
     }
   }
 

--- a/frontend/src/routes/ConsultationReview.tsx
+++ b/frontend/src/routes/ConsultationReview.tsx
@@ -301,8 +301,18 @@ export function ConsultationReview() {
 
             <Panel title="Suggestions" count={analysis.suggestions.length}>
               {analysis.suggestions.length === 0 ? (
+                /* Three readings, not two, because the system distinguishes
+                   them and the reader deserves the same distinction. Absence is
+                   its own case: consultations analysed before `outOfScope`
+                   shipped have no value, and reading that as `false` would
+                   assert the corpus was consulted when nobody knows. */
                 <p className="text-sm text-ink-muted">
-                  No cited suggestions. This may be outside the guideline corpus&rsquo;s scope.
+                  {analysis.outOfScope === true &&
+                    'Outside the guideline corpus’s scope, so no suggestions were offered.'}
+                  {analysis.outOfScope === false &&
+                    'Within the guideline corpus’s scope, with nothing to suggest for this consultation.'}
+                  {analysis.outOfScope === undefined &&
+                    'No cited suggestions. This consultation was analysed before scope was recorded, so whether the corpus applied is not known.'}
                 </p>
               ) : (
                 analysis.suggestions.map((suggestion) => (

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -316,6 +316,23 @@ export const ConsultationAnalysisSchema = z.object({
    */
   clinicalFacts: ClinicalFactsSchema.optional(),
   operational: OperationalBlockSchema.optional(),
+  /**
+   * Whether the consultation fell outside the guideline corpus, carried through
+   * to the reader rather than stopping at the pipeline.
+   *
+   * The model already produces this and `makeSuggestionsAndRedFlagsSchema`
+   * documents why it exists: an empty `suggestions` array conflates "out of
+   * scope, suggestions suppressed" with "in scope, nothing to suggest"
+   * (docs/trd.md §19 row 7). That reasoning only pays off if the distinction
+   * survives to the UI, and until now it was dropped when the analysis was
+   * assembled, leaving the review screen to hedge with "this **may be** outside
+   * the corpus's scope" about something the system already knew.
+   *
+   * Optional because consultations analysed before this shipped have no value
+   * persisted. Absence means "not recorded by this version" and must keep the
+   * old hedge, never be read as `false`.
+   */
+  outOfScope: z.boolean().optional(),
 })
 
 // ─── Consultation lifecycle ──────────────────────────────────────────────────


### PR DESCRIPTION
Four fixes from Adam testing the walkthrough on production, plus the scope signal the review screen was hedging about.

## 1. The Help Button Was Not in the Corner

A single 7rem offset cleared the mobile dock **and** the review screen's approve bar on every route, including the majority with no bottom chrome at all.

It now takes the corner and lifts only where something is genuinely beneath it. Both offsets measured rather than guessed: the mobile dock reaches ~4.5rem, the sticky approve bar ~5rem, so `bottom-24` (6rem) clears both and everywhere else gets `bottom-6`.

## 2. Starting the Tour Blocked for ~50 Seconds

Running the real pipeline is the point; waiting for it behind a modal reads as broken rather than thorough.

The tour now **opens immediately and the analysis catches up**. The first two stops (list, intake) do not touch the analysis, so there is nothing to wait for until the third, and by the time a viewer has read those the call has usually landed. A stop that does need it waits *at that stop*, with the product on screen, and Next reads `Analysing` rather than simply stalling.

Structurally this required `resolveStepRoute` to become a pure function taking the analysis explicitly. A step that resumes after awaiting cannot read it from a closure captured at render time, which would still hold the `null` it started with.

## 3. Glass Card, Travelling Ring at Half Opacity

The card lets the screen it describes show through, so the tour reads as an overlay on the product. The ring drops to 50% opacity, because a solid ring competes with what it points at, and here that is frequently a red flag.

**The ring keeps animating under `prefers-reduced-motion`, deliberately and narrowly.** The blanket rule in `index.css` collapses every animation to `0.01ms`, which is right for decoration and wrong here: the travelling gradient is how the ring reads as the tour's pointer rather than as the highlighted component's own styling, and switching Windows animations off is commonly a performance choice.

Defensible on the merits, not merely convenient: WCAG 2.3.3 targets motion that moves content or the viewport, and a colour stop sliding along a 2px ring at 50% opacity over six seconds moves neither. **The explicit in-app `data-motion="reduced"` setting still wins over the exemption** — an OS flag is a broad hint, an in-product toggle is somebody choosing.

## 4. Finishing Lands on Intake

The tour ended on the guideline corpus, a reference page and a dead end. Leaving early through End or Escape still does **not** redirect, because that is someone getting out rather than arriving.

## Plus: `outOfScope` Now Reaches the Reader

Reported as a one-line copy fix. It is not — **the value never reached the frontend at all.**

The model produces it, `makeSuggestionsAndRedFlagsSchema` documents why it exists (an empty `suggestions` array conflates "out of scope, suppressed" with "in scope, nothing to suggest", TRD §19 row 7), and `runAnalysis` then dropped it when assembling the analysis. So the review screen hedged that something "may be" outside the corpus that the system had already determined.

Three readings now, not two. Optional on the schema, so consultations analysed before this keep the hedge rather than being silently read as in scope.

## Verification

Browser-driven under `prefers-reduced-motion: reduce`, which is Adam's reported environment:

```
mode: prefers-reduced-motion REDUCE (Windows animations off)
1. FAB corner gap: bottom=24px right=24px
2. tour visible after 0.0s  (was about 50s)
3. ring: {"opacity":"0.5","animationName":"tour-ring-travel","duration":"6s",
          "iterations":"infinite","hasGradient":true}
   gradient=yes opacity=0.5 moving=YES
4. card: backdrop=blur(20px) saturate(1.5)
5. reached final step, button reads "Finish"
6. after Finish, landed on /consultations/new
   step bar gone: yes
7. console errors: none
```

Gates: typecheck clean, biome clean, 387 tests passing.

## Clinical-Safety Checklist

- [x] No new egress path. No change to de-identification, `LLMClient`, or any provider call.
- [x] No deterministic red-flag hit suppressed, downgraded or filtered.
- [x] Citations stay ID-constrained. `outOfScope` is a scope signal, not a citation, and no citation handling changed.
- [x] Nothing presented as a diagnosis; approval remains an explicit doctor action.
- [x] No transcript bodies, note contents or vault entries logged.
- [x] No clinical content in web storage. The tour's analysis stays in React state and is dropped on exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The guided tour now starts analysis immediately and keeps users informed while results are prepared.
  * Tour navigation shows progress feedback and supports animated highlighting with theme-aware styling.
  * Completing the tour now takes users directly to the intake screen.

* **Improvements**
  * Suggestions clearly indicate whether guidance is out of scope, unavailable, or not yet determined.
  * Help controls reposition appropriately on consultation review screens and mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->