### PR TITLE
chore: add a local Postgres so development stops writing to the live database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,16 @@ PORT=3001
 CORS_ORIGIN=http://localhost:5173
 
 # ─── Database (Supabase Postgres) ─────────────────────────────────────────────
+# For local development, prefer the Postgres in docker-compose.yml. There is
+# only one Supabase project and the deployed API uses it, so pointing these at
+# Supabase means local writes edit live data (GitHub issue #106):
+#
+#   docker compose up -d
+#   DATABASE_URL="postgresql://catatmd:catatmd@127.0.0.1:5434/catatmd"
+#   DIRECT_URL="postgresql://catatmd:catatmd@127.0.0.1:5434/catatmd"
+#
+# The deployed values below are the shape Render and Supabase need.
+#
 # Pooled connection (Supavisor, port 6543) — used by the app at runtime.
 # Prisma needs pgbouncer=true on the pooled URL.
 DATABASE_URL="postgresql://postgres.<ref>:<password>@aws-0-ap-southeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+# Local development database (GitHub issue #106).
+#
+# Without this, `.env` points at the same Supabase instance the deployed API
+# uses, because there is no second Supabase project available on the free plan.
+# That made every local click on a mutating control an edit to live data, and it
+# has already written a test row into the guest demo account.
+#
+# The image and credentials deliberately match the throwaway Postgres in
+# `.github/workflows/ci.yml`, so a suite that passes locally is running against
+# the same server version CI will use.
+#
+#   docker compose up -d
+#   bun run db:migrate
+#
+# Port 5434, not 5432. Both 5432 and 5433 were already bound on the machine this
+# was written on, and a compose file that fails to start because a developer
+# happens to run Postgres already is a compose file nobody uses. Override with
+# POSTGRES_PORT if 5434 is taken too.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: catatmd-dev-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: catatmd
+      POSTGRES_PASSWORD: catatmd
+      POSTGRES_DB: catatmd
+    ports:
+      - '${POSTGRES_PORT:-5434}:5432'
+    volumes:
+      - catatmd-dev-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U catatmd -d catatmd']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  catatmd-dev-db:

--- a/docs/README.md
+++ b/docs/README.md
@@ -262,6 +262,7 @@ The load-bearing module rule: **no module outside `backend/src/lib/llm/` may imp
 ```bash
 bun install
 cp .env.example .env          # fill DATABASE_URL, DIRECT_URL, BETTER_AUTH_SECRET, QWEN_API_KEY
+docker compose up -d          # local Postgres, see "Use the local database" below
 bun run prisma:generate
 bun run db:migrate
 bun run dev                   # shared watch + API :3001 + web :5173
@@ -274,6 +275,27 @@ bun run lint                  # biome
 bun run typecheck             # all three workspaces
 bun run test                  # vitest
 ```
+
+### Use The Local Database
+
+**There is only one Supabase project, and the deployed API uses it.** Point `.env` at Supabase and every local click on a control that writes is editing live data. That is not hypothetical: it has already written a test row into the guest demo account, and the matching audit rows cannot be removed because the chain is append-only by design.
+
+`docker-compose.yml` runs Postgres 16 locally on port **5434**, matching the image and credentials CI uses, so a suite that passes here is running against the server version CI will use:
+
+```bash
+docker compose up -d
+```
+
+```ini
+DATABASE_URL="postgresql://catatmd:catatmd@127.0.0.1:5434/catatmd"
+DIRECT_URL="postgresql://catatmd:catatmd@127.0.0.1:5434/catatmd"
+```
+
+Then `bun run db:migrate` as usual. No `pgbouncer=true`, because there is no pooler in front of it, and both URLs are the same for the same reason.
+
+Port 5434 rather than 5432 because 5432 and 5433 are commonly already bound. Override with `POSTGRES_PORT` if 5434 is taken too.
+
+**Point `.env` back at Supabase only when you specifically mean to.** Reading deployed data is usually fine; writing to it is what caused the problem above.
 
 - `BETTER_AUTH_SECRET` — generate with `openssl rand -base64 32`.
 - `PORT` defaults to `3001`, which is commonly taken (Grafana, other dev servers). Set `PORT` and `BETTER_AUTH_URL` together if you move it — better-auth's URL must match the origin the API actually serves on.


### PR DESCRIPTION
## What Changed

`docker-compose.yml` runs Postgres 16 locally, and the setup docs point at it instead of Supabase.

Closes **#106**.

## Why

**There is one Supabase project and the deployed API uses it.** With `.env` pointing there, every local click on a control that writes edits live data. That is not hypothetical: it already wrote a test dismissal into the **guest demo account**, and the matching `AuditEvent` rows cannot be removed because the chain is append-only by design.

The blast radius grew this evening rather than gradually. Read-only local testing was safe; the disposition and approval work means the UI now has several controls that write, and **approval is terminal and irreversible**.

**Not a PHI incident.** Everything in that instance is synthetic, so this is integrity and demo hygiene rather than privacy.

## Why Local Postgres, Not A Second Supabase Project

Not a preference. **The Supabase free plan is at its project limit**, so that option does not exist.

It was the recommendation anyway, and the argument is that it is **proven here rather than invented for the occasion**: CI already runs a throwaway `postgres:16-alpine` and the whole suite passes against it. The compose file matches CI's image and credentials, so a suite passing locally runs against the same server version CI will use.

## Port 5434, Not 5432

Both 5432 and 5433 were already bound on the machine this was written on. A compose file that fails to start because a developer happens to run Postgres already is a compose file nobody uses. `POSTGRES_PORT` overrides it.

Same class of environment collision as `PORT=3001` already documented in the README for Grafana.

## Verification

Verified end to end rather than assumed:

| Step | Result |
| --- | --- |
| `docker compose up -d` | container healthy, `PostgreSQL 16.15` |
| `prisma migrate deploy` | all migrations applied |
| Schema | all 8 tables created |
| **Full suite against the local database** | **406 tests pass** |

Also checked: `.env.example` carries no real credential, and `docker-compose.yml` is not a deployable path, so this costs no Vercel slot.

## Nobody's Setup Breaks

This is **additive**. `.env` is untouched, so an existing checkout keeps working exactly as it does now until its owner chooses to switch. The README says plainly that pointing back at Supabase is fine when you mean to, and that reading deployed data is usually fine while writing to it is what caused the problem.

## Notes For The Reviewer

Clinical-Safety section deleted: no source paths touched, no runtime code changed.

`.env.example` gains a comment block at the top of the database section rather than replacing the deployed values, because those are still the shape Render and Supabase need.

One thing this does **not** do: it does not stop anyone pointing `.env` at Supabase and writing to it. A visible non-production marker in the UI was option 3 on the issue and remains unbuilt; it is frontend work and would compose with this rather than replace it.