### PR TITLE
feat(ui): add multi-select and erasure to the consultations list

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,7 +4,11 @@ import express from 'express'
 import helmet from 'helmet'
 import { env } from './config/env.js'
 import { errorHandler } from './middleware/error-handler.js'
-import { analyzeRateLimit, ephemeralAnalyzeRateLimit } from './middleware/rate-limit.js'
+import {
+  analyzeRateLimit,
+  ephemeralAnalyzeRateLimit,
+  eraseRateLimit,
+} from './middleware/rate-limit.js'
 import { requestContext } from './middleware/request-context.js'
 import { requireSession } from './middleware/require-session.js'
 import { authRouter } from './routes/auth.js'
@@ -50,6 +54,9 @@ export function createApp() {
   // transcript from the body, so it spends an LLM call without the caller
   // having stored anything first (#80).
   app.post('/api/consultations/analyze-ephemeral', ephemeralAnalyzeRateLimit)
+  // Destructive and irreversible rather than expensive, so its own bucket: an
+  // erase sweep must not be funded by an unspent analysis budget (#114).
+  app.post('/api/consultations/erase', eraseRateLimit)
 
   // ── Clinical routers ─────────────────────────────────────────────────────
   // These inherit the session guard and the analyze limiter above, and must

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -63,3 +63,25 @@ export const ephemeralAnalyzeRateLimit = rateLimit({
     error: { code: 'rate_limited', message: 'Too many analysis requests. Please retry shortly.' },
   },
 })
+
+/**
+ * Per-IP limiter for `POST /api/consultations/erase` (#114).
+ *
+ * Erasure spends no LLM call, so this is not a cost control. It is here because
+ * the route is destructive and irreversible: the batch bound stops one request
+ * erasing an unbounded number of consultations, and this stops a caller
+ * sidestepping that bound by sending many requests.
+ *
+ * Ten a minute is far above the handful of gestures a doctor tidying a list
+ * makes, and far below what a script sweeping ids would need.
+ */
+export const eraseRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 10,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  keyGenerator: clientKey,
+  message: {
+    error: { code: 'rate_limited', message: 'Too many erase requests. Please retry shortly.' },
+  },
+})

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -216,7 +216,7 @@ beforeEach(() => {
 })
 
 function seed(status: string, extra: Record<string, unknown> = {}) {
-  store.set('c1', {
+  const row = {
     id: 'c1',
     doctorId: 'doctor-1',
     status,
@@ -232,7 +232,10 @@ function seed(status: string, extra: Record<string, unknown> = {}) {
     createdAt: new Date(),
     updatedAt: new Date(),
     ...extra,
-  })
+  }
+  // Keyed by the row's own id so `extra` can seed a second consultation, which
+  // the erase-batch tests need. Defaults to 'c1' as before.
+  store.set(row.id as string, row)
 }
 
 /** A complete, schema-valid analysis — `toDetail` parses on the way out. */
@@ -854,5 +857,91 @@ describe('evidence links', () => {
     const cough = links.find((l) => l.fieldId === 'clinicalFacts.symptoms.cough')
     expect(cough?.speaker).toBe('patient')
     expect(cough?.offsetSeconds, 'absent timing must not become 0').toBeUndefined()
+  })
+})
+
+describe('erase', () => {
+  const erase = (ids: string[]) => call('POST', '/api/consultations/erase', { ids })
+
+  const listedIds = async () => {
+    const res = await call('GET', '/api/consultations')
+    const body = (await res.json()) as { consultations: { id: string }[] }
+    return body.consultations.map((c) => c.id)
+  }
+
+  it('erases the selection, leaves the rest, and drops them from the list', async () => {
+    seed('draft')
+    seed('awaiting_review', { id: 'c2' })
+    seed('draft', { id: 'c3' })
+
+    const res = await erase(['c1', 'c3'])
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ erased: ['c1', 'c3'], failed: [] })
+    expect(store.get('c1')?.erasedAt).toBeInstanceOf(Date)
+    expect(store.get('c2')?.erasedAt, 'an unselected row must be untouched').toBeNull()
+    // The list is what a doctor actually sees, so the tombstone has to be
+    // invisible there rather than merely flagged in the row.
+    await expect(listedIds()).resolves.toEqual(['c2'])
+  })
+
+  it('erases an approved consultation', async () => {
+    // Deliberate, and the DPIA is the reason: erasure serves a data-subject
+    // right that does not lapse because a doctor signed the note. The weight of
+    // the decision is carried by the confirmation counting approved notes, not
+    // by refusing here.
+    seed('approved', { approvedAt: new Date() })
+
+    await expect(erase(['c1']).then((r) => r.json())).resolves.toEqual({
+      erased: ['c1'],
+      failed: [],
+    })
+  })
+
+  it("reports another doctor's id as failed without erasing it, and still erases the rest", async () => {
+    seed('draft')
+    seed('draft', { id: 'c9', doctorId: 'doctor-2' })
+
+    const res = await erase(['c1', 'c9'])
+
+    await expect(res.json()).resolves.toEqual({ erased: ['c1'], failed: ['c9'] })
+    expect(store.get('c9')?.erasedAt, "another doctor's row must survive").toBeNull()
+  })
+
+  it('records one erasure audit event per consultation actually erased', async () => {
+    seed('draft')
+    seed('draft', { id: 'c2' })
+
+    await erase(['c1', 'c2', 'missing'])
+
+    expect(
+      audits.filter((a) => a.action === 'consultation.erased').map((a) => a.consultationId),
+    ).toEqual(['c1', 'c2'])
+  })
+
+  it('surfaces an unexpected database fault as a 500 rather than a per-id failure', async () => {
+    // The failed/erased split reports the ownership gate's 404 and nothing
+    // else. Folding a real fault into `failed` would render in the UI as a
+    // routine skip, so a write that broke would look like a row already gone.
+    seed('draft')
+    const { prisma } = await import('../lib/prisma.js')
+    vi.mocked(prisma.consultation.update).mockRejectedValueOnce(new Error('connection reset'))
+
+    const res = await erase(['c1'])
+
+    expect(res.status).toBe(500)
+    expect(await res.text()).not.toContain('connection reset')
+  })
+
+  it.each([
+    ['an empty selection', []],
+    ['more ids than one batch may carry', Array.from({ length: 101 }, (_, i) => `c${i}`)],
+  ])('rejects %s with 400', async (_label, ids) => {
+    seed('draft')
+
+    const res = await erase(ids)
+
+    expect(res.status).toBe(400)
+    expect(store.get('c1')?.erasedAt, 'a rejected batch must erase nothing').toBeNull()
   })
 })

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -7,6 +7,8 @@ import {
   type Disposition,
   type DispositionInput,
   DispositionInputSchema,
+  ERASE_BATCH_LIMIT,
+  EraseConsultationsInputSchema,
   type InformationGap,
   type SoapNote,
   SoapNoteSchema,
@@ -16,6 +18,7 @@ import {
 import { Router } from 'express'
 import { z } from 'zod'
 import { analyseNote, buildEvidenceLinks } from '../analysis/index.js'
+import { eraseConsultation } from '../audit/erasure.js'
 import { type AnalysisFailureReason, getAuditHistory, recordAuditEvent } from '../audit/index.js'
 import {
   type ClinicalProfile,
@@ -767,4 +770,62 @@ consultationsRouter.post('/:id/approve', async (req, res) => {
   })
 
   res.json({ consultation: await toDetailWithApprover(updated) })
+})
+
+/**
+ * Erases a selection of consultations (issue #114).
+ *
+ * **This is a tombstone, not a delete, and the distinction is load-bearing.**
+ * `eraseConsultation` nulls the three PHI columns and stamps `erasedAt`; the
+ * row itself stays, because `AuditEvent.consultationId` is `onDelete: Restrict`
+ * and is a hash-chain input. Removing the row would orphan every audit event
+ * that references it and break tamper evidence, which is the one property the
+ * chain exists to provide. `.claude/rules/security.md` states that as a
+ * do-not-change; this route is the caller it was waiting for, not a relaxation
+ * of it.
+ *
+ * Any status may be erased, approved included. The DPIA frames erasure as
+ * serving a data-subject right, and that right does not stop applying because a
+ * doctor signed the note, so the weight of erasing an approved record is
+ * carried by the confirmation in the UI, which counts them, rather than by a
+ * block here.
+ *
+ * A collection-level POST rather than `DELETE /:id`, because one gesture should
+ * cost one rate-limit token rather than N, and because the ordering below has
+ * to be decided server-side.
+ */
+consultationsRouter.post('/erase', async (req, res) => {
+  const parsed = EraseConsultationsInputSchema.safeParse(req.body)
+  if (!parsed.success) {
+    throw new HttpError(
+      400,
+      'invalid_body',
+      `Supply between 1 and ${ERASE_BATCH_LIMIT} consultation ids to erase.`,
+    )
+  }
+
+  const actor = doctorId(req)
+  const erased: string[] = []
+  const failed: string[] = []
+
+  // Sequential, deliberately. Each erasure appends an audit row, and `prevHash`
+  // is unique so that two concurrent appends cannot fork the chain;
+  // `recordAuditEvent` retries a head race only three times, so a `Promise.all`
+  // over a selection this size would exhaust that and fail rows for a reason
+  // that has nothing to do with the request.
+  for (const id of parsed.data.ids) {
+    try {
+      await eraseConsultation(id, actor)
+      erased.push(id)
+    } catch (error) {
+      // The ownership gate's 404 is the expected miss: not this doctor's, or
+      // already erased. Neither justifies abandoning the rest of the batch.
+      // Anything else is a real fault and must not be flattened into a tidy
+      // per-id failure that the client would render as a routine skip.
+      if (!(error instanceof HttpError && error.status === 404)) throw error
+      failed.push(id)
+    }
+  }
+
+  res.json({ erased, failed })
 })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,8 @@ import {
   type ConsultationListItem,
   ConsultationListItemSchema,
   type DispositionInput,
+  type EraseConsultationsResult,
+  EraseConsultationsResultSchema,
   ErrorEnvelopeSchema,
   type Fixture,
   FixtureSchema,
@@ -170,6 +172,20 @@ export const api = {
       method: 'PATCH',
       body: JSON.stringify(body),
     }).then((r) => r.consultation),
+
+  /**
+   * Erases a selection (issue #114). A tombstone, not a delete: the clinical
+   * content goes, the audit chain that references the consultation stays, so
+   * the row cannot be removed without breaking tamper evidence.
+   *
+   * Partial success is normal rather than exceptional, so this resolves with
+   * both lists instead of rejecting when some ids do not land.
+   */
+  eraseConsultations: (ids: string[]): Promise<EraseConsultationsResult> =>
+    request('/consultations/erase', EraseConsultationsResultSchema, {
+      method: 'POST',
+      body: JSON.stringify({ ids }),
+    }),
 
   approve: (id: string): Promise<ConsultationDetail> =>
     request(`/consultations/${id}/approve`, ConsultationEnvelope, { method: 'POST' }).then(

--- a/frontend/src/routes/ConsultationList.tsx
+++ b/frontend/src/routes/ConsultationList.tsx
@@ -1,9 +1,11 @@
-import type { ConsultationStatus } from '@shared/types'
-import { useQuery } from '@tanstack/react-query'
-import { Plus } from 'lucide-react'
+import type { ConsultationListItem, ConsultationStatus } from '@shared/types'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Plus, Trash2 } from 'lucide-react'
+import { useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { api } from '../lib/api.js'
+import { ApiError, api } from '../lib/api.js'
 import { cn } from '../lib/cn.js'
+import { Button } from '../ui/Button.js'
 import { EmptyState, Skeleton } from '../ui/Card.js'
 import { PageHeader } from '../ui/PageHeader.js'
 
@@ -19,6 +21,20 @@ const STATUS: Record<ConsultationStatus, { label: string; className: string }> =
   approved: { label: 'Approved', className: 'border-accent/40 text-accent' },
 }
 
+/**
+ * How each status is named when counted in the erase confirmation.
+ *
+ * Separate from `STATUS.label` because these are read as nouns inside a
+ * sentence ("1 approved note") rather than as a chip on a row, and because the
+ * approved wording is the one a doctor most needs to register before agreeing.
+ */
+const ERASE_NOUN: Record<ConsultationStatus, { one: string; many: string }> = {
+  draft: { one: 'draft', many: 'drafts' },
+  analyzing: { one: 'consultation being analysed', many: 'consultations being analysed' },
+  awaiting_review: { one: 'consultation awaiting review', many: 'consultations awaiting review' },
+  approved: { one: 'approved note', many: 'approved notes' },
+}
+
 const formatDate = (value: Date) =>
   new Intl.DateTimeFormat('en-MY', {
     day: 'numeric',
@@ -27,11 +43,53 @@ const formatDate = (value: Date) =>
     minute: '2-digit',
   }).format(value)
 
+const CHECKBOX =
+  'size-4 shrink-0 cursor-pointer accent-accent disabled:cursor-not-allowed disabled:opacity-40'
+
+const count = (n: number, noun: string) => `${n} ${noun}${n === 1 ? '' : 's'}`
+
 export function ConsultationList() {
+  const queryClient = useQueryClient()
   const { data, isPending } = useQuery({
     queryKey: ['consultations'],
     queryFn: api.listConsultations,
   })
+  const [picked, setPicked] = useState<ReadonlySet<string>>(new Set())
+  const [notice, setNotice] = useState<string | null>(null)
+  const dialog = useRef<HTMLDialogElement>(null)
+
+  const consultations = data ?? []
+
+  // Derived from the rows rather than read straight out of state, so a
+  // selection cannot outlive the consultation it points at. Without this, a
+  // list that refreshed while the dialog was open could erase by an id the
+  // doctor could no longer see.
+  const selected = consultations.filter((c) => picked.has(c.id))
+  const allSelected = consultations.length > 0 && selected.length === consultations.length
+
+  const erase = useMutation({
+    mutationFn: () => api.eraseConsultations(selected.map((c) => c.id)),
+    onSuccess: ({ erased, failed }) => {
+      dialog.current?.close()
+      setPicked(new Set())
+      // Silent on a clean run: the rows disappearing is the confirmation, and a
+      // message saying so would be noise. A partial failure is the opposite and
+      // must never be swallowed by the rows that did go.
+      setNotice(
+        failed.length === 0
+          ? null
+          : `${count(erased.length, 'consultation')} erased. ${count(failed.length, 'other')} could not be, and may already have been erased elsewhere.`,
+      )
+      return queryClient.invalidateQueries({ queryKey: ['consultations'] })
+    },
+  })
+
+  const toggle = (id: string) =>
+    setPicked((current) => {
+      const next = new Set(current)
+      if (!next.delete(id)) next.add(id)
+      return next
+    })
 
   return (
     <div className="mx-auto max-w-4xl">
@@ -50,7 +108,61 @@ export function ConsultationList() {
         }
       />
 
-      <div data-tour="consultation-list" className="mt-8 flex flex-col gap-2">
+      {notice && (
+        <p
+          role="status"
+          className="mt-6 rounded-card border border-urgent/40 bg-urgent/8 px-4 py-3 text-sm text-ink"
+        >
+          {notice}
+        </p>
+      )}
+
+      {consultations.length > 0 && (
+        <div
+          data-print="hide"
+          className="mt-8 flex min-h-9 items-center justify-between gap-4 border-b border-line pb-3"
+        >
+          <label className="flex cursor-pointer items-center gap-3 text-sm text-ink-muted">
+            <input
+              type="checkbox"
+              className={CHECKBOX}
+              checked={allSelected}
+              // A DOM property rather than an attribute: there is no
+              // `indeterminate` in HTML, only on the element.
+              ref={(el) => {
+                if (el) el.indeterminate = selected.length > 0 && !allSelected
+              }}
+              onChange={() =>
+                setPicked(allSelected ? new Set() : new Set(consultations.map((c) => c.id)))
+              }
+            />
+            <span aria-live="polite">
+              {selected.length === 0 ? 'Select all' : `${selected.length} selected`}
+            </span>
+          </label>
+
+          {selected.length > 0 && (
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="ghost" onClick={() => setPicked(new Set())}>
+                Clear
+              </Button>
+              <Button
+                size="sm"
+                variant="danger"
+                icon={<Trash2 aria-hidden className="size-3.5" />}
+                onClick={() => {
+                  erase.reset()
+                  dialog.current?.showModal()
+                }}
+              >
+                Erase {selected.length}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div data-tour="consultation-list" className="mt-4 flex flex-col gap-2">
         {isPending &&
           [0, 1, 2].map((key) => <Skeleton key={key} className="h-18 w-full rounded-card" />)}
 
@@ -69,32 +181,150 @@ export function ConsultationList() {
           />
         )}
 
-        {data?.map((consultation) => {
+        {consultations.map((consultation) => {
           const status = STATUS[consultation.status]
+          const when = formatDate(consultation.createdAt)
           return (
-            <Link
+            <div
               key={consultation.id}
-              to={`/consultations/${consultation.id}`}
-              className="flex items-center justify-between gap-4 rounded-card border border-line bg-surface px-4 py-4 transition-colors hover:border-ink-muted/50"
+              className={cn(
+                'flex items-center gap-3 rounded-card border bg-surface pl-4 transition-colors',
+                picked.has(consultation.id)
+                  ? 'border-accent/50 bg-accent/4'
+                  : 'border-line hover:border-ink-muted/50',
+              )}
             >
-              <div className="min-w-0">
-                <p className="truncate text-sm font-medium">{formatDate(consultation.createdAt)}</p>
-                <p className="mt-0.5 font-mono text-2xs text-ink-muted">
-                  {consultation.id.slice(0, 8)}
-                </p>
-              </div>
-              <span
-                className={cn(
-                  'shrink-0 rounded-full border px-2.5 py-1 text-2xs font-medium',
-                  status.className,
-                )}
+              {/* A sibling of the link, never a child of it: a control nested
+                  inside an anchor is not reachable as its own target. */}
+              <input
+                type="checkbox"
+                data-print="hide"
+                className={CHECKBOX}
+                checked={picked.has(consultation.id)}
+                onChange={() => toggle(consultation.id)}
+                aria-label={`Select consultation from ${when}`}
+              />
+              <Link
+                to={`/consultations/${consultation.id}`}
+                className="flex min-w-0 flex-1 items-center justify-between gap-4 py-4 pr-4"
               >
-                {status.label}
-              </span>
-            </Link>
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{when}</p>
+                  <p className="mt-0.5 font-mono text-2xs text-ink-muted">
+                    {consultation.id.slice(0, 8)}
+                  </p>
+                </div>
+                <span
+                  className={cn(
+                    'shrink-0 rounded-full border px-2.5 py-1 text-2xs font-medium',
+                    status.className,
+                  )}
+                >
+                  {status.label}
+                </span>
+              </Link>
+            </div>
           )
         })}
       </div>
+
+      <EraseDialog
+        ref={dialog}
+        selected={selected}
+        pending={erase.isPending}
+        error={erase.error}
+        onConfirm={() => erase.mutate()}
+      />
     </div>
+  )
+}
+
+/**
+ * The confirmation, and the one place the system is honest about what erasure
+ * actually is.
+ *
+ * It says "erased", not "deleted", because the row does not go.
+ * `eraseConsultation` nulls the clinical columns and stamps `erasedAt`, while
+ * the audit chain that references the consultation stays intact. Calling that a
+ * delete would be a comfortable lie in a product whose whole claim is a
+ * tamper-evident record.
+ *
+ * The status breakdown exists so the weight of the selection is visible at the
+ * moment of the decision. Approved notes are erasable, which is deliberate and
+ * follows docs/dpia.md: erasure serves a data-subject right that does not lapse
+ * because a doctor signed the note. But a doctor about to erase one should not
+ * discover that afterwards.
+ *
+ * A native <dialog>, for the same reason as the tour's: focus trapping, Escape
+ * and inertness of the page behind it, none of them hand-rolled.
+ */
+function EraseDialog({
+  ref,
+  selected,
+  pending,
+  error,
+  onConfirm,
+}: {
+  ref: React.Ref<HTMLDialogElement>
+  selected: ConsultationListItem[]
+  pending: boolean
+  error: unknown
+  onConfirm: () => void
+}) {
+  // Ordered by `STATUS`, so the heaviest line lands last.
+  const breakdown = (Object.keys(STATUS) as ConsultationStatus[])
+    .map((status) => ({ status, n: selected.filter((c) => c.status === status).length }))
+    .filter(({ n }) => n > 0)
+
+  const close = () => (ref as React.RefObject<HTMLDialogElement | null>).current?.close()
+
+  return (
+    <dialog
+      ref={ref}
+      data-print="hide"
+      aria-labelledby="erase-title"
+      className="m-auto w-[26rem] max-w-[calc(100vw-2rem)] rounded-card border border-line bg-surface p-0 text-ink backdrop:bg-scrim backdrop:backdrop-blur-sm"
+    >
+      <div className="p-6">
+        <h2 id="erase-title" className="text-lg font-semibold">
+          Erase {count(selected.length, 'consultation')}?
+        </h2>
+
+        <ul className="mt-4 flex flex-col gap-1 text-sm">
+          {breakdown.map(({ status, n }) => (
+            <li
+              key={status}
+              // Approved is the line that changes the decision, so it is the one
+              // that is coloured. It still says the word, because colour is
+              // never the only carrier of a meaning here (issue #30).
+              className={status === 'approved' ? 'font-medium text-urgent' : 'text-ink-muted'}
+            >
+              {n} {n === 1 ? ERASE_NOUN[status].one : ERASE_NOUN[status].many}
+            </li>
+          ))}
+        </ul>
+
+        <p className="mt-4 text-sm leading-relaxed text-ink-muted">
+          The transcript, analysis and edited note are permanently erased. A tamper-evident audit
+          record that the consultation existed and was erased is retained, and cannot be removed.
+        </p>
+        <p className="mt-2 text-sm font-medium">This cannot be undone.</p>
+
+        {error != null && (
+          <p role="alert" className="mt-3 text-sm text-emergency">
+            {error instanceof ApiError ? error.message : 'Nothing was erased. Please try again.'}
+          </p>
+        )}
+
+        <div className="mt-6 flex justify-end gap-2">
+          <Button onClick={close} disabled={pending}>
+            Cancel
+          </Button>
+          <Button variant="danger" loading={pending} onClick={onConfirm}>
+            Erase {selected.length}
+          </Button>
+        </div>
+      </div>
+    </dialog>
   )
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -484,6 +484,38 @@ export const ConsultationListItemSchema = ConsultationSchema.pick({
 })
 
 /**
+ * How many consultations one erase request may carry.
+ *
+ * The handler erases sequentially rather than concurrently, because every
+ * erasure appends to the audit hash chain and `AuditEvent.prevHash` is unique
+ * precisely so two concurrent appends cannot silently fork it. A batch is
+ * therefore a serial run of transactions, and this bound is what keeps its
+ * duration predictable.
+ *
+ * `GET /api/consultations` is unpaginated, so a doctor holding more than this
+ * many cannot clear them in a single gesture. That is a known edge of the
+ * missing pagination rather than of erasure, and it fails loudly at validation
+ * instead of silently erasing a prefix of the selection.
+ */
+export const ERASE_BATCH_LIMIT = 100
+
+export const EraseConsultationsInputSchema = z.object({
+  ids: z.array(z.string().min(1)).min(1).max(ERASE_BATCH_LIMIT),
+})
+
+/**
+ * Partial success is a real outcome here, so it is in the contract rather than
+ * collapsed into a status code. An id lands in `failed` when the ownership gate
+ * refuses it, which covers both "not this doctor's" and "already erased" and
+ * deliberately does not distinguish them, for the same reason
+ * `assertOwnedConsultation` returns 404 rather than 403.
+ */
+export const EraseConsultationsResultSchema = z.object({
+  erased: z.array(z.string()),
+  failed: z.array(z.string()),
+})
+
+/**
  * What a doctor decided about a red flag or a gap.
  *
  * Three states rather than a boolean, because "I have seen this and it is
@@ -628,6 +660,8 @@ export type SuggestionsAndRedFlagsResponse = z.infer<
 >
 export type ConsultationListItem = z.infer<typeof ConsultationListItemSchema>
 export type ConsultationDetail = z.infer<typeof ConsultationDetailSchema>
+export type EraseConsultationsInput = z.infer<typeof EraseConsultationsInputSchema>
+export type EraseConsultationsResult = z.infer<typeof EraseConsultationsResultSchema>
 export type ErrorEnvelope = z.infer<typeof ErrorEnvelopeSchema>
 export type Fixture = z.infer<typeof FixtureSchema>
 export type GuidelineChunk = z.infer<typeof GuidelineChunkSchema>


### PR DESCRIPTION
## What Changed

`/consultations` gained per-row checkboxes, a select-all with a correct indeterminate state, and a confirmed bulk erase. `POST /api/consultations/erase` is the first HTTP caller `eraseConsultation()` has ever had.

Closes #114

## Why

The list was read-only, so a demo account filled up with no way to tidy it.

**Erasure is a tombstone, not a row delete, and that is not a shortcut.** `AuditEvent.consultationId` is `onDelete: Restrict` because it is a hash-chain input (#64); removing the row would orphan its audit events and break tamper evidence. The clinical content goes, the record that a consultation existed and was erased stays.

Any status is erasable, approved included. `docs/dpia.md` frames erasure as serving a data-subject right that does not lapse because a doctor signed the note, so the weight is carried by a confirmation that counts approved notes rather than by refusing.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — 419 passing, up from 412
- [x] Manually exercised the affected flow, against a local Postgres rather than the shared instance

Seven tests added in `backend/src/routes/consultations.test.ts`: the erased-vanish-from-list contract, approved-is-erasable, another doctor's id reported as failed while the rest still erase, one audit event per consultation actually erased, an unexpected database fault surfacing as 500 rather than a tidy per-id failure, and both validation bounds.

Exercised in the browser on a local database, then checked in Postgres:

- All five rows retained, three tombstoned with `transcript`, `analysis` and `editedNote` null, two untouched
- **`verifyAuditChainFromDatabase()` returns `{"ok":true,"verified":7}` after the erasure**
- A guest erasing another doctor's consultation gets `failed`, and the row is untouched, indistinguishable from one that does not exist
- Partial success: `{"erased":["demo-await-1"],"failed":["demo-draft-1","not-a-real-id"]}`
- Empty selection and 101 ids both 400

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider — this route makes no model call
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model — `redflags/` untouched
- [x] Citations remain ID-constrained; no free-text references accepted
- [x] No transcript bodies, note contents, or vault entries written to logs — audit rows carry the action and the consultation id only
- [x] Fixtures added are synthetic — none added

## Notes For The Reviewer

**The batch is sequential on purpose.** Every erasure appends to the audit chain, `prevHash` is unique precisely so two concurrent appends cannot fork it, and `recordAuditEvent` retries a head race only three times. A `Promise.all` over a selection would exhaust that and fail rows for a reason unrelated to the request. That is also why the batch is bounded at 100 and why this is a collection-level `POST /erase` rather than `DELETE /:id`: one gesture should cost one rate-limit token, not N.

**The failed/erased split reports the ownership gate's 404 and nothing else.** A real database fault rethrows as a 500, because folding it into `failed` would render in the UI as a routine skip, so a write that broke would look like a row already gone.

Known bound, not introduced here: `GET /api/consultations` is unpaginated, so a doctor holding more than 100 cannot clear them in one gesture. It fails loudly at validation rather than silently erasing a prefix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Select one or more consultations from the consultation list and erase them in bulk.
  - Review a confirmation dialog showing selected records, status-specific counts, and irreversible-action messaging.
  - See which records were erased and which could not be processed when an operation has partial results.
  - The list refreshes automatically after erasure, with clearer selection controls and visual feedback.

- **Bug Fixes**
  - Improved handling for unauthorized, already-erased, invalid, or failed consultation erasure requests.
  - Added safeguards against excessive erase requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->