### PR TITLE
feat(analysis): surface evidence links, and time the fixture corpus

### DIFF
--- a/backend/src/fixtures/corpus.ts
+++ b/backend/src/fixtures/corpus.ts
@@ -26,32 +26,41 @@ export const FIXTURES: readonly Fixture[] = [
     transcript: {
       source: 'fixture',
       turns: [
-        { speaker: 'doctor', text: 'Morning, what brings you in today?' },
+        { speaker: 'doctor', text: 'Morning, what brings you in today?', offsetSeconds: 0.0 },
         {
           speaker: 'patient',
           text: "Doctor, I'm Kamal. Batuk sudah 3 hari lah, and my throat also quite sakit.",
+          offsetSeconds: 3.6,
         },
-        { speaker: 'doctor', text: 'Any fever?' },
+        { speaker: 'doctor', text: 'Any fever?', offsetSeconds: 10.2 },
         {
           speaker: 'patient',
           text: 'Yesterday quite hot, I check at home, 38.2 degrees. Today okay already.',
+          offsetSeconds: 12.2,
         },
-        { speaker: 'doctor', text: 'Any phlegm when you cough?' },
-        { speaker: 'patient', text: 'A bit, whitish colour, not much.' },
+        { speaker: 'doctor', text: 'Any phlegm when you cough?', offsetSeconds: 18.0 },
+        { speaker: 'patient', text: 'A bit, whitish colour, not much.', offsetSeconds: 21.1 },
         {
           speaker: 'doctor',
           text: 'Let me check your throat... okay, throat is red, tonsils a bit swollen.',
+          offsetSeconds: 24.3,
         },
         {
           speaker: 'doctor',
           text: "This looks viral currently. I'll dispense some medicine for you.",
+          offsetSeconds: 32.1,
         },
-        { speaker: 'patient', text: 'Can I get MC, doctor? Need to rest lah.' },
+        {
+          speaker: 'patient',
+          text: 'Can I get MC, doctor? Need to rest lah.',
+          offsetSeconds: 37.0,
+        },
         {
           speaker: 'doctor',
           text: "I'll give you 2 days MC. Take the medicine three times a day after food.",
+          offsetSeconds: 41.5,
         },
-        { speaker: 'patient', text: 'Okay doctor, thank you.' },
+        { speaker: 'patient', text: 'Okay doctor, thank you.', offsetSeconds: 48.5 },
       ],
     },
   },
@@ -69,30 +78,46 @@ export const FIXTURES: readonly Fixture[] = [
     transcript: {
       source: 'fixture',
       turns: [
-        { speaker: 'doctor', text: "Hi, what's your name, and what's wrong today?" },
+        {
+          speaker: 'doctor',
+          text: "Hi, what's your name, and what's wrong today?",
+          offsetSeconds: 0.0,
+        },
         {
           speaker: 'patient',
           text:
             "I'm Puan Salmah binti Yusof, doctor. My throat pain very bad since last night, " +
             'I cannot swallow anything now, even my own saliva I am drooling out.',
+          offsetSeconds: 4.7,
         },
-        { speaker: 'doctor', text: 'I see you are drooling. Any trouble breathing?' },
+        {
+          speaker: 'doctor',
+          text: 'I see you are drooling. Any trouble breathing?',
+          offsetSeconds: 17.0,
+        },
         {
           speaker: 'patient',
           text:
             "Yes, breathing feels very tight, and there's a noisy high-pitched sound when I " +
             'breathe in, especially when I lie down.',
+          offsetSeconds: 21.6,
         },
         {
           speaker: 'doctor',
           text: 'I can hear that stridor now when you breathe in. How long has this been going on?',
+          offsetSeconds: 31.1,
         },
-        { speaker: 'patient', text: 'Maybe 12 hours, getting worse and worse.' },
+        {
+          speaker: 'patient',
+          text: 'Maybe 12 hours, getting worse and worse.',
+          offsetSeconds: 39.5,
+        },
         {
           speaker: 'doctor',
           text:
             'Puan Salmah, this is serious — I need to refer you to the hospital emergency ' +
             'department right away, cannot manage this here.',
+          offsetSeconds: 43.3,
         },
       ],
     },
@@ -110,27 +135,35 @@ export const FIXTURES: readonly Fixture[] = [
     transcript: {
       source: 'fixture',
       turns: [
-        { speaker: 'doctor', text: "What's the problem today?" },
+        { speaker: 'doctor', text: "What's the problem today?", offsetSeconds: 0.0 },
         {
           speaker: 'patient',
           text: 'Batuk sudah 4 hari, throat also a bit sakit lah, but fever already gone since yesterday.',
+          offsetSeconds: 2.9,
         },
         {
           speaker: 'doctor',
           text: 'Let me check your throat and chest... throat looks a bit red, chest sounds clear.',
+          offsetSeconds: 10.4,
         },
         {
           speaker: 'doctor',
           text:
             "Okay, I'll dispense Paracetamol for the throat discomfort, and a cough syrup, " +
             'take three times a day.',
+          offsetSeconds: 19.4,
         },
-        { speaker: 'patient', text: 'Can I get MC, doctor? I still feel weak.' },
+        {
+          speaker: 'patient',
+          text: 'Can I get MC, doctor? I still feel weak.',
+          offsetSeconds: 27.3,
+        },
         {
           speaker: 'doctor',
           text: "Sure, I'll give you 2 days MC. Come back if it doesn't improve or gets worse.",
+          offsetSeconds: 32.0,
         },
-        { speaker: 'patient', text: 'Okay doctor, thank you very much.' },
+        { speaker: 'patient', text: 'Okay doctor, thank you very much.', offsetSeconds: 39.5 },
       ],
     },
   },
@@ -148,37 +181,42 @@ export const FIXTURES: readonly Fixture[] = [
     transcript: {
       source: 'fixture',
       turns: [
-        { speaker: 'doctor', text: "What's bringing you in today?" },
+        { speaker: 'doctor', text: "What's bringing you in today?", offsetSeconds: 0.0 },
         {
           speaker: 'patient',
           text:
             "Erm, my cough... actually I'm not sure how long already. Maybe two weeks? Or " +
             'was it before Raya... I lost count already lah.',
+          offsetSeconds: 3.4,
         },
-        { speaker: 'doctor', text: 'Is the cough productive, any phlegm?' },
+        { speaker: 'doctor', text: 'Is the cough productive, any phlegm?', offsetSeconds: 15.5 },
         {
           speaker: 'patient',
           text: 'Sometimes yes sometimes no, depends on the day I think. This morning got a bit, now nothing.',
+          offsetSeconds: 19.3,
         },
-        { speaker: 'doctor', text: 'Any fever?' },
+        { speaker: 'doctor', text: 'Any fever?', offsetSeconds: 27.3 },
         {
           speaker: 'patient',
           text:
             'I feel warm sometimes at night but I never check with thermometer. My wife also ' +
             'not sure, she said maybe I was just flushed only.',
+          offsetSeconds: 29.6,
         },
-        { speaker: 'doctor', text: 'Any chest pain or breathlessness?' },
+        { speaker: 'doctor', text: 'Any chest pain or breathlessness?', offsetSeconds: 41.0 },
         {
           speaker: 'patient',
           text:
             "Hard to say doctor. When I climb stairs I get a bit puffed, but I'm also not " +
             "exercising much nowadays, so maybe that's just unfit already.",
+          offsetSeconds: 44.4,
         },
         {
           speaker: 'doctor',
           text:
             'Let me examine you... chest sounds are hard to interpret clearly, some ' +
             'transmitted upper airway noise.',
+          offsetSeconds: 56.5,
         },
         {
           speaker: 'doctor',
@@ -186,6 +224,7 @@ export const FIXTURES: readonly Fixture[] = [
             "I'm not entirely sure what's going on here, the story is not very clear. Let's " +
             'start with something symptomatic first, and I want to see you again in a few ' +
             "days if it doesn't settle.",
+          offsetSeconds: 65.8,
         },
       ],
     },
@@ -209,57 +248,84 @@ export const FIXTURES: readonly Fixture[] = [
         {
           speaker: 'doctor',
           text: 'Morning Encik Ahmad bin Ismail, please have a seat. Can I confirm your IC number for the file?',
+          offsetSeconds: 0.0,
         },
-        { speaker: 'patient', text: 'Yes doctor, my NRIC is 850523-14-5677.' },
+        { speaker: 'patient', text: 'Yes doctor, my NRIC is 850523-14-5677.', offsetSeconds: 8.8 },
         {
           speaker: 'doctor',
           text: 'And your date of birth, just to double check — 23 May 1985?',
+          offsetSeconds: 11.9,
         },
-        { speaker: 'patient', text: 'Yes correct doctor.' },
-        { speaker: 'doctor', text: 'And your contact number is still 012-3456789?' },
+        { speaker: 'patient', text: 'Yes correct doctor.', offsetSeconds: 18.5 },
+        {
+          speaker: 'doctor',
+          text: 'And your contact number is still 012-3456789?',
+          offsetSeconds: 20.4,
+        },
         {
           speaker: 'patient',
           text:
             'Yes, same number. My address also same — No. 12, Jalan Meranti 5, Taman Desa ' +
             'Aman, 43000 Kajang, Selangor.',
+          offsetSeconds: 24.6,
         },
         {
           speaker: 'doctor',
           text: 'And email for your invoice, is it ahmad.ismail85@example.com?',
+          offsetSeconds: 33.4,
         },
-        { speaker: 'patient', text: "Yes doctor, that's correct." },
-        { speaker: 'doctor', text: 'Alright Encik Ahmad, what brings you in today?' },
+        { speaker: 'patient', text: "Yes doctor, that's correct.", offsetSeconds: 37.9 },
+        {
+          speaker: 'doctor',
+          text: 'Alright Encik Ahmad, what brings you in today?',
+          offsetSeconds: 40.2,
+        },
         {
           speaker: 'patient',
           text:
             'Doctor, batuk and sore throat since 2 days ago. Fever also, quite high last ' +
             'night, 38.9 degrees. No phlegm, just dry cough.',
+          offsetSeconds: 44.8,
         },
         {
           speaker: 'doctor',
           text: 'Any chest pain, difficulty breathing, or coughing up blood?',
+          offsetSeconds: 55.0,
         },
         {
           speaker: 'patient',
           text: 'No, none of that. Breathing is fine, no pain in the chest.',
+          offsetSeconds: 59.8,
         },
-        { speaker: 'doctor', text: 'Any nausea, vomiting, or difficulty swallowing?' },
+        {
+          speaker: 'doctor',
+          text: 'Any nausea, vomiting, or difficulty swallowing?',
+          offsetSeconds: 65.6,
+        },
         {
           speaker: 'patient',
           text: 'No doctor, can eat and drink as normal, just a bit painful to swallow when very dry.',
+          offsetSeconds: 69.4,
         },
         {
           speaker: 'doctor',
           text: 'Any history of asthma, heart disease, or are you on any regular medication?',
+          offsetSeconds: 77.3,
         },
         {
           speaker: 'patient',
           text: "No asthma or heart problem. I'm not on any medication, no known drug allergy also.",
+          offsetSeconds: 83.9,
         },
-        { speaker: 'doctor', text: 'Do you smoke? And anyone at home or work been sick lately?' },
+        {
+          speaker: 'doctor',
+          text: 'Do you smoke? And anyone at home or work been sick lately?',
+          offsetSeconds: 91.0,
+        },
         {
           speaker: 'patient',
           text: "No doctor, I don't smoke. My colleague at office also had a cough last week though.",
+          offsetSeconds: 97.4,
         },
         {
           speaker: 'doctor',
@@ -268,6 +334,7 @@ export const FIXTURES: readonly Fixture[] = [
             '82, respiratory rate 16, oxygen saturation 98% on room air. Let me check your ' +
             'throat now... throat is red, tonsils mildly swollen with no exudate, neck nodes ' +
             'mildly tender on the left side. Chest is clear on auscultation.',
+          offsetSeconds: 105.2,
         },
         {
           speaker: 'doctor',
@@ -275,23 +342,27 @@ export const FIXTURES: readonly Fixture[] = [
             'This looks like a viral upper respiratory tract infection, Encik Ahmad. ' +
             "I'll dispense Paracetamol 500mg, one tablet four times a day for the fever, " +
             'and a lozenge for the throat. No antibiotics needed for now.',
+          offsetSeconds: 129.8,
         },
-        { speaker: 'patient', text: 'Okay doctor, can I get an MC?' },
+        { speaker: 'patient', text: 'Okay doctor, can I get an MC?', offsetSeconds: 145.5 },
         {
           speaker: 'doctor',
           text:
             "Yes, I'll give you 2 days MC, and please come back for review in 3 days if " +
             "you're not improving, or sooner if you develop breathing difficulty.",
+          offsetSeconds: 149.8,
         },
         {
           speaker: 'patient',
           text: 'Thank you doctor. This is for my TPA panel claim, is that okay?',
+          offsetSeconds: 162.1,
         },
         {
           speaker: 'doctor',
           text:
             "Yes, I'll note it on the invoice for PMCare. Registration number for our clinic " +
             'file is RC-2026-00842.',
+          offsetSeconds: 168.9,
         },
       ],
     },

--- a/backend/src/lib/logger.leak.test.ts
+++ b/backend/src/lib/logger.leak.test.ts
@@ -22,7 +22,12 @@ import { FIXTURES } from '../fixtures/index.js'
 const FIXTURE = FIXTURES.find((f) => f.id === 'urti-identifier-dense-routine')
 if (!FIXTURE) throw new Error('identifier-dense fixture missing')
 
-vi.mock('../analysis/index.js', () => ({
+// `importOriginal` so `buildEvidenceLinks` stays real. This test's value is
+// that it runs the actual analyse path and proves nothing from it reaches the
+// drain, so stubbing a link builder that carries verbatim transcript spans
+// would remove exactly the content it exists to chase.
+vi.mock('../analysis/index.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   analyseNote: vi.fn(async () => ({
     note: {
       subjective: '[PATIENT_1] reports cough and sore throat for two days.',
@@ -43,6 +48,13 @@ vi.mock('../analysis/index.js', () => ({
     },
     operational: {
       diagnosis: { state: 'PRESENT', value: 'URTI', evidence: '[PATIENT_1] likely has a URTI' },
+      // `OperationalBlockSchema` defaults every field, so the real `analyseNote`
+      // always returns all of them; omitting them made this a shape production
+      // never produces.
+      medicationsDispensed: [],
+      mcDays: { state: 'NOT_ASSESSED' },
+      referral: { state: 'NOT_ASSESSED' },
+      followUp: { state: 'NOT_ASSESSED' },
     },
     gaps: [
       {

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -7,7 +7,10 @@ import { ACTIVE_CLINICAL_VERSIONS } from '../clinical-versions/index.js'
  * state machine, the red-flag union and rehydration — not the model. The
  * modules themselves are covered by #3/#4/#5 and #6.
  */
-vi.mock('../analysis/index.js', () => ({
+// `importOriginal` so `buildEvidenceLinks` stays real: it is a pure mapping
+// worth exercising rather than stubbing, and a wholesale mock left it undefined.
+vi.mock('../analysis/index.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
   analyseNote: vi.fn(async () => ({
     note: {
       subjective: '[PATIENT_1] reports a cough',
@@ -37,6 +40,12 @@ vi.mock('../analysis/index.js', () => ({
         { state: 'PRESENT', value: 'paracetamol', evidence: 'giving [PATIENT_1] paracetamol' },
       ],
       mcDays: { state: 'NOT_ASSESSED' },
+      // Present because `OperationalBlockSchema` defaults every field, so the
+      // real `analyseNote` always returns all of them. Omitting them here made
+      // the stub a shape production never produces, which went unnoticed until
+      // `buildEvidenceLinks` became the first consumer to read them (#10).
+      referral: { state: 'NOT_ASSESSED' },
+      followUp: { state: 'NOT_ASSESSED' },
     },
     gaps: [
       {
@@ -657,5 +666,86 @@ describe('POST /api/consultations/analyze-ephemeral', () => {
     const res = await call('POST', '/api/consultations/analyze-ephemeral', body([]))
 
     expect(res.status).toBe(400)
+  })
+})
+
+/**
+ * Evidence links (#10). The interesting property is not that links exist, it is
+ * what happens when a span cannot be attributed to exactly one turn: the trace
+ * must decline rather than guess, because a confidently wrong provenance on a
+ * clinical record is worse than an absent one.
+ */
+describe('evidence links', () => {
+  const linksOf = async (extra: Record<string, unknown> = {}) => {
+    seed('awaiting_review', extra)
+    await call('POST', '/api/consultations/c1/analyze')
+    const analysis = store.get('c1')?.analysis as {
+      evidenceLinks: {
+        fieldId: string
+        evidence: string
+        speaker?: string
+        offsetSeconds?: number
+      }[]
+    }
+    return analysis.evidenceLinks
+  }
+
+  it('carries one link per evidenced field, rehydrated', async () => {
+    const links = await linksOf()
+
+    expect(links.map((l) => l.fieldId)).toEqual([
+      'clinicalFacts.symptoms.cough',
+      'clinicalFacts.history.smoking',
+      'operational.diagnosis',
+      'operational.medicationsDispensed[0]',
+    ])
+    expect(links.every((l) => !l.evidence.includes('[PATIENT_1]'))).toBe(true)
+    expect(links[0]?.evidence).toContain('Ahmad')
+  })
+
+  it('attributes a span to the one turn that contains it', async () => {
+    const links = await linksOf({
+      transcript: {
+        source: 'paste',
+        turns: [
+          { speaker: 'doctor', text: 'What brings you in?', offsetSeconds: 0 },
+          { speaker: 'patient', text: 'I am Ahmad and Ahmad has a dry cough', offsetSeconds: 4.2 },
+        ],
+      },
+    })
+
+    const cough = links.find((l) => l.fieldId === 'clinicalFacts.symptoms.cough')
+    expect(cough?.speaker).toBe('patient')
+    expect(cough?.offsetSeconds).toBe(4.2)
+  })
+
+  /** The property that stops the trace inventing provenance. */
+  it('declines to attribute a span that appears in more than one turn', async () => {
+    const links = await linksOf({
+      transcript: {
+        source: 'paste',
+        turns: [
+          { speaker: 'patient', text: 'I am Ahmad and Ahmad has a dry cough', offsetSeconds: 1 },
+          { speaker: 'doctor', text: 'So Ahmad has a dry cough, noted', offsetSeconds: 9 },
+        ],
+      },
+    })
+
+    const cough = links.find((l) => l.fieldId === 'clinicalFacts.symptoms.cough')
+    expect(cough?.speaker, 'ambiguous attribution must resolve to nothing').toBeUndefined()
+    expect(cough?.offsetSeconds).toBeUndefined()
+  })
+
+  it('resolves the speaker but omits the offset when a transcript carries no timings', async () => {
+    const links = await linksOf({
+      transcript: {
+        source: 'paste',
+        turns: [{ speaker: 'patient', text: 'I am Ahmad and Ahmad has a dry cough' }],
+      },
+    })
+
+    const cough = links.find((l) => l.fieldId === 'clinicalFacts.symptoms.cough')
+    expect(cough?.speaker).toBe('patient')
+    expect(cough?.offsetSeconds, 'absent timing must not become 0').toBeUndefined()
   })
 })

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -12,7 +12,7 @@ import {
 } from '@shared/types'
 import { Router } from 'express'
 import { z } from 'zod'
-import { analyseNote } from '../analysis/index.js'
+import { analyseNote, buildEvidenceLinks } from '../analysis/index.js'
 import { type AnalysisFailureReason, getAuditHistory, recordAuditEvent } from '../audit/index.js'
 import {
   type ClinicalProfile,
@@ -245,6 +245,29 @@ async function runAnalysis(
 
   const rehydrate = (value: string) => vault.rehydrate(value)
 
+  /**
+   * Attributes a span to the turn it came from, for the evidence trace (#10).
+   *
+   * Resolved by locating the rehydrated span rather than asked of the model,
+   * so a link is only ever attributed to a turn that demonstrably contains it.
+   * A span matching zero turns, or more than one, resolves to nothing: a
+   * confidently wrong attribution on a clinical record is worse than an absent
+   * one, and "which of these two turns" is not a question this can answer.
+   */
+  const attribute = (span: string) => {
+    const needle = span.replace(/\s+/g, ' ').trim().toLowerCase()
+    if (needle.length === 0) return {}
+    const hits = transcript.turns.filter((turn) =>
+      turn.text.replace(/\s+/g, ' ').toLowerCase().includes(needle),
+    )
+    const turn = hits.length === 1 ? hits[0] : undefined
+    if (turn === undefined) return {}
+    return {
+      speaker: turn.speaker,
+      ...(turn.offsetSeconds === undefined ? {} : { offsetSeconds: turn.offsetSeconds }),
+    }
+  }
+
   const analysis = {
     note: {
       subjective: rehydrate(noteResult.note.subjective),
@@ -280,6 +303,15 @@ async function runAnalysis(
     // reader whether the corpus had nothing to say or was never consulted, which
     // is the conflation this flag exists to prevent (docs/trd.md §19 row 7).
     outOfScope: suggestionResult.outOfScope,
+    // Built from the post-evidence-check facts, so every link is a span that
+    // survived §21.4 rather than one the model asserted. Checklist fields only:
+    // the note is independent prose and has no traceable provenance (#10).
+    evidenceLinks: buildEvidenceLinks(noteResult.clinicalFacts, noteResult.operational).map(
+      (link) => {
+        const evidence = rehydrate(link.evidence)
+        return { ...link, evidence, ...attribute(evidence) }
+      },
+    ),
   }
 
   return { analysis, detected, discardedFieldIds: noteResult.discardedFieldIds }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -292,6 +292,25 @@ export const ClinicalSuggestionSchema = z.object({
   citations: z.array(CitationSchema).min(1),
 })
 
+/**
+ * One established checklist field and the transcript span that evidenced it.
+ *
+ * `speaker` and `offsetSeconds` are optional and are resolved by locating the
+ * span in the transcript rather than asserted by the model. They are omitted
+ * when the span cannot be located in exactly one turn, or when the transcript
+ * carries no timings (`offsetSeconds` is itself optional on a turn, and a
+ * pasted or uploaded transcript has none). Omission means "not resolvable",
+ * never "the start of the consultation".
+ */
+export const EvidenceLinkSchema = z.object({
+  /** e.g. `clinicalFacts.symptoms.cough`, `operational.diagnosis`. */
+  fieldId: z.string(),
+  state: AssertionStateSchema,
+  evidence: z.string(),
+  speaker: SpeakerSchema.optional(),
+  offsetSeconds: z.number().nonnegative().optional(),
+})
+
 // ─── Analysis envelope ───────────────────────────────────────────────────────
 
 export const ConsultationAnalysisSchema = z.object({
@@ -316,6 +335,27 @@ export const ConsultationAnalysisSchema = z.object({
    */
   clinicalFacts: ClinicalFactsSchema.optional(),
   operational: OperationalBlockSchema.optional(),
+  /**
+   * Each established checklist field paired with the verbatim transcript span
+   * behind it, so a doctor can check what the system read rather than trusting
+   * it (GitHub issue #10, docs/trd.md §19 row 17).
+   *
+   * **These trace checklist fields, never note sentences.** The note is
+   * generated prose from a separate model call (§12) and is not composed from
+   * these facts, so no sentence in it has a provenance link and none can be
+   * recovered afterwards. Matching note text back to the transcript by
+   * similarity would manufacture provenance the system does not have, which in
+   * a clinical record is worse than showing none.
+   *
+   * Every span here already survived the evidence check (§21.4), so a link is
+   * a span that was matched against the de-identified transcript rather than
+   * one the model asserted.
+   *
+   * Optional for the same reason as `clinicalFacts`: consultations analysed
+   * before this shipped have none, and absence means "not recorded by this
+   * version", never "nothing was evidenced".
+   */
+  evidenceLinks: z.array(EvidenceLinkSchema).optional(),
   /**
    * Whether the consultation fell outside the guideline corpus, carried through
    * to the reader rather than stopping at the pipeline.


### PR DESCRIPTION
## What Changed

Toward **#10 AC7**, per Adam's call to backfill timings rather than drop timestamps from the criterion. Two halves, both backend.

**The payload shape @AlaskanTuna is building against:**

```ts
evidenceLinks?: {
  fieldId: string          // "clinicalFacts.symptoms.cough", "operational.diagnosis"
  state: AssertionState
  evidence: string         // rehydrated verbatim span
  speaker?: 'doctor' | 'patient'
  offsetSeconds?: number
}[]
```

## 1. `offsetSeconds` Across All 59 Fixture Turns

Derived from what each turn actually says, at roughly 2.3 words/second (conservative for Manglish with code-switching), plus a gap that widens after a question and before a long answer, and an extra pause on turns whose ellipsis marks an examination rather than speech.

Monotonic within each fixture, non-round by construction. A doctor's two-word question and a patient's rambling answer do not occupy the same span. These fixtures are the reference corpus an evaluator reads, so obviously synthetic timings would undercut what they exist to demonstrate.

## 2. `buildEvidenceLinks` Reaches The Payload

It has existed, exported and documented, with **zero references repo-wide** since it was written. TRD §19 row 17 scoped surfacing it out pending a decision that has now been made.

**Attribution declines rather than guesses.** Speaker and offset are resolved by locating the rehydrated span in the transcript, never asked of the model. A span matching **zero** turns, or **more than one**, resolves to neither:

> a confidently wrong provenance on a clinical record is worse than an absent one

An absent timing stays absent rather than defaulting to `0`.

## These Trace Checklist Fields, Never Note Sentences

Stated in the schema so nobody wires a sentence-level trace to it later. The note is independent prose from a separate model call (`analysis/index.ts:41-56`) and has no recoverable provenance. Full reasoning in [my comment on #10](https://github.com/AlaskanTuna/catatmd/issues/10#issuecomment-5291002205).

## Two Test Stubs Described A Shape Production Never Produces

Both `consultations.test.ts` and `logger.leak.test.ts` mocked `../analysis/index.js` wholesale and omitted `operational` fields that `OperationalBlockSchema` defaults, so `referral` and `followUp` were absent where the real `analyseNote` always returns them. It went unnoticed until `buildEvidenceLinks` became the first consumer to read them.

Both now use `importOriginal` and carry the full block. **The leak test deliberately keeps `buildEvidenceLinks` real**: stubbing a builder that carries verbatim transcript spans would remove exactly the content that test exists to chase. It passes, which is a real confirmation that the new spans do not reach the log drain.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (394 passing, 4 new)

New tests pin the properties that matter:

| Test | Property |
| --- | --- |
| carries one link per evidenced field, rehydrated | no `[PATIENT_1]` survives to the payload |
| attributes a span to the one turn that contains it | speaker and offset resolve |
| **declines to attribute a span in more than one turn** | ambiguity resolves to nothing, not a guess |
| omits the offset when a transcript has no timings | absent timing never becomes `0` |

Fixture timings independently checked as monotonic and non-negative across all 5 fixtures.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider — this reads pipeline output, no new egress
- [x] No provider SDK imported outside `backend/src/lib/llm/` — untouched
- [x] Deterministic red-flag hits remain unsuppressable — untouched
- [x] Citations remain ID-constrained — untouched
- [x] No transcript bodies, note contents, or vault entries logged — the leak test now runs this code path for real and still passes
- [x] Fixtures added are synthetic — timings added to existing synthetic fixtures, no content changed

## Notes For The Reviewer

Every span here already survived the evidence check (§21.4), so a link is a span matched against the de-identified transcript rather than one the model asserted.

`evidenceLinks` is optional for the same reason as `clinicalFacts`: consultations analysed before this have none, and absence means "not recorded by this version", never "nothing was evidenced".

Backend and shared only, so the deploy filter skips this and it costs no Vercel slot.