### PR TITLE
feat(shell): warn on screen when a dev build is writing to the shared database

### DIFF
--- a/backend/src/routes/health.test.ts
+++ b/backend/src/routes/health.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Issue #106. The warning banner in the SPA is driven entirely by this field,
+ * so its two safety properties live here rather than in the UI:
+ *
+ * - production must never emit it, so the deployed API cannot be the source of
+ *   a warning about itself
+ * - anything that is not provably on this machine must read as `remote`, so an
+ *   unparseable or unexpected connection string fails towards warning rather
+ *   than towards silence
+ */
+const envMock = { NODE_ENV: 'development', DATABASE_URL: '', LLM_PROVIDER: 'qwen' }
+
+vi.mock('../config/env.js', () => ({ env: envMock }))
+vi.mock('../lib/prisma.js', () => ({ prisma: { $queryRaw: vi.fn(async () => [{ 1: 1 }]) } }))
+
+async function health() {
+  vi.resetModules()
+  const { healthRouter } = await import('./health.js')
+  const layer = healthRouter.stack.find((entry) => entry.route?.path === '/health')
+  const handler = layer?.route?.stack[0]?.handle as (
+    req: unknown,
+    res: unknown,
+  ) => Promise<void> | void
+  let body: Record<string, unknown> = {}
+  const res = {
+    json: (payload: Record<string, unknown>) => {
+      body = payload
+    },
+    status: () => res,
+  }
+  await handler({}, res)
+  return body
+}
+
+beforeEach(() => {
+  envMock.NODE_ENV = 'development'
+  envMock.DATABASE_URL = ''
+})
+
+describe('database locality reporting', () => {
+  it('says nothing at all in production', async () => {
+    envMock.NODE_ENV = 'production'
+    envMock.DATABASE_URL = 'postgresql://user:pw@db.supabase.co:5432/postgres'
+
+    const body = await health()
+
+    // Absent, not `remote`. The deployed API has no business describing itself
+    // as somewhere a developer might be about to write.
+    expect(body).not.toHaveProperty('database')
+  })
+
+  it.each([
+    ['postgresql://u:p@localhost:5434/catatmd', 'local'],
+    ['postgresql://u:p@127.0.0.1:5434/catatmd', 'local'],
+    ['postgresql://u:p@db.supabase.co:5432/postgres', 'remote'],
+    ['postgresql://u:p@aws-0-ap-southeast-1.pooler.supabase.com:6543/postgres', 'remote'],
+  ])('classifies %s as %s', async (url, expected) => {
+    envMock.DATABASE_URL = url
+
+    expect((await health()).database).toBe(expected)
+  })
+
+  it('treats an unparseable connection string as remote', async () => {
+    envMock.DATABASE_URL = 'not-a-url'
+
+    // The safe direction. A string this code cannot read is not evidence that
+    // the database is local, and guessing `local` would silence the warning on
+    // exactly the setup nobody understands.
+    expect((await health()).database).toBe('remote')
+  })
+})

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -4,10 +4,44 @@ import { prisma } from '../lib/prisma.js'
 
 export const healthRouter = Router()
 
+/**
+ * Whether this API is talking to a database on this machine (issue #106).
+ *
+ * Coarse by design. It answers "would writing here affect the shared
+ * instance", which is the only question the caller needs, and it never
+ * discloses the host, the port, the database name or any credential. A
+ * connection string is a secret and this is a boolean wearing a label.
+ *
+ * Reported **only outside production**. The deployed API is always remote, so
+ * the field would carry no information there, and omitting it means the
+ * production API cannot be the source of a warning about itself.
+ */
+function databaseLocality(): 'local' | 'remote' | undefined {
+  if (env.NODE_ENV === 'production') return undefined
+  const host = (() => {
+    try {
+      return new URL(env.DATABASE_URL).hostname
+    } catch {
+      // An unparseable URL is not a reason to claim safety.
+      return ''
+    }
+  })()
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' ? 'local' : 'remote'
+}
+
 healthRouter.get('/health', async (_req, res) => {
   try {
     await prisma.$queryRaw`SELECT 1`
-    res.json({ status: 'ok', provider: env.LLM_PROVIDER })
+    const locality = databaseLocality()
+    // Spread rather than `database: undefined`. Both serialise identically,
+    // because `JSON.stringify` drops undefined values, but only this one is
+    // absent before serialisation. The production API's silence should not
+    // depend on a property of the serialiser.
+    res.json({
+      status: 'ok',
+      provider: env.LLM_PROVIDER,
+      ...(locality ? { database: locality } : {}),
+    })
   } catch {
     res.status(503).json({ status: 'degraded', database: 'unreachable' })
   }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -184,4 +184,18 @@ export const api = {
 
   guidelines: (): Promise<GuidelineChunk[]> =>
     request('/guidelines', GuidelinesEnvelope).then((r) => r.guidelines),
+
+  /**
+   * `database` is absent in production by design, so a missing field must be
+   * read as "no warning to give", never as a failure to check.
+   */
+  health: () =>
+    request(
+      '/health',
+      z.object({
+        status: z.string(),
+        provider: z.string().optional(),
+        database: z.enum(['local', 'remote', 'unreachable']).optional(),
+      }),
+    ),
 }

--- a/frontend/src/shell/AppShell.tsx
+++ b/frontend/src/shell/AppShell.tsx
@@ -6,6 +6,7 @@ import { HelpButton } from '../demo/HelpButton.js'
 import { Spotlight } from '../demo/Spotlight.js'
 import { cn } from '../lib/cn.js'
 import { CursorGlow } from '../ui/CursorGlow.js'
+import { LiveDataWarning } from './LiveDataWarning.js'
 import { MobileDock } from './MobileDock.js'
 import { SidebarIsland } from './SidebarIsland.js'
 import { SiteFooter } from './SiteFooter.js'
@@ -67,6 +68,7 @@ export function AppShell() {
         {/* Outside the page layer: the spotlight ring and the step bar sit above
             the sidebar and the scrim, and a coachmark clipped by the surface it
             is pointing at would defeat itself. */}
+        <LiveDataWarning />
         <HelpButton />
         <DemoStepBar />
         <Spotlight />

--- a/frontend/src/shell/LiveDataWarning.tsx
+++ b/frontend/src/shell/LiveDataWarning.tsx
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query'
+import { AlertTriangle } from 'lucide-react'
+import { api } from '../lib/api.js'
+
+/**
+ * Says so, on screen, when this development build is writing to the shared
+ * database (issue #106).
+ *
+ * The hazard it exists for is specific and was not hypothetical: a review
+ * control clicked during local testing wrote a real dismissal into the demo
+ * account, because `.env` pointed at the deployed Supabase instance and nothing
+ * on screen said so. `docker-compose.yml` gives a local Postgres, but adopting
+ * it is opt-in, so until a developer switches their `.env` the hazard is still
+ * there and silent. This makes it loud.
+ *
+ * **It cannot appear in production, and that is structural rather than
+ * careful.** Two independent conditions must both hold, and either alone is
+ * sufficient to prevent it:
+ *
+ * 1. `import.meta.env.DEV` is a compile-time constant that is `false` in every
+ *    `vite build`, so this component's body is eliminated from the production
+ *    bundle. The code is not shipped, not merely unreached.
+ * 2. The API omits `database` entirely when `NODE_ENV` is production, so even a
+ *    development bundle pointed at the deployed API is told nothing to warn
+ *    about.
+ *
+ * That ordering matters. A banner reading "non-production" on the real product,
+ * during an evaluation, would be a worse failure than the one it prevents, so
+ * the safe direction is the default: say nothing unless positively told there
+ * is something to say.
+ */
+export function LiveDataWarning() {
+  // Guard first, so everything below is dead code in a production build.
+  if (!import.meta.env.DEV) return null
+  return <LiveDataBanner />
+}
+
+function LiveDataBanner() {
+  const health = useQuery({
+    queryKey: ['health'],
+    queryFn: api.health,
+    staleTime: Number.POSITIVE_INFINITY,
+    retry: false,
+  })
+
+  // Anything other than an explicit `remote` is silence, including an error, a
+  // pending fetch, and the absent field a production API returns.
+  if (health.data?.database !== 'remote') return null
+
+  return (
+    <div
+      role="status"
+      data-print="hide"
+      style={{ zIndex: 'var(--z-toast)' }}
+      className="fixed inset-x-0 top-0 flex items-center justify-center gap-2 bg-urgent-rule px-4 py-1.5 text-center text-xs font-medium text-ink"
+    >
+      <AlertTriangle aria-hidden className="size-3.5 shrink-0" />
+      <span>
+        Development build connected to the <strong>shared database</strong>. Anything you approve,
+        edit or dismiss here changes real data. Run <code>docker compose up -d</code> and point{' '}
+        <code>DATABASE_URL</code> at it to work locally.
+      </span>
+    </div>
+  )
+}


### PR DESCRIPTION
The option left unbuilt when #112 closed #106. The local Postgres is **opt-in**, so until a developer switches their `.env` the hazard is unchanged and silent: a review control clicked locally writes to the demo account. That is not hypothetical — it is how a real dismissal reached it earlier today.

## It Cannot Appear in Production

Structurally, rather than carefully. **Two independent conditions must both hold, and either alone prevents it.**

**1. The code is not in the production bundle.** `import.meta.env.DEV` is a compile-time constant, `false` in every `vite build`, so the component body is eliminated:

```
$ grep -rl "shared database" frontend/dist/assets/*.js
  → ABSENT
$ grep -c "LiveDataBanner" frontend/dist/assets/*.js
  → no chunk contains it
```

Not shipped, not merely unreached.

**2. The production API says nothing to warn about.** It omits `database` entirely when `NODE_ENV` is production. Verified against the live API:

```
$ curl https://catatmd-api.onrender.com/api/health
{"status":"ok","provider":"qwen"}     ← no database field
$ curl http://localhost:3001/api/health
{"status":"ok","provider":"qwen","database":"remote"}
```

**That ordering is the design.** A banner reading "non-production" on the real product during an evaluation would be a worse failure than the one it prevents. So silence is the default, and only an explicit `remote` speaks. A pending fetch, an error, and an absent field are all silence.

## The Signal Discloses Nothing

Coarse by design. It answers *"would writing here affect the shared instance"* and never reveals host, port, database name or credential. A connection string is a secret; this is a boolean wearing a label.

## Two Properties Pinned by Tests

- **Production omits the field** — asserted on the object *before* serialisation. The first version passed `database: undefined`, which serialises identically because `JSON.stringify` drops undefined, but the key existed. The test caught it and the code now spreads conditionally, so the production API's silence does not depend on a property of the serialiser.
- **Anything not provably on this machine reads as `remote`**, including an unparseable connection string. An unfamiliar setup fails towards warning rather than towards silence, because a string this code cannot read is not evidence the database is local.

Six cases, covering localhost, `127.0.0.1`, Supabase direct, Supabase pooler, production, and garbage input.

## Verification

Browser: banner renders in dev against the shared database, reading *"Development build connected to the shared database. Anything you approve, edit or dismiss here changes real data."*

Gates: typecheck clean, biome clean, **412 tests passing**, production build succeeds and does not contain the banner.

## Clinical-Safety Checklist

- [x] No new egress path; no change to de-identification or `LLMClient`.
- [x] No red-flag hit suppressed, downgraded or filtered.
- [x] Citations unchanged and still ID-constrained.
- [x] Nothing presented as a diagnosis; approval unchanged.
- [x] **No secret or connection detail disclosed** — the field is a two-value enum, and is absent in production.
- [x] No transcript bodies, note contents or vault entries logged.
- [x] No clinical content in web storage.