### PR TITLE
feat(review): let a doctor dismiss a finding, with a reason and without losing it

### DIFF
--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import type { DispositionState } from '@shared/types'
 import type { ProfileId } from '../clinical-profiles/index.js'
 import type { ActiveClinicalVersions } from '../clinical-versions/index.js'
 import { prisma } from '../lib/prisma.js'
@@ -75,6 +76,15 @@ export type ConsultationAuditEvent =
   | { action: 'consultation.erased' }
   | { action: 'redflag.acknowledged'; metadata: { redFlagId: string } }
   | { action: 'gap.reviewed'; metadata: { gapId: string } }
+  /*
+   * The three-way disposition (issue #10). `state` is recorded and the
+   * dismissal reason deliberately is not: the reason is clinician free text
+   * about a specific patient, so it is clinical content and stays on the
+   * consultation, which is the clinical record. Copying it here would put
+   * unredacted prose in the table whose purpose is to be widely readable.
+   */
+  | { action: 'redflag.disposition_set'; metadata: { redFlagId: string; state: DispositionState } }
+  | { action: 'gap.disposition_set'; metadata: { gapId: string; state: DispositionState } }
   | { action: 'consultation.approved' }
 
 /**

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -217,6 +217,8 @@ function seed(status: string, extra: Record<string, unknown> = {}) {
     approvedAt: null,
     acknowledgedRedFlagIds: null,
     reviewedGapIds: null,
+    redFlagDispositions: null,
+    gapDispositions: null,
     erasedAt: null,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -463,6 +465,111 @@ describe('state machine — patch', () => {
 
     expect(store.get('c1')?.acknowledgedRedFlagIds).toEqual(['rf-1', 'rf-2'])
     expect(audits.filter((a) => a.action === 'redflag.acknowledged')).toHaveLength(1)
+  })
+})
+
+/**
+ * Issue #10 AC4. The three-way disposition is the one review control that can
+ * set a safety signal aside, so these pin the properties that make that safe
+ * rather than merely the happy path.
+ */
+describe('finding dispositions', () => {
+  it('refuses a dismissal with no reason', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    const res = await call('PATCH', '/api/consultations/c1', {
+      redFlagDispositions: [{ id: 'rf-1', state: 'dismissed' }],
+    })
+
+    expect(res.status).toBe(400)
+    expect(store.get('c1')?.redFlagDispositions).toBeNull()
+  })
+
+  it('refuses a reason on a state that is not a dismissal', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    const res = await call('PATCH', '/api/consultations/c1', {
+      redFlagDispositions: [{ id: 'rf-1', state: 'acknowledged', reason: 'not needed here' }],
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('leaves the red flag itself untouched when one is dismissed', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+    const before = JSON.stringify(store.get('c1')?.analysis)
+
+    const res = await call('PATCH', '/api/consultations/c1', {
+      redFlagDispositions: [
+        { id: 'rf-1', state: 'dismissed', reason: 'Chronic, already worked up' },
+      ],
+    })
+
+    // The whole invariant in one assertion: a dismissal records a decision and
+    // never removes or downgrades the finding it refers to.
+    expect(res.status).toBe(200)
+    expect(JSON.stringify(store.get('c1')?.analysis)).toBe(before)
+    const detail = (await res.json()) as { consultation: { analysis: { redFlags: unknown[] } } }
+    expect(detail.consultation.analysis.redFlags).toHaveLength(ANALYSIS.redFlags.length)
+  })
+
+  it('keeps the dismissal reason out of the audit trail', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+    const reason = 'Patient has had this cough for years, chest clear on exam'
+
+    await call('PATCH', '/api/consultations/c1', {
+      redFlagDispositions: [{ id: 'rf-1', state: 'dismissed', reason }],
+    })
+
+    // A reason is clinician free text about a patient, so it is clinical
+    // content and belongs only on the consultation. The event records that a
+    // decision happened and which one, never the prose.
+    const event = audits.find((a) => a.action === 'redflag.disposition_set')
+    expect(event?.metadata).toEqual({ redFlagId: 'rf-1', state: 'dismissed' })
+    expect(JSON.stringify(audits)).not.toContain('chest clear')
+  })
+
+  it('records a reversal rather than silently overwriting it', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    await call('PATCH', '/api/consultations/c1', {
+      redFlagDispositions: [{ id: 'rf-1', state: 'acknowledged' }],
+    })
+    await call('PATCH', '/api/consultations/c1', {
+      redFlagDispositions: [{ id: 'rf-1', state: 'dismissed', reason: 'Resolved on review' }],
+    })
+
+    const stored = store.get('c1')?.redFlagDispositions as { id: string; state: string }[]
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.state).toBe('dismissed')
+    // Current state is one row; the history of getting there is the audit trail.
+    expect(audits.filter((a) => a.action === 'redflag.disposition_set')).toHaveLength(2)
+  })
+
+  it('does not re-audit a decision that changes nothing', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    await call('PATCH', '/api/consultations/c1', {
+      redFlagDispositions: [{ id: 'rf-1', state: 'acknowledged' }],
+    })
+    await call('PATCH', '/api/consultations/c1', {
+      redFlagDispositions: [{ id: 'rf-1', state: 'acknowledged' }],
+    })
+
+    expect(audits.filter((a) => a.action === 'redflag.disposition_set')).toHaveLength(1)
+  })
+
+  it('reads a pre-disposition row forward as acknowledged', async () => {
+    // Rows reviewed before #10 carry only the boolean form, and every id in it
+    // meant acknowledged. Projecting on read avoids rewriting review history.
+    seed('awaiting_review', { analysis: ANALYSIS, acknowledgedRedFlagIds: ['rf-1'] })
+
+    const res = await call('GET', '/api/consultations/c1')
+    const detail = (await res.json()) as { consultation: { redFlagDispositions: unknown } }
+
+    expect(detail.consultation.redFlagDispositions).toEqual([
+      { id: 'rf-1', state: 'acknowledged', decidedAt: expect.any(String) },
+    ])
   })
 })
 

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -1,9 +1,12 @@
-import type { Consultation } from '@prisma/client'
+import type { Consultation, Prisma } from '@prisma/client'
 import {
   type ConsultationAnalysis,
   ConsultationAnalysisSchema,
   ConsultationDetailSchema,
   ConsultationListItemSchema,
+  type Disposition,
+  type DispositionInput,
+  DispositionInputSchema,
   type InformationGap,
   type SoapNote,
   SoapNoteSchema,
@@ -44,6 +47,30 @@ function doctorId(req: { doctorId?: string }): string {
  * JSON columns are `Json?` to Prisma, so this is the only place their shape is
  * actually checked.
  */
+/**
+ * Reads dispositions, projecting a pre-#10 row forward rather than migrating it.
+ *
+ * A consultation reviewed before dispositions existed carries only a list of
+ * ids, and every id in it meant "acknowledged". Deriving that on read is
+ * lossless and leaves the stored data untouched, which is preferable to a
+ * backfill that rewrites clinical review history to fit a newer shape.
+ *
+ * `decidedAt` is unknowable for those rows. `updatedAt` is the closest honest
+ * answer: the decision happened at or before the row was last written.
+ */
+function dispositionsFor(
+  stored: Prisma.JsonValue | null,
+  legacyIds: Prisma.JsonValue | null,
+  fallbackAt: Date,
+) {
+  if (stored !== null && stored !== undefined) return stored
+  return ((legacyIds as string[] | null) ?? []).map((id) => ({
+    id,
+    state: 'acknowledged' as const,
+    decidedAt: fallbackAt,
+  }))
+}
+
 function toDetail(row: Consultation, approvedBy: string | null = null) {
   return ConsultationDetailSchema.parse({
     id: row.id,
@@ -57,6 +84,12 @@ function toDetail(row: Consultation, approvedBy: string | null = null) {
     approvedBy,
     acknowledgedRedFlagIds: row.acknowledgedRedFlagIds ?? [],
     reviewedGapIds: row.reviewedGapIds ?? [],
+    redFlagDispositions: dispositionsFor(
+      row.redFlagDispositions,
+      row.acknowledgedRedFlagIds,
+      row.updatedAt,
+    ),
+    gapDispositions: dispositionsFor(row.gapDispositions, row.reviewedGapIds, row.updatedAt),
   })
 }
 
@@ -482,8 +515,33 @@ const PatchBodySchema = z
     editedNote: SoapNoteSchema.partial().optional(),
     acknowledgedRedFlagIds: z.array(z.string()).optional(),
     reviewedGapIds: z.array(z.string()).optional(),
+    redFlagDispositions: z.array(DispositionInputSchema).optional(),
+    gapDispositions: z.array(DispositionInputSchema).optional(),
   })
   .refine((body) => Object.keys(body).length > 0, { message: 'empty patch' })
+
+/**
+ * Applies decisions onto the stored set, last decision per id winning.
+ *
+ * A doctor revising a judgement is legitimate, so this is not append-only the
+ * way `acknowledgedRedFlagIds` is. The invariant that column protects is
+ * untouched by that: the red flag itself still lives in `analysis` and is never
+ * removed or downgraded here, and every change writes an `AuditEvent`, so the
+ * history of a reversal survives even though only the current state is stored.
+ */
+function applyDispositions(
+  stored: Prisma.JsonValue | null,
+  incoming: DispositionInput[],
+  decidedAt: Date,
+) {
+  const next = new Map(
+    ((stored as Disposition[] | null) ?? []).map((entry) => [entry.id, entry] as const),
+  )
+  for (const decision of incoming) {
+    next.set(decision.id, { ...decision, decidedAt })
+  }
+  return [...next.values()]
+}
 
 consultationsRouter.patch('/:id', async (req, res) => {
   const actor = doctorId(req)
@@ -536,6 +594,30 @@ consultationsRouter.patch('/:id', async (req, res) => {
   const newFlags = (patch.acknowledgedRedFlagIds ?? []).filter((id) => !previousFlags.has(id))
   const newGaps = (patch.reviewedGapIds ?? []).filter((id) => !previousGaps.has(id))
 
+  /*
+   * A decision is only an event when it changes something. Re-sending the same
+   * state on an unrelated patch would otherwise fill the audit trail with
+   * restatements and bury the reversals, which are the entries anyone reading
+   * this back actually cares about.
+   */
+  const decidedAt = new Date()
+  const priorFlagState = new Map(
+    ((consultation.redFlagDispositions as Disposition[] | null) ?? []).map(
+      (entry) => [entry.id, entry] as const,
+    ),
+  )
+  const priorGapState = new Map(
+    ((consultation.gapDispositions as Disposition[] | null) ?? []).map(
+      (entry) => [entry.id, entry] as const,
+    ),
+  )
+  const changed = (prior: Map<string, Disposition>, decision: DispositionInput) => {
+    const before = prior.get(decision.id)
+    return before?.state !== decision.state || before?.reason !== decision.reason
+  }
+  const flagDecisions = (patch.redFlagDispositions ?? []).filter((d) => changed(priorFlagState, d))
+  const gapDecisions = (patch.gapDispositions ?? []).filter((d) => changed(priorGapState, d))
+
   const updated = await prisma.consultation.update({
     where: { id: consultation.id },
     data: {
@@ -546,6 +628,24 @@ consultationsRouter.patch('/:id', async (req, res) => {
       ...(patch.reviewedGapIds === undefined
         ? {}
         : { reviewedGapIds: [...previousGaps, ...newGaps] }),
+      ...(patch.redFlagDispositions === undefined
+        ? {}
+        : {
+            redFlagDispositions: applyDispositions(
+              consultation.redFlagDispositions,
+              patch.redFlagDispositions,
+              decidedAt,
+            ),
+          }),
+      ...(patch.gapDispositions === undefined
+        ? {}
+        : {
+            gapDispositions: applyDispositions(
+              consultation.gapDispositions,
+              patch.gapDispositions,
+              decidedAt,
+            ),
+          }),
     },
   })
 
@@ -570,6 +670,33 @@ consultationsRouter.patch('/:id', async (req, res) => {
       actorId: actor,
       consultationId: consultation.id,
       metadata: { gapId },
+    })
+  }
+
+  /*
+   * The decision is audited; the reason text is not.
+   *
+   * A dismissal reason is clinician free text about a specific patient, so it
+   * is clinical content and falls under the same rule as note bodies and
+   * transcripts: ids and event types only. It is stored once, on the
+   * consultation, which is the clinical record and the right home for it.
+   * Copying it into `AuditEvent` would put unredacted clinical prose in a
+   * second table whose whole purpose is to be widely readable for verification.
+   */
+  for (const decision of flagDecisions) {
+    await recordAuditEvent({
+      action: 'redflag.disposition_set',
+      actorId: actor,
+      consultationId: consultation.id,
+      metadata: { redFlagId: decision.id, state: decision.state },
+    })
+  }
+  for (const decision of gapDecisions) {
+    await recordAuditEvent({
+      action: 'gap.disposition_set',
+      actorId: actor,
+      consultationId: consultation.id,
+      metadata: { gapId: decision.id, state: decision.state },
     })
   }
 

--- a/frontend/src/demo/DemoTour.tsx
+++ b/frontend/src/demo/DemoTour.tsx
@@ -329,6 +329,8 @@ async function runEphemeral(): Promise<ConsultationDetail> {
     approvedBy: null,
     acknowledgedRedFlagIds: [],
     reviewedGapIds: [],
+    redFlagDispositions: [],
+    gapDispositions: [],
   }
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,7 @@ import {
   ConsultationDetailSchema,
   type ConsultationListItem,
   ConsultationListItemSchema,
+  type DispositionInput,
   ErrorEnvelopeSchema,
   type Fixture,
   FixtureSchema,
@@ -161,6 +162,8 @@ export const api = {
       editedNote?: Partial<SoapNote>
       acknowledgedRedFlagIds?: string[]
       reviewedGapIds?: string[]
+      redFlagDispositions?: DispositionInput[]
+      gapDispositions?: DispositionInput[]
     },
   ): Promise<ConsultationDetail> =>
     request(`/consultations/${id}`, ConsultationEnvelope, {

--- a/frontend/src/review/SafetyCards.tsx
+++ b/frontend/src/review/SafetyCards.tsx
@@ -1,4 +1,11 @@
-import type { ClinicalSuggestion, GuidelineChunk, InformationGap, RedFlag } from '@shared/types'
+import type {
+  ClinicalSuggestion,
+  Disposition,
+  DispositionInput,
+  GuidelineChunk,
+  InformationGap,
+  RedFlag,
+} from '@shared/types'
 import { AlertTriangle, Check, CircleAlert, HelpCircle, Info, ShieldCheck } from 'lucide-react'
 import { useState } from 'react'
 import { cn } from '../lib/cn.js'
@@ -21,16 +28,141 @@ const SEVERITY = {
   advisory: { label: 'Advisory', rule: 'bg-advisory-rule', text: 'text-advisory', Icon: Info },
 } as const
 
+const STATE_LABEL = {
+  acknowledged: 'Acknowledged, retained in the record',
+  dismissed: 'Dismissed, retained in the record',
+  not_applicable: 'Not clinically applicable, retained in the record',
+} as const
+
+/**
+ * The three-way decision on a finding (issue #10, AC4).
+ *
+ * **Every terminal label says "retained in the record", and that is the point.**
+ * A doctor dismissing an escalation trigger needs to see that they are recording
+ * a judgement rather than deleting a warning, because a control that reads like
+ * deletion invites clearing the rail to make it quiet.
+ *
+ * A reason is required to dismiss and cannot be given otherwise. Dismissing is
+ * the only one of the three that sets aside a safety signal on the doctor's own
+ * authority, so it is the one that has to be defensible later. Putting a
+ * mandatory box on the other two would train people to type "n/a" until the
+ * field means nothing.
+ *
+ * None of the three turns green. Green means approved on this screen, and a
+ * doctor should not have to hold two meanings for one colour.
+ */
+function DispositionControl({
+  findingId,
+  disposition,
+  onDecide,
+  acknowledgeLabel,
+}: {
+  findingId: string
+  disposition: Disposition | undefined
+  onDecide: (decision: DispositionInput) => void
+  acknowledgeLabel: string
+}) {
+  const [mode, setMode] = useState<'settled' | 'choosing' | 'reason'>('settled')
+  const [reason, setReason] = useState('')
+  const reasonId = `dismiss-reason-${findingId}`
+
+  if (disposition && mode === 'settled') {
+    return (
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span className="inline-flex items-center gap-1.5 text-xs font-medium text-ink-muted">
+          <Check aria-hidden className="size-3.5" />
+          {STATE_LABEL[disposition.state]}
+        </span>
+        {disposition.reason && (
+          <span className="text-xs text-ink-muted">
+            <span className="font-medium text-ink">Reason:</span> {disposition.reason}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => setMode('choosing')}
+          className="rounded-control px-1.5 py-0.5 text-xs font-medium text-accent transition-colors hover:bg-sunken"
+        >
+          Change
+        </button>
+      </div>
+    )
+  }
+
+  if (mode === 'reason') {
+    const trimmed = reason.trim()
+    return (
+      <div className="flex flex-col gap-2">
+        <label htmlFor={reasonId} className="text-xs font-medium text-ink">
+          Why are you dismissing this?
+        </label>
+        <textarea
+          id={reasonId}
+          value={reason}
+          onChange={(event) => setReason(event.target.value)}
+          rows={2}
+          maxLength={500}
+          className="w-full rounded-control border border-line bg-surface p-2 text-sm text-ink outline-none focus-visible:border-accent"
+        />
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            disabled={trimmed.length === 0}
+            onClick={() => {
+              onDecide({ id: findingId, state: 'dismissed', reason: trimmed })
+              setMode('settled')
+              setReason('')
+            }}
+          >
+            Confirm Dismissal
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setMode('settled')}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        size="sm"
+        onClick={() => {
+          onDecide({ id: findingId, state: 'acknowledged' })
+          setMode('settled')
+        }}
+      >
+        {acknowledgeLabel}
+      </Button>
+      <Button size="sm" variant="ghost" onClick={() => setMode('reason')}>
+        Dismiss
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => {
+          onDecide({ id: findingId, state: 'not_applicable' })
+          setMode('settled')
+        }}
+      >
+        Not Applicable
+      </Button>
+    </div>
+  )
+}
+
 export function RedFlagCard({
   flag,
-  acknowledged,
-  onAcknowledge,
+  disposition,
+  onDecide,
 }: {
   flag: RedFlag
-  acknowledged: boolean
-  onAcknowledge: () => void
+  disposition: Disposition | undefined
+  onDecide: (decision: DispositionInput) => void
 }) {
   const severity = SEVERITY[flag.severity]
+  const acknowledged = disposition !== undefined
 
   return (
     <Card className="overflow-hidden" data-tour={`flag-${flag.severity}`}>
@@ -63,21 +195,13 @@ export function RedFlagCard({
           </div>
         </div>
 
-        <div className="mt-3 flex items-center gap-2">
-          {acknowledged ? (
-            /* Acknowledged, never deleted. Issue #10: a dismissed flag is
-               retained with its resolution state, and stays in the printed
-               document. It also never turns green, because green means
-               approved and a doctor should not scan for two meanings. */
-            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-ink-muted">
-              <Check aria-hidden className="size-3.5" />
-              Acknowledged, retained in the record
-            </span>
-          ) : (
-            <Button size="sm" onClick={onAcknowledge}>
-              Acknowledge
-            </Button>
-          )}
+        <div className="mt-3">
+          <DispositionControl
+            findingId={flag.id}
+            disposition={disposition}
+            onDecide={onDecide}
+            acknowledgeLabel="Acknowledge"
+          />
         </div>
       </div>
     </Card>
@@ -113,13 +237,14 @@ const GAP_PRIORITY = {
 
 export function GapCard({
   gap,
-  reviewed,
-  onReview,
+  disposition,
+  onDecide,
 }: {
   gap: InformationGap
-  reviewed: boolean
-  onReview: () => void
+  disposition: Disposition | undefined
+  onDecide: (decision: DispositionInput) => void
 }) {
+  const reviewed = disposition !== undefined
   return (
     /* Gaps are not severity. A gap is a prompt to ask something, not a
        warning, so it renders as a dotted-outline card in muted ink rather
@@ -142,16 +267,12 @@ export function GapCard({
         </div>
       </div>
       <div className="mt-3">
-        {reviewed ? (
-          <span className="inline-flex items-center gap-1.5 text-xs font-medium text-ink-muted">
-            <Check aria-hidden className="size-3.5" />
-            Reviewed
-          </span>
-        ) : (
-          <Button size="sm" variant="ghost" onClick={onReview}>
-            Mark Reviewed
-          </Button>
-        )}
+        <DispositionControl
+          findingId={gap.id}
+          disposition={disposition}
+          onDecide={onDecide}
+          acknowledgeLabel="Mark Reviewed"
+        />
       </div>
     </div>
   )

--- a/frontend/src/routes/ConsultationReview.tsx
+++ b/frontend/src/routes/ConsultationReview.tsx
@@ -1,4 +1,10 @@
-import type { ClinicalAssertion, ConsultationDetail, SoapNote } from '@shared/types'
+import type {
+  ClinicalAssertion,
+  ConsultationDetail,
+  Disposition,
+  DispositionInput,
+  SoapNote,
+} from '@shared/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Printer, Sparkles } from 'lucide-react'
 import { useState } from 'react'
@@ -13,6 +19,25 @@ import { GapCard, RedFlagCard, SuggestionCard } from '../review/SafetyCards.js'
 import { Button } from '../ui/Button.js'
 import { Card, Skeleton } from '../ui/Card.js'
 import { PageHeader } from '../ui/PageHeader.js'
+
+/** The current decision about a finding, or `undefined` if none was made. */
+function byId(dispositions: Disposition[], id: string): Disposition | undefined {
+  return dispositions.find((entry) => entry.id === id)
+}
+
+/**
+ * Applies a decision in memory, matching what the API does on a stored row.
+ *
+ * The tour's consultation has no id to PATCH, so every control on this screen
+ * would 404 mid-demo without this. Last decision per id wins, exactly as
+ * `applyDispositions` does on the server, so the demo cannot drift from the
+ * behaviour it is demonstrating.
+ */
+function mergeDispositions(current: Disposition[], incoming: DispositionInput[]): Disposition[] {
+  const next = new Map(current.map((entry) => [entry.id, entry] as const))
+  for (const decision of incoming) next.set(decision.id, { ...decision, decidedAt: new Date() })
+  return [...next.values()]
+}
 
 const SEVERITY_ORDER = { emergency: 0, urgent: 1, advisory: 2 } as const
 
@@ -66,6 +91,17 @@ export function ConsultationReview() {
           ? { acknowledgedRedFlagIds: body.acknowledgedRedFlagIds }
           : {}),
         ...(body.reviewedGapIds ? { reviewedGapIds: body.reviewedGapIds } : {}),
+        ...(body.redFlagDispositions
+          ? {
+              redFlagDispositions: mergeDispositions(
+                current.redFlagDispositions,
+                body.redFlagDispositions,
+              ),
+            }
+          : {}),
+        ...(body.gapDispositions
+          ? { gapDispositions: mergeDispositions(current.gapDispositions, body.gapDispositions) }
+          : {}),
         updatedAt: new Date(),
       } as ConsultationDetail
     },
@@ -97,7 +133,10 @@ export function ConsultationReview() {
   const flags = [...(analysis?.redFlags ?? [])].sort(
     (a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity],
   )
-  const unacknowledged = flags.filter((f) => !detail.acknowledgedRedFlagIds.includes(f.id))
+  // A flag counts as handled once any decision has been recorded about it,
+  // whichever of the three it was. The approve bar surfaces the count of
+  // undecided flags, not of un-acknowledged ones.
+  const unacknowledged = flags.filter((f) => byId(detail.redFlagDispositions, f.id) === undefined)
 
   // Transcript turns carry no id in the shared contract, and position *is*
   // their identity: the list is immutable for a given consultation and is
@@ -251,12 +290,8 @@ export function ConsultationReview() {
                   <RedFlagCard
                     key={flag.id}
                     flag={flag}
-                    acknowledged={detail.acknowledgedRedFlagIds.includes(flag.id)}
-                    onAcknowledge={() =>
-                      patch.mutate({
-                        acknowledgedRedFlagIds: [...detail.acknowledgedRedFlagIds, flag.id],
-                      })
-                    }
+                    disposition={byId(detail.redFlagDispositions, flag.id)}
+                    onDecide={(decision) => patch.mutate({ redFlagDispositions: [decision] })}
                   />
                 ))
               )}
@@ -279,10 +314,8 @@ export function ConsultationReview() {
                 >
                   <GapCard
                     gap={gap}
-                    reviewed={detail.reviewedGapIds.includes(gap.id)}
-                    onReview={() =>
-                      patch.mutate({ reviewedGapIds: [...detail.reviewedGapIds, gap.id] })
-                    }
+                    disposition={byId(detail.gapDispositions, gap.id)}
+                    onDecide={(decision) => patch.mutate({ gapDispositions: [decision] })}
                   />
                 </div>
               ))}

--- a/prisma/migrations/20260814080435_add_finding_dispositions/migration.sql
+++ b/prisma/migrations/20260814080435_add_finding_dispositions/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "consultation" ADD COLUMN     "gapDispositions" JSONB,
+ADD COLUMN     "redFlagDispositions" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,9 +121,26 @@ model Consultation {
 
   /// Array of `RedFlag.id` the doctor has acknowledged. Acknowledgment is
   /// additive only — a red flag is never removed or downgraded by it.
+  ///
+  /// Superseded by `redFlagDispositions` for consultations reviewed after that
+  /// shipped, and kept because older rows carry only this form. A row with no
+  /// dispositions projects these forward as `acknowledged`, so both are read
+  /// and neither is migrated.
   acknowledgedRedFlagIds Json?
   /// Array of `InformationGap.id` the doctor has marked as reviewed.
   reviewedGapIds         Json?
+
+  /// The doctor's decision per red flag: acknowledged, dismissed with a reason,
+  /// or not clinically applicable (issue #10).
+  ///
+  /// A decision never alters the finding. The red flag stays in `analysis`
+  /// exactly as the rules engine produced it, which is what keeps the
+  /// never-removed-or-downgraded invariant above true even though a doctor can
+  /// now dismiss one. `AuditEvent` remains the authority for how a decision
+  /// changed over time; this column holds only the current state.
+  redFlagDispositions    Json?
+  /// The same, per `InformationGap.id`.
+  gapDispositions        Json?
 
   approvedAt DateTime?
   createdAt  DateTime  @default(now())

--- a/shared/src/index.test.ts
+++ b/shared/src/index.test.ts
@@ -290,6 +290,8 @@ describe('API envelope schemas', () => {
       approvedBy: null,
       acknowledgedRedFlagIds: [],
       reviewedGapIds: [],
+      redFlagDispositions: [],
+      gapDispositions: [],
     })
     expect(result.success).toBe(true)
   })
@@ -309,6 +311,8 @@ describe('API envelope schemas', () => {
       approvedBy: 'Dr Siti Rahman',
       acknowledgedRedFlagIds: [],
       reviewedGapIds: [],
+      redFlagDispositions: [],
+      gapDispositions: [],
     })
     expect(approved.success).toBe(true)
     if (approved.success) {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -433,6 +433,59 @@ export const ConsultationListItemSchema = ConsultationSchema.pick({
   updatedAt: true,
 })
 
+/**
+ * What a doctor decided about a red flag or a gap.
+ *
+ * Three states rather than a boolean, because "I have seen this and it is
+ * handled" and "this does not apply to this patient" are different clinical
+ * judgements and collapsing them loses the one a reviewer would want to read.
+ *
+ * **A disposition never changes the finding it refers to.** The red flag stays
+ * in `analysis` exactly as the rules engine and model produced it; this records
+ * a decision *about* it. That is what preserves the invariant on the
+ * `acknowledgedRedFlagIds` column, that a flag is never removed or downgraded,
+ * while still letting a doctor say a flag does not apply.
+ */
+export const DispositionStateSchema = z.enum(['acknowledged', 'dismissed', 'not_applicable'])
+export type DispositionState = z.infer<typeof DispositionStateSchema>
+
+/**
+ * `reason` is required on `dismissed` and forbidden elsewhere.
+ *
+ * Dismissing is the only one of the three that discards a safety signal on the
+ * doctor's own authority, so it is the one that has to be defensible later.
+ * Acknowledging and marking not-applicable are self-explanatory and a mandatory
+ * free-text box on either would train people to type "n/a" until the field
+ * means nothing.
+ */
+const DispositionShape = z.object({
+  id: z.string(),
+  state: DispositionStateSchema,
+  reason: z.string().trim().min(1).max(500).optional(),
+  decidedAt: z.coerce.date(),
+})
+
+export const DispositionSchema = DispositionShape.refine(
+  (value) =>
+    value.state === 'dismissed' ? value.reason !== undefined : value.reason === undefined,
+  {
+    message: 'A dismissal requires a reason, and only a dismissal may carry one.',
+    path: ['reason'],
+  },
+)
+export type Disposition = z.infer<typeof DispositionSchema>
+
+/** The client proposes a decision; the server stamps when it was made. */
+export const DispositionInputSchema = DispositionShape.omit({ decidedAt: true }).refine(
+  (value) =>
+    value.state === 'dismissed' ? value.reason !== undefined : value.reason === undefined,
+  {
+    message: 'A dismissal requires a reason, and only a dismissal may carry one.',
+    path: ['reason'],
+  },
+)
+export type DispositionInput = z.infer<typeof DispositionInputSchema>
+
 export const ConsultationDetailSchema = ConsultationSchema.extend({
   editedNote: SoapNoteSchema.nullable(),
   approvedAt: z.coerce.date().nullable(),
@@ -454,6 +507,16 @@ export const ConsultationDetailSchema = ConsultationSchema.extend({
   approvedBy: z.string().nullable(),
   acknowledgedRedFlagIds: z.array(z.string()),
   reviewedGapIds: z.array(z.string()),
+  /**
+   * What the doctor decided about each red flag and each gap (issue #10, AC4).
+   *
+   * Kept alongside `acknowledgedRedFlagIds` rather than replacing it, because
+   * consultations reviewed before this shipped carry only the boolean form.
+   * Those rows project forward as `acknowledged`, which is what they meant, and
+   * no data migration is needed to read them.
+   */
+  redFlagDispositions: z.array(DispositionSchema),
+  gapDispositions: z.array(DispositionSchema),
 })
 
 export const ErrorEnvelopeSchema = z.object({


### PR DESCRIPTION
Issue #10, AC4. Adam chose the three-way vocabulary with a required reason on dismissal.

## The Problem

Gaps and red flags carried one bit, acknowledged or not. That cannot express the two judgements a doctor actually makes: *"I have seen this and it is handled"* and *"this does not apply to this patient"*. Collapsing them loses the one a reviewer would most want to read.

## The Safety Property, Stated Plainly

**A disposition never changes the finding it refers to.** The red flag stays in `analysis` exactly as the rules engine produced it; this records a decision *about* it.

That is what keeps the existing invariant on `acknowledgedRedFlagIds` true — *"a red flag is never removed or downgraded"* — while still letting a doctor set one aside. Pinned by a test asserting `analysis` is byte-identical after a dismissal.

Every terminal label reads **"retained in the record"**, because a control that reads like deletion invites clearing the rail to make it quiet. None of the three turns green: green means approved on this screen, and a doctor should not hold two meanings for one colour.

## Why the Reason Rules Are Asymmetric

A reason is **required** to dismiss and **refused** on the other two.

Dismissing is the only one of the three that sets aside a safety signal on the doctor's own authority, so it is the one that has to be defensible later. A mandatory box on acknowledge or not-applicable would train people to type "n/a" until the field means nothing.

## The Reason Is Deliberately Not Audited

It is stored on the consultation and **kept out of `AuditEvent`**.

A dismissal reason is clinician free text about a specific patient, so it is clinical content under the same rule as note bodies and transcripts: ids and event types only. The event records that a decision happened and which one, never the prose. Copying it would put unredacted clinical text in the table whose whole purpose is to be widely readable for verification.

## Reversals

A doctor revising a judgement is legitimate, so this is not append-only the way `acknowledgedRedFlagIds` is. The row holds current state; `AuditEvent` holds how it got there. A restatement that changes nothing writes no event, so reversals stay findable instead of being buried under repeats.

## Migration

**Additive: two nullable JSONB columns, no data touched.**

Rows reviewed before this carry only the boolean form and are projected forward *on read* as `acknowledged`, which is what they meant. No backfill, so no rewriting of clinical review history to fit a newer shape. `decidedAt` is unknowable for those rows; `updatedAt` is the closest honest answer.

## Verification

Browser-driven against a seeded consultation:

```
1. gap cards on screen: 23
2. controls offered: ["Mark Reviewed","Dismiss","Not Applicable"]
3. Confirm disabled with empty reason: YES
4. Confirm enabled once a reason is given: YES
5. says retained: YES / shows reason: YES
6. cards still rendered after dismissal: 23 (want 23)
7. survives reload: YES
8. console errors: none
```

Seven new backend tests: both reason rules, the untouched-analysis invariant, audit redaction (asserts the reason text appears nowhere in the trail), reversal, restatement, and the legacy projection.

Gates: typecheck clean, biome clean, **397 tests passing** (32 shared + 356 backend + 9 frontend).

## Note on AC7

Not in this PR. The peer established that AC7 as worded is unbuildable: the note is independent generated prose, not composed from the clinical facts, so no note sentence has a provenance link to recover. Being tracked separately as a criterion correction plus checklist-field tracing.

## Clinical-Safety Checklist

- [x] No new egress path; no change to de-identification or `LLMClient`.
- [x] **No deterministic red-flag hit is suppressed, downgraded or filtered.** A dismissal is a recorded decision beside the flag, never a change to it, asserted by test.
- [x] Citations unchanged and still ID-constrained.
- [x] Nothing presented as a diagnosis. Approval remains an explicit doctor action and is unchanged.
- [x] **No clinical free text added to logs or the audit trail** — the dismissal reason is deliberately excluded, with a test asserting it.
- [x] No clinical content in web storage.