### PR TITLE
fix(llm): bound medicationsDispensed at ten so Gemini can decode clinical_facts

### DIFF
--- a/docs/trd.md
+++ b/docs/trd.md
@@ -290,6 +290,8 @@ One adapter class implements `LLMClient` for all three providers — Qwen, Gemin
 
 The sentence above says provider selection is a constructor parameter. That is true of the mechanism and currently **not** true of the outcome for one provider, so the limit is recorded here rather than discovered by whoever next sets `LLM_PROVIDER=gemini`.
 
+> **Superseded 14/08/26.** The cause is now established and fixed. This subsection is kept as filed, because its ruled-out list is what the next reader will reach for and two of its three bullets need qualifying. Read "Resolved 14/08/26" below before acting on anything here.
+
 Measured 14/08/26 against `gemini-3.5-flash-lite` on the live OpenAI-compatible endpoint, sending each schema the pipeline actually uses, all with `strict: true`:
 
 | Call                        | JSON Schema size | Depth | Result                   |
@@ -311,6 +313,35 @@ The remaining difference is scale: `clinical_facts` is roughly 20x larger, three
 **Consequence:** Gemini is a configured provider that cannot currently run an analysis, and `AGENTS.md`'s constraint on it (local dev, synthetic data only) should be read as a rule about what it may be pointed at rather than a statement that it works. Production is unaffected: it runs Qwen, and a boot guard throws on `LLM_PROVIDER=gemini` regardless (§7).
 
 Tracked as GitHub issue #96. The fix worth doing is shrinking or splitting `clinical_facts`, which would reduce the largest prompt in the system for every provider rather than special-casing one, and is deliberately **not** bundled with this disclosure.
+
+#### Resolved 14/08/26: `maxItems` Is Expanded Into The Schema Budget
+
+Closes GitHub issue #96. No adapter change and no provider-specific code were required.
+
+**The bisect.** Only `medicationsDispensed.maxItems` was varied, in the real `clinical_facts` schema, with nothing else in the request changed:
+
+| `maxItems` | absent | 1   | 2   | 3   | 5   | 10  | 20      |
+| ---------- | ------ | --- | --- | --- | --- | --- | ------- |
+| Result     | 200    | 200 | 200 | 200 | 200 | 200 | **400** |
+
+From the other side, varying only `gaps.maxItems` in `note_and_gaps`, the 686 B schema that already passes:
+
+| `maxItems` | 30  | 100     | 300     | 1000    |
+| ---------- | --- | ------- | ------- | ------- |
+| Result     | 200 | **400** | **400** | **400** |
+
+**Gemini expands a bounded array into `maxItems` copies of the item schema before measuring the result against its own budget.** A 686 B schema fails at `maxItems: 100` while a 14,240 B schema passes at `maxItems: 10`, which no explanation in bytes, depth, or authored property count survives. Going from 10 to 20 alters the schema by two bytes, adds no authored property, and flips the result.
+
+**Two corrections to the ruled-out list above.**
+
+- **"Not a JSON Schema keyword" is true as written and misleading in effect.** No keyword is rejected. One keyword's _value_ is the multiplier that decides the outcome, so a reader who rules out keywords rules out the cause.
+- **"The remaining difference is scale" is right about the budget and wrong about its units.** What is capped is post-expansion property count. Bytes and depth co-vary with it, which is why they looked causal.
+
+**Fix:** `medicationsDispensed` is bounded at 10 rather than 20 (`shared/src/index.ts`). That bound already existed as a runaway-decoding guard, and its own comment already argued twenty was far beyond any single GP consultation, so this tightens a Tier 1 control (§21.3) rather than weakening one, and it applies to every provider rather than special-casing Gemini. Pinned by a test in `shared/src/index.test.ts`.
+
+**Verified through the real pipeline**, which is the standard §21.2 sets rather than a toy probe: `analyseNote` and `generateSuggestions` both complete on `gemini-3.5-flash-lite` against a synthetic fixture, returning all 34 checklist fields, a four-section SOAP note, gaps, and corpus-constrained citations. Qwen re-verified unchanged on `qwen3.7-flash`.
+
+**Not closed by this.** Shrinking or splitting `clinical_facts` remains worth doing on its own merits, because it cuts the largest prompt in the system for every provider including the one production runs. The headroom here is thin: the budget is shared across the whole schema, so adding checklist fields can push it back over with no array involved.
 
 ### Request Bounds
 

--- a/shared/src/index.test.ts
+++ b/shared/src/index.test.ts
@@ -250,6 +250,41 @@ describe('LLM-facing schemas convert to JSON Schema for constrained decoding', (
     expect(json).toHaveProperty('properties.clinicalFacts')
   })
 
+  /**
+   * GitHub issue #96. Gemini expands a bounded array into `maxItems` copies of
+   * the item schema before measuring the result against its own schema budget,
+   * so this one number decides whether `clinical_facts` is accepted at all.
+   * Measured 14/08/26 against the live endpoint: bodiless HTTP 400 at twenty,
+   * HTTP 200 at ten and below, with nothing else in the request changed.
+   *
+   * `note_and_gaps` is deliberately not covered here. It carries `maxItems: 30`
+   * and passes, because the budget is per-schema rather than per-keyword and it
+   * is 686 bytes against 14,240. Asserting one number across both would force a
+   * bound neither schema needs.
+   */
+  it('keeps every clinical_facts array bound inside the Gemini expansion budget', () => {
+    const collectMaxItems = (node: unknown): number[] =>
+      typeof node !== 'object' || node === null
+        ? []
+        : Object.entries(node).flatMap(([key, value]) =>
+            key === 'maxItems' && typeof value === 'number' ? [value] : collectMaxItems(value),
+          )
+
+    const bounds = collectMaxItems(
+      z.toJSONSchema(ClinicalFactsResponseSchema, { target: 'draft-7' }),
+    )
+
+    expect(bounds, 'A bound that vanished would pass the loop below vacuously.').not.toHaveLength(0)
+    for (const bound of bounds) {
+      expect(
+        bound,
+        'Raising this past ten stops Gemini running the pipeline at all (issue ' +
+          '#96), and the failure is a bodiless 400 that names no cause. Only the ' +
+          'live endpoint can prove a larger value, so re-measure before changing it.',
+      ).toBeLessThanOrEqual(10)
+    }
+  })
+
   it('converts note_and_gaps without throwing (TRD §6 step 2)', () => {
     const json = z.toJSONSchema(NoteAndGapsResponseSchema, { target: 'draft-7' })
     expect(json).toHaveProperty('properties.note')

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -228,9 +228,18 @@ const buildOperationalBlock = <T extends z.ZodType>(field: T) =>
      * structural (Tier 1) rather than a token budget to tune — raising
      * `max_tokens` only buys a longer loop.
      *
-     * Twenty dispensed items is far beyond any single GP consultation.
+     * Ten dispensed items is far beyond any single GP consultation.
+     *
+     * Lowered from twenty on 14/08/26 (GitHub issue #96, docs/trd.md §6).
+     * Gemini expands a bounded array into `maxItems` copies of the item schema
+     * before measuring it against its own schema budget, so twenty assertion
+     * objects pushed `clinical_facts` past that budget and every request
+     * failed with a bodiless 400. Measured: the same schema passes at ten and
+     * below. The bound is now load-bearing for two unrelated reasons, and
+     * raising it back stops Gemini running at all rather than merely widening
+     * a ceiling.
      */
-    medicationsDispensed: z.array(field).max(20).default([]),
+    medicationsDispensed: z.array(field).max(10).default([]),
     mcDays: field,
     referral: field,
     followUp: field,


### PR DESCRIPTION
## What Changed

`LLM_PROVIDER=gemini` runs the analyse pipeline. `medicationsDispensed` is bounded at 10 rather than 20, which is the whole code change.

Closes #96

## Why

Gemini expands a bounded array into `maxItems` copies of the item schema before measuring the result against its own schema budget. The single `maxItems: 20` pushed `clinical_facts` past that budget, and since it is the first call `analyseNote` makes, the pipeline died there with a bodiless 400.

#96 and the §6 disclosure in #105 could not separate size, depth and property count, and left "which limit binds is not established". It is none of the three. Varying only that one number:

| `maxItems` | absent | 1 | 2 | 3 | 5 | 10 | 20 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Result | 200 | 200 | 200 | 200 | 200 | 200 | **400** |

And from the other side, `note_and_gaps` is 686 B against 14,240 B and still fails at `maxItems: 100`. Going from 10 to 20 changes the schema by two bytes and adds no authored property, and it flips the result, so bytes and depth are not what is capped. Post-expansion property count is.

**This tightens a control rather than weakening one.** The bound already existed as a runaway-decoding guard, and its own comment already argued twenty was far beyond any single GP consultation. It stays Tier 1 (§21.3) for every provider.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manually exercised the affected flow

Added `keeps every clinical_facts array bound inside the Gemini expansion budget` to `shared/src/index.test.ts`, which walks the emitted JSON Schema and fails if any `maxItems` exceeds 10, so a future widening fails here rather than as a 400 in someone's dev session.

Manual, through the real pipeline rather than a probe, which is the standard §21.2 sets:

- `analyseNote` and `generateSuggestions` both complete on `gemini-3.5-flash-lite` against a synthetic fixture, returning all 34 checklist fields, a four-section SOAP note, gaps, and citations constrained to corpus IDs.
- Qwen re-verified unchanged on `qwen3.7-flash`.

## Clinical-Safety Checklist

The diff touches none of the listed paths, but it changes what the model can emit, so it is answered rather than deleted.

- [x] No new path sends un-de-identified text to a provider, egress still goes through `deid/` then `LLMClient`
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model
- [x] Citations remain ID-constrained; no free-text references accepted, and this was confirmed live rather than assumed
- [x] No transcript bodies, note contents, or vault entries written to logs
- [x] No fixtures added

## Notes For The Reviewer

**The alternative was measured and rejected.** Stripping `maxItems` for Gemini only, via a constructor flag set in `build()`, also works. It was dropped because it forks behaviour per provider, against `.claude/rules/security.md`'s "do not fork per-provider client code", and demotes that bound to Tier 3 for Gemini.

**`docs/trd.md` §6 keeps @AlaskanTuna's original disclosure intact** and adds a dated resolution subsection after it, following the §21.2 precedent for superseded measurements. Two bullets in its ruled-out list needed qualifying, since "not a JSON Schema keyword" is true as written but rules out the cause in effect.

**Not closed by this.** Shrinking or splitting `clinical_facts` remains worth doing on its own merits, because it cuts the largest prompt in the system for every provider including the one production runs. The headroom is thin: the budget is shared across the whole schema, so adding checklist fields can push it back over with no array involved. Suggest a separate `type:task`.

**Unrelated observation.** Qwen took 39s and 44s for the two calls in local verification, against the mean of 19.9s recorded in §19 row 19, which is over the CAP-1 30s budget. Nothing to do with this diff, but worth a look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced the maximum number of dispensed medications supported in clinical facts from 20 to 10.
  - Prevented schema validation failures when processing clinical facts with Gemini.

- **Tests**
  - Added regression coverage to ensure clinical facts array limits remain within supported bounds.
  - Confirmed compatible behavior across Gemini and Qwen processing.

- **Documentation**
  - Documented the schema limitation and its resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->