### PR TITLE
docs: disclose the ASR model-weights CDN fetch on the on-device path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,8 @@ The claim stops there rather than going one word further, because on modest clin
 
 That last clause is the load-bearing one. Silently switching to hosted transcription because a device is slow would be a privacy control that fails **open** under load — degrading exactly when the doctor is least able to notice — so it is written down as rejected rather than left to an implementer's judgement. The hosted adapter is specified and audited but **not built**. See `docs/trd.md` §20.
 
+**One request does leave the browser on the on-device path, and it is named here rather than left to be discovered.** The speech model's weights are fetched from a public CDN the first time they are needed, then cached. It is a download of public model weights, not an upload: no audio, no transcript and no identifier is part of it, because the request happens before any of them exist. The CDN sees the clinic's IP address and which model was asked for, and nothing else. Nothing that data-residency rules attach to leaves the country on that path, because no patient data is in the request. If a deployment requires that no third-party endpoint be contacted at all, the weights can be served from the application's own origin instead, at the cost of hosting the model as a static asset. Who observes what is set out in full in `docs/trd.md` §20.
+
 ### The Provider Is A Swappable Adapter
 
 All three supported providers speak the OpenAI-compatible protocol and are selected by `LLM_PROVIDER`. This is a deliberate architectural commitment: it is what makes "what happens when data residency requirements change" answerable with a configuration change rather than a rewrite.

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -1108,6 +1108,24 @@ On the `asr_hosted` path, that sentence stops being true, and the documentation 
 
 In both cases the resulting `Transcript` is submitted through the existing `POST /api/consultations` contract (§13). No new backend route is required; the only shared-schema change is `Transcript.source` (§3).
 
+#### The One Network Call The Local Path Does Make
+
+The claim above is about **patient data**, and stated without this it reads as broader than it is. On the `asr_local` path one request does leave the browser, and a reviewer watching the network tab will see it: the model weights are fetched from the Hugging Face CDN on first use (see Delivery, below). Naming it here rather than only in a delivery table is deliberate, because the section a reviewer checks for egress claims should be the section that discloses the egress.
+
+**The direction is what makes it safe, not a policy.** It is a download of public model weights, not an upload. No audio, no transcript, no identifier, and no consultation content is part of that request, because it happens before any of them exist.
+
+| Party            | What it observes                                                       |
+| ---------------- | ---------------------------------------------------------------------- |
+| Hugging Face CDN | The clinician device's IP address, which model was requested, and when |
+| Hugging Face CDN | **No** patient data of any kind, and no transcript                     |
+
+Two things follow that are worth stating plainly rather than leaving a reviewer to infer:
+
+- **Nothing that PDPA cross-border transfer rules attach to leaves the country on this path**, because no personal data of a patient is in the request. The clinician's IP is visible to a non-Malaysian CDN, which is a fact about the clinic's own network rather than a patient data transfer, and it is the same exposure as loading any third-party asset.
+- **It is removable.** Serving the weights from the application's own origin instead of the CDN eliminates the third-party request entirely, at the cost of hosting roughly 240 MB of static assets. That is a deployment decision rather than an architectural one, and it is the answer if a customer requires that no third-party endpoint be contacted at all. It also interacts with the COOP/COEP constraint noted below, which pulls in the same direction.
+
+Neither point is hypothetical for the reader: `asr_local` is **not built** (no `@huggingface/transformers` dependency is present in `frontend/`), so this describes the contract the implementation must hold to, not behaviour shipping today.
+
 ### Deciding Whether To Offer Audio — The Two-Stage Capability Probe
 
 The probe's job is to decide **whether to offer audio on this device at all** — not to silently pick a mode. Mode selection is the doctor's (see the governing rule); capability is a fact about the machine.


### PR DESCRIPTION
## What Changed

`docs/trd.md` §20 and the README's "Audio Stays On The Device By Default" now disclose that the on-device ASR path fetches model weights from a public CDN, and set out exactly what each party observes.

## Why

Data residency is a scored part of the brief, and the gap was in the worst possible place.

§20's "What Crosses The Network" states the local path is **"the one point in the system where 'never leaves the device' is literally true rather than a control being relied upon"**. The CDN fetch was recorded only in a delivery table further down and in a COOP/COEP aside. So the section a reviewer reads for egress claims was the one section that did not disclose the egress.

A reviewer watching the network tab sees a request to a third-party CDN, reads a doc saying nothing crosses the network, and has to guess which is wrong. That is a self-inflicted wound on the exact dimension being scored.

## What The Docs Now Say

- **The direction is the control.** It is a download of public model weights, not an upload. No audio, transcript, or identifier is in the request, because it happens before any of them exist.
- **What the CDN observes**, as a table: the clinic's IP address, which model was requested, and when. No patient data of any kind.
- **The residency conclusion, stated rather than implied.** Nothing PDPA cross-border transfer rules attach to leaves the country on this path, because no patient personal data is in the request. The clinician's IP being visible to a non-Malaysian CDN is disclosed as the same exposure as loading any third-party asset, rather than glossed.
- **It is removable.** Serving the weights from the app's own origin eliminates the third-party request entirely, at the cost of hosting ~240 MB of static assets. A deployment decision, not an architectural one, and the answer if a customer requires no third-party endpoint be contacted. It also pulls the same way as the existing COOP/COEP constraint.

## Honesty About Status

Marked in both documents as the contract the implementation must hold to, **not** shipped behaviour. `asr_local` is not built and there is no `@huggingface/transformers` dependency in `frontend/`.

## Verification

- [x] Claims checked against the code: no ASR implementation and no transformers dependency exist
- [x] README/TRD split respected — README carries the narrative a reviewer needs, TRD carries the per-party disclosure table

## Notes For The Reviewer

Clinical-Safety section deleted: documentation only, no source paths touched.

Raised by @AlaskanTuna as the highest-value open item for an external evaluator, and it was right: the architecture was already sound here, only the disclosure was missing.

Docs-only, so the deploy filter skips this and it costs no Vercel slot.