### PR TITLE
feat(shell): add a notification centre, account menu and sign out

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -14,10 +14,16 @@ import { requireSession } from './middleware/require-session.js'
 import { authRouter } from './routes/auth.js'
 import { consultationsRouter } from './routes/consultations.js'
 import { healthRouter } from './routes/health.js'
+import { notificationsRouter } from './routes/notifications.js'
 import { referenceRouter } from './routes/reference.js'
 
 /** Routes that carry clinical data. Everything here requires a session. */
-const PROTECTED_PREFIXES = ['/api/consultations', '/api/fixtures', '/api/guidelines']
+const PROTECTED_PREFIXES = [
+  '/api/consultations',
+  '/api/fixtures',
+  '/api/guidelines',
+  '/api/notifications',
+]
 
 export function createApp() {
   const app = express()
@@ -63,6 +69,7 @@ export function createApp() {
   // stay above `errorHandler` — an error handler registered before a router
   // never sees that router's errors.
   app.use('/api', referenceRouter)
+  app.use('/api', notificationsRouter)
   app.use('/api/consultations', consultationsRouter)
 
   app.use(errorHandler)

--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import type { DispositionState } from '@shared/types'
+import { type DispositionState, NotificationActionSchema } from '@shared/types'
 import type { ProfileId } from '../clinical-profiles/index.js'
 import type { ActiveClinicalVersions } from '../clinical-versions/index.js'
 import { prisma } from '../lib/prisma.js'
@@ -248,5 +248,26 @@ export async function getAuditHistory(consultationId: string) {
     where: { consultationId },
     orderBy: { createdAt: 'asc' },
     select: { id: true, action: true, metadata: true, actorId: true, createdAt: true },
+  })
+}
+
+/**
+ * The recent notifiable events for one actor, newest first (issue #116).
+ *
+ * Scoped on `actorId` in the query rather than filtered afterwards, so there is
+ * no shape of this function that reads another doctor's events into memory
+ * first. `@@index([actorId, createdAt])` already covers the access path.
+ *
+ * `metadata` is deliberately not selected. It is the one audit column that
+ * could ever carry something richer than a label, and a feed rendered in the
+ * chrome of every screen is the last place that should be the first consumer of
+ * it.
+ */
+export async function getActorNotifications(actorId: string, limit: number) {
+  return prisma.auditEvent.findMany({
+    where: { actorId, action: { in: NotificationActionSchema.options } },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+    select: { id: true, action: true, consultationId: true, createdAt: true },
   })
 }

--- a/backend/src/routes/notifications.test.ts
+++ b/backend/src/routes/notifications.test.ts
@@ -1,0 +1,175 @@
+import { readFileSync } from 'node:fs'
+import type { Server } from 'node:http'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The notification feed is a read over `AuditEvent`, so the properties worth
+ * pinning are the ones that stop it becoming a second, looser way to read that
+ * table: it must be scoped to the caller in the query, it must expose only the
+ * four notifiable actions, and it must never carry `metadata`.
+ */
+type Row = {
+  id: string
+  action: string
+  actorId: string
+  consultationId: string | null
+  createdAt: Date
+  metadata?: unknown
+}
+
+const rows: Row[] = []
+
+vi.mock('../middleware/require-session.js', () => ({
+  requireSession: (req: { doctorId?: string }, _res: unknown, next: () => void) => {
+    req.doctorId = 'doctor-1'
+    next()
+  },
+}))
+
+vi.mock('../lib/prisma.js', () => ({
+  prisma: {
+    auditEvent: {
+      findMany: vi.fn(
+        async ({
+          where,
+          take,
+          select,
+        }: {
+          where: { actorId: string; action: { in: string[] } }
+          take: number
+          select: Record<string, boolean>
+        }) => {
+          const matched = rows
+            .filter((r) => r.actorId === where.actorId && where.action.in.includes(r.action))
+            .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+            .slice(0, take)
+          // Mirrors Prisma's `select`, so a column the route never asked for
+          // cannot reach the assertion by way of a too-generous stub.
+          return matched.map((r) =>
+            Object.fromEntries(Object.keys(select).map((k) => [k, r[k as keyof Row]])),
+          )
+        },
+      ),
+    },
+  },
+}))
+
+let server: Server
+let origin: string
+
+beforeAll(async () => {
+  const { createApp } = await import('../app.js')
+  server = createApp().listen(0)
+  await new Promise((r) => server.once('listening', r))
+  const addr = server.address()
+  if (typeof addr === 'string' || addr === null) throw new Error('no port')
+  origin = `http://127.0.0.1:${addr.port}`
+})
+
+afterAll(() => server.close())
+
+beforeEach(() => {
+  rows.length = 0
+})
+
+let clock = 0
+function seed(action: string, extra: Partial<Row> = {}) {
+  clock += 1000
+  rows.push({
+    id: `e${rows.length}`,
+    action,
+    actorId: 'doctor-1',
+    consultationId: 'c1',
+    createdAt: new Date(clock),
+    ...extra,
+  })
+}
+
+const feed = async () => {
+  const res = await fetch(`${origin}/api/notifications`)
+  return { status: res.status, body: (await res.json()) as { notifications: Row[] } }
+}
+
+describe('notification feed', () => {
+  it("never returns another doctor's events", async () => {
+    seed('consultation.approved', { actorId: 'doctor-2', id: 'theirs' })
+    seed('consultation.approved', { id: 'mine' })
+
+    const { body } = await feed()
+
+    expect(body.notifications.map((n) => n.id)).toEqual(['mine'])
+  })
+
+  it('returns only the four notifiable actions', async () => {
+    // The noisy half of the taxonomy. A feed carrying these is a log, and it is
+    // also a much larger surface to have to keep free of clinical text.
+    for (const action of [
+      'consultation.created',
+      'consultation.analysis_started',
+      'consultation.edited',
+      'redflag.disposition_set',
+      'gap.reviewed',
+    ]) {
+      seed(action)
+    }
+    seed('consultation.analysis_completed')
+    seed('consultation.analysis_failed')
+    seed('consultation.approved')
+    seed('consultation.erased')
+
+    const { body } = await feed()
+
+    expect(body.notifications.map((n) => n.action).sort()).toEqual([
+      'consultation.analysis_completed',
+      'consultation.analysis_failed',
+      'consultation.approved',
+      'consultation.erased',
+    ])
+  })
+
+  it('orders newest first', async () => {
+    seed('consultation.approved', { id: 'older' })
+    seed('consultation.erased', { id: 'newer' })
+
+    const { body } = await feed()
+
+    expect(body.notifications.map((n) => n.id)).toEqual(['newer', 'older'])
+  })
+
+  it('never carries audit metadata', async () => {
+    // `metadata` holds detector labels today, and is the one audit column that
+    // could ever carry more than a label. Chrome rendered on every screen must
+    // not be the first thing to read it.
+    seed('consultation.analysis_completed', { metadata: { detectorLabels: ['NRIC'] } })
+
+    const { body } = await feed()
+
+    expect(body.notifications[0]).not.toHaveProperty('metadata')
+    expect(JSON.stringify(body)).not.toContain('NRIC')
+  })
+
+  it('caps the feed at the shared limit', async () => {
+    const { NOTIFICATION_FEED_LIMIT } = await import('@shared/types')
+    for (let i = 0; i < NOTIFICATION_FEED_LIMIT + 5; i += 1) seed('consultation.approved')
+
+    const { body } = await feed()
+
+    expect(body.notifications).toHaveLength(NOTIFICATION_FEED_LIMIT)
+  })
+})
+
+describe('route protection', () => {
+  it('mounts /api/notifications under a session-guarded prefix', () => {
+    // Authentication in this app is per-prefix, not global, so a new top-level
+    // prefix is unauthenticated by default. That failure mode is silent and
+    // this feed reads the audit log, so it is pinned in source rather than left
+    // to a reviewer noticing.
+    const app = readFileSync(new URL('../app.ts', import.meta.url), 'utf8')
+    const prefixes = app.slice(
+      app.indexOf('const PROTECTED_PREFIXES'),
+      app.indexOf('export function createApp'),
+    )
+
+    expect(prefixes).toContain("'/api/notifications'")
+  })
+})

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -1,0 +1,36 @@
+import { NOTIFICATION_FEED_LIMIT, NotificationItemSchema } from '@shared/types'
+import { Router } from 'express'
+import { z } from 'zod'
+import { getActorNotifications } from '../audit/index.js'
+import { HttpError } from '../lib/http-error.js'
+
+export const notificationsRouter = Router()
+
+/** `req.doctorId` is set by `requireSession`, which guards this prefix. */
+function doctorId(req: { doctorId?: string }): string {
+  if (!req.doctorId) throw new HttpError(401, 'unauthenticated', 'Sign in to continue.')
+  return req.doctorId
+}
+
+const FeedEnvelope = z.object({ notifications: z.array(NotificationItemSchema) })
+
+/**
+ * What this doctor has finished recently (issue #116).
+ *
+ * A read over `AuditEvent`, not a table of its own. That log is already a
+ * per-actor append-only stream whose rows carry an id and a member of a closed
+ * action enum, so a feed built on it cannot carry clinical text: the constraint
+ * is structural rather than a rule this route has to remember.
+ *
+ * There is no unread state here on purpose. Persisting one would mean either a
+ * migration or a second `localStorage` key, and the badge is worth neither; the
+ * client counts what arrived since it last opened the panel.
+ */
+notificationsRouter.get('/notifications', async (req, res) => {
+  const rows = await getActorNotifications(doctorId(req), NOTIFICATION_FEED_LIMIT)
+
+  // Parsed on the way out like every other response. It also pins the promise
+  // above: anything that ever appeared in `metadata` would fail here rather
+  // than reach a client.
+  res.json(FeedEnvelope.parse({ notifications: rows }))
+})

--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,7 @@
         "lucide-react": "^0.545.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-hot-toast": "2.6.0",
         "react-router-dom": "^7.9.3",
         "tailwind-merge": "^3.3.1",
         "zod": "^4.1.13",
@@ -802,6 +803,8 @@
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
+    "goober": ["goober@2.1.19", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -1021,6 +1024,8 @@
     "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
     "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
+    "react-hot-toast": ["react-hot-toast@2.6.0", "", { "dependencies": { "csstype": "^3.1.3", "goober": "^2.1.16" }, "peerDependencies": { "react": ">=16", "react-dom": ">=16" } }, "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "lucide-react": "^0.545.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-hot-toast": "2.6.0",
     "react-router-dom": "^7.9.3",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.1.13"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { Privacy } from './routes/Privacy.js'
 import { AppShell } from './shell/AppShell.js'
 import { MarketingShell } from './shell/MarketingShell.js'
 import { Skeleton } from './ui/Card.js'
+import { Toaster } from './ui/Toaster.js'
 
 function RequireSession({ children }: { children: ReactNode }) {
   const session = useQuery({ queryKey: ['session'], queryFn: api.session, retry: false })
@@ -30,6 +31,9 @@ function RequireSession({ children }: { children: ReactNode }) {
 export function App() {
   return (
     <BrowserRouter>
+      {/* Outside <Routes> so a toast raised during a navigation is not
+          unmounted by the navigation that raised it. */}
+      <Toaster />
       <Routes>
         {/* Login is deliberately outside the marketing shell: it is a
             full-height split with its own brand pane, and a topbar and footer

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,6 +13,8 @@ import {
   FixtureSchema,
   type GuidelineChunk,
   GuidelineChunkSchema,
+  type NotificationItem,
+  NotificationItemSchema,
   type SoapNote,
   type Transcript,
 } from '@shared/types'
@@ -71,6 +73,7 @@ const ConsultationEnvelope = z.object({ consultation: ConsultationDetailSchema }
 const ListEnvelope = z.object({ consultations: z.array(ConsultationListItemSchema) })
 const FixturesEnvelope = z.object({ fixtures: z.array(FixtureSchema) })
 const GuidelinesEnvelope = z.object({ guidelines: z.array(GuidelineChunkSchema) })
+const NotificationsEnvelope = z.object({ notifications: z.array(NotificationItemSchema) })
 
 /**
  * Audit events, read only for the provenance stamp on the review screen.
@@ -197,6 +200,13 @@ export const api = {
 
   fixtures: (): Promise<Fixture[]> =>
     request('/fixtures', FixturesEnvelope).then((r) => r.fixtures),
+
+  /**
+   * The doctor's own recent completed work, derived from `AuditEvent` (#116).
+   * Carries an id, an action enum and a consultation id, never free text.
+   */
+  notifications: (): Promise<NotificationItem[]> =>
+    request('/notifications', NotificationsEnvelope).then((r) => r.notifications),
 
   guidelines: (): Promise<GuidelineChunk[]> =>
     request('/guidelines', GuidelinesEnvelope).then((r) => r.guidelines),

--- a/frontend/src/routes/ConsultationList.tsx
+++ b/frontend/src/routes/ConsultationList.tsx
@@ -2,6 +2,7 @@ import type { ConsultationListItem, ConsultationStatus } from '@shared/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Plus, Trash2 } from 'lucide-react'
 import { useRef, useState } from 'react'
+import toast from 'react-hot-toast'
 import { Link } from 'react-router-dom'
 import { ApiError, api } from '../lib/api.js'
 import { cn } from '../lib/cn.js'
@@ -55,7 +56,6 @@ export function ConsultationList() {
     queryFn: api.listConsultations,
   })
   const [picked, setPicked] = useState<ReadonlySet<string>>(new Set())
-  const [notice, setNotice] = useState<string | null>(null)
   const dialog = useRef<HTMLDialogElement>(null)
 
   const consultations = data ?? []
@@ -72,14 +72,17 @@ export function ConsultationList() {
     onSuccess: ({ erased, failed }) => {
       dialog.current?.close()
       setPicked(new Set())
-      // Silent on a clean run: the rows disappearing is the confirmation, and a
-      // message saying so would be noise. A partial failure is the opposite and
-      // must never be swallowed by the rows that did go.
-      setNotice(
-        failed.length === 0
-          ? null
-          : `${count(erased.length, 'consultation')} erased. ${count(failed.length, 'other')} could not be, and may already have been erased elsewhere.`,
-      )
+      // A partial failure is an error even though the request succeeded, and it
+      // gets the longer error duration, because "some of what you asked for did
+      // not happen" is the one outcome here a doctor may need to act on.
+      if (failed.length > 0) {
+        toast.error(
+          `${count(erased.length, 'consultation')} erased. ${count(failed.length, 'other')} could not be, and may already have been erased elsewhere.`,
+        )
+      } else {
+        toast.success(`${count(erased.length, 'consultation')} erased.`)
+      }
+      void queryClient.invalidateQueries({ queryKey: ['notifications'] })
       return queryClient.invalidateQueries({ queryKey: ['consultations'] })
     },
   })
@@ -107,15 +110,6 @@ export function ConsultationList() {
           </Link>
         }
       />
-
-      {notice && (
-        <p
-          role="status"
-          className="mt-6 rounded-card border border-urgent/40 bg-urgent/8 px-4 py-3 text-sm text-ink"
-        >
-          {notice}
-        </p>
-      )}
 
       {consultations.length > 0 && (
         <div

--- a/frontend/src/routes/ConsultationReview.tsx
+++ b/frontend/src/routes/ConsultationReview.tsx
@@ -8,6 +8,7 @@ import type {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Printer, Sparkles } from 'lucide-react'
 import { useState } from 'react'
+import toast from 'react-hot-toast'
 import { Link, Navigate, useParams } from 'react-router-dom'
 import { DEMO_CONSULTATION_ID, useDemoTour } from '../demo/DemoTour.js'
 import { ApiError, api } from '../lib/api.js'
@@ -69,6 +70,19 @@ export function ConsultationReview() {
   const invalidate = (next: ConsultationDetail) => {
     queryClient.setQueryData(['consultation', id], next)
     void queryClient.invalidateQueries({ queryKey: ['consultations'] })
+    // Approval and a completed analysis both write notifiable audit rows, so
+    // the bell has to be told the feed it is holding is stale (#116).
+    void queryClient.invalidateQueries({ queryKey: ['notifications'] })
+  }
+
+  /**
+   * Only on the stored path. Demo Mode approves in memory and persists nothing
+   * (#80), so a toast reading "approved" there would claim a record exists that
+   * does not.
+   */
+  const onApproved = (next: ConsultationDetail) => {
+    invalidate(next)
+    toast.success('Note approved. This record is now final.')
   }
 
   const analyze = useMutation({ mutationFn: () => api.analyze(id), onSuccess: invalidate })
@@ -381,7 +395,7 @@ export function ConsultationReview() {
           approvedAt={detail.approvedAt}
           approvedBy={detail.approvedBy}
           unacknowledgedCount={unacknowledged.length}
-          onApproved={isEphemeral ? tour.updateEphemeral : invalidate}
+          onApproved={isEphemeral ? tour.updateEphemeral : onApproved}
         />
       )}
     </div>

--- a/frontend/src/shell/AppShell.tsx
+++ b/frontend/src/shell/AppShell.tsx
@@ -6,6 +6,7 @@ import { HelpButton } from '../demo/HelpButton.js'
 import { Spotlight } from '../demo/Spotlight.js'
 import { cn } from '../lib/cn.js'
 import { CursorGlow } from '../ui/CursorGlow.js'
+import { ChromeCluster } from './ChromeCluster.js'
 import { LiveDataWarning } from './LiveDataWarning.js'
 import { MobileDock } from './MobileDock.js'
 import { SidebarIsland } from './SidebarIsland.js'
@@ -69,6 +70,7 @@ export function AppShell() {
             the sidebar and the scrim, and a coachmark clipped by the surface it
             is pointing at would defeat itself. */}
         <LiveDataWarning />
+        <ChromeCluster />
         <HelpButton />
         <DemoStepBar />
         <Spotlight />

--- a/frontend/src/shell/ChromeCluster.tsx
+++ b/frontend/src/shell/ChromeCluster.tsx
@@ -1,0 +1,127 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Bell, LogOut, Moon, Sun, UserRound } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api } from '../lib/api.js'
+import { useTheme } from '../lib/theme.js'
+import { Button } from '../ui/Button.js'
+import { Dropover } from './Dropover.js'
+import { NotificationPanel } from './NotificationPanel.js'
+
+/**
+ * The signed-in chrome that is not navigation: theme, notifications, account
+ * (issue #116).
+ *
+ * One cluster rather than three floating buttons. They are a single group to a
+ * keyboard user, a single thing to hide when printing, and a single surface to
+ * keep clear of the tour FAB in the opposite corner. Three separate circles
+ * would also have read as three primary actions, which is what a FAB means and
+ * none of these are.
+ *
+ * The theme control moved here from `SidebarIsland` and `MobileDock` rather
+ * than being added alongside them: two switches for one setting is a bug that
+ * takes a while to notice.
+ *
+ * The top offset is driven by `--live-banner-inset`, which only the dev-only
+ * live-data banner ever sets. Production never defines it, so the fallback of
+ * zero is what ships, and this file needs no knowledge of that banner.
+ */
+export function ChromeCluster() {
+  const { resolved, setPreference } = useTheme()
+  const [seenAt, setSeenAt] = useState<number | null>(null)
+
+  const notifications = useQuery({
+    queryKey: ['notifications'],
+    queryFn: api.notifications,
+    retry: false,
+  })
+
+  // Everything is unread until the panel has been opened once this session.
+  // A bell that starts empty on every load is a bell with nothing to say.
+  const unread = (notifications.data ?? []).filter(
+    (item) => seenAt === null || item.createdAt.getTime() > seenAt,
+  ).length
+
+  const markSeen = useCallback(() => setSeenAt(Date.now()), [])
+
+  return (
+    <div
+      data-print="hide"
+      style={{ zIndex: 'var(--z-sidebar)', top: 'calc(0.75rem + var(--live-banner-inset, 0px))' }}
+      className="glass fixed right-4 flex items-center gap-1 rounded-float p-1.5 md:right-6"
+    >
+      <button
+        type="button"
+        onClick={() => setPreference(resolved === 'dark' ? 'light' : 'dark')}
+        aria-label={resolved === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+        title={resolved === 'dark' ? 'Light Theme' : 'Dark Theme'}
+        className="flex size-9 items-center justify-center rounded-control text-ink-muted transition-colors duration-150 hover:bg-sunken/60 hover:text-ink"
+      >
+        {resolved === 'dark' ? (
+          <Sun aria-hidden className="size-4.5" />
+        ) : (
+          <Moon aria-hidden className="size-4.5" />
+        )}
+      </button>
+
+      <Dropover
+        label={unread > 0 ? `Notifications, ${unread} new` : 'Notifications'}
+        icon={<Bell aria-hidden className="size-4.5" />}
+        badge={unread}
+      >
+        {(close) => <NotificationPanel onSeen={markSeen} close={close} />}
+      </Dropover>
+
+      <Dropover label="Account" icon={<UserRound aria-hidden className="size-4.5" />}>
+        {() => <AccountPanel />}
+      </Dropover>
+    </div>
+  )
+}
+
+function AccountPanel() {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const session = useQuery({ queryKey: ['session'], queryFn: api.session, retry: false })
+
+  const signOut = useMutation({
+    mutationFn: api.signOut,
+    onSuccess: async () => {
+      // Cleared, not just invalidated. The cache holds consultations, notes and
+      // analyses; leaving them in memory for whoever signs in next on this
+      // device would undo the sign-out it is meant to complete.
+      queryClient.clear()
+      await navigate('/login')
+    },
+  })
+
+  return (
+    <div className="p-4">
+      {session.data?.user ? (
+        <>
+          <p className="truncate text-sm font-medium">{session.data.user.name}</p>
+          <p className="mt-0.5 truncate text-2xs text-ink-muted">{session.data.user.email}</p>
+        </>
+      ) : (
+        <p className="text-sm text-ink-muted">Signed in.</p>
+      )}
+
+      <Button
+        size="sm"
+        variant="secondary"
+        icon={<LogOut aria-hidden className="size-3.5" />}
+        loading={signOut.isPending}
+        onClick={() => signOut.mutate()}
+        className="mt-4 w-full"
+      >
+        Sign Out
+      </Button>
+
+      {signOut.error != null && (
+        <p role="alert" className="mt-2 text-2xs text-emergency">
+          Sign out failed. Please try again.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/shell/Dropover.tsx
+++ b/frontend/src/shell/Dropover.tsx
@@ -1,0 +1,108 @@
+import { type ReactNode, useEffect, useId, useRef, useState } from 'react'
+import { cn } from '../lib/cn.js'
+
+/**
+ * A button in the chrome cluster and the panel it opens (issue #116).
+ *
+ * Hand-rolled for the same reason `ui/Select.tsx` is: nothing in this codebase
+ * uses a headless UI library, and two controls are a poor reason to introduce
+ * one. The dismissal behaviour is deliberately identical to that file's, so the
+ * two feel like one system rather than two hand-rolls.
+ *
+ * No `role="menu"`. One of these holds a list of notifications and the other
+ * holds a heading and a button, and neither is a menu of commands; claiming the
+ * role would promise arrow-key semantics that are not implemented. The trigger
+ * carries `aria-expanded` and the panel is labelled, which is what is actually
+ * true.
+ */
+export function Dropover({
+  label,
+  icon,
+  badge,
+  align = 'right',
+  children,
+}: {
+  label: string
+  icon: ReactNode
+  /** Rendered as a count on the trigger. Omitted entirely when zero. */
+  badge?: number
+  align?: 'left' | 'right'
+  children: (close: () => void) => ReactNode
+}) {
+  const [open, setOpen] = useState(false)
+  const wrap = useRef<HTMLDivElement>(null)
+  const trigger = useRef<HTMLButtonElement>(null)
+  const panelId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      if (!wrap.current?.contains(event.target as Node)) setOpen(false)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      setOpen(false)
+      // Focus goes back to the button that opened it, never to the top of the
+      // document. Escape is a keyboard gesture and it should leave a keyboard
+      // user where they were.
+      trigger.current?.focus()
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  return (
+    <div ref={wrap} className="relative">
+      <button
+        ref={trigger}
+        type="button"
+        aria-label={label}
+        title={label}
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={() => setOpen((value) => !value)}
+        className={cn(
+          'relative flex size-9 items-center justify-center rounded-control transition-colors duration-150',
+          open ? 'bg-accent/12 text-accent' : 'text-ink-muted hover:bg-sunken/60 hover:text-ink',
+        )}
+      >
+        {icon}
+        {badge !== undefined && badge > 0 && (
+          <span
+            // The count is on the trigger's accessible name rather than only in
+            // this dot, so it is not a purely visual signal.
+            aria-hidden
+            className="absolute -top-0.5 -right-0.5 flex min-w-4 items-center justify-center rounded-pill bg-urgent px-1 text-[0.625rem] leading-4 font-semibold text-ink"
+          >
+            {badge > 9 ? '9+' : badge}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          id={panelId}
+          // No role and no name, deliberately. This is a disclosure: the named
+          // button sits immediately before the content it reveals and carries
+          // `aria-expanded`, so the panel is just content. Giving it `role=
+          // "menu"` would promise arrow-key semantics that are not implemented,
+          // and `role="group"` would be a name repeated from the trigger.
+          style={{ zIndex: 'var(--z-modal)' }}
+          className={cn(
+            // Opaque, not glass. docs/DESIGN.md reserves translucency for
+            // chrome, and the moment a panel carries a list a doctor reads, it
+            // is content sitting in chrome rather than chrome.
+            'absolute top-11 w-80 max-w-[calc(100vw-2rem)] rounded-card border border-line bg-surface shadow-raised',
+            align === 'right' ? 'right-0' : 'left-0',
+          )}
+        >
+          {children(() => setOpen(false))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/shell/LiveDataWarning.tsx
+++ b/frontend/src/shell/LiveDataWarning.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { AlertTriangle } from 'lucide-react'
+import { useEffect } from 'react'
 import { api } from '../lib/api.js'
 
 /**
@@ -35,6 +36,9 @@ export function LiveDataWarning() {
   return <LiveDataBanner />
 }
 
+/** `py-1.5` around a `text-xs` line, plus a small gap for what sits beneath. */
+const BANNER_HEIGHT = '2rem'
+
 function LiveDataBanner() {
   const health = useQuery({
     queryKey: ['health'],
@@ -43,9 +47,24 @@ function LiveDataBanner() {
     retry: false,
   })
 
+  const showing = health.data?.database === 'remote'
+
+  // Published as a custom property so fixed chrome can sit below this banner
+  // without importing anything from it, and without production paying for a
+  // dev-only concern: nothing sets this variable in a production build, so the
+  // fallback of zero is what ships (#116).
+  useEffect(() => {
+    if (!showing) return
+    const root = document.documentElement
+    root.style.setProperty('--live-banner-inset', BANNER_HEIGHT)
+    return () => {
+      root.style.removeProperty('--live-banner-inset')
+    }
+  }, [showing])
+
   // Anything other than an explicit `remote` is silence, including an error, a
   // pending fetch, and the absent field a production API returns.
-  if (health.data?.database !== 'remote') return null
+  if (!showing) return null
 
   return (
     <div

--- a/frontend/src/shell/MobileDock.tsx
+++ b/frontend/src/shell/MobileDock.tsx
@@ -1,7 +1,6 @@
 import { BookMarked, FileText, Plus } from 'lucide-react'
 import { NavLink } from 'react-router-dom'
 import { cn } from '../lib/cn.js'
-import { ThemeToggle } from '../ui/ThemeToggle.js'
 
 /**
  * The small-screen replacement for the sidebar island, not a squeezed version
@@ -44,7 +43,6 @@ export function MobileDock() {
           {label}
         </NavLink>
       ))}
-      <ThemeToggle className="flex-1" />
     </nav>
   )
 }

--- a/frontend/src/shell/NotificationPanel.tsx
+++ b/frontend/src/shell/NotificationPanel.tsx
@@ -1,0 +1,142 @@
+import type { NotificationAction, NotificationItem } from '@shared/types'
+import { useQuery } from '@tanstack/react-query'
+import { CheckCircle2, CircleAlert, Sparkles, Trash2 } from 'lucide-react'
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { api } from '../lib/api.js'
+import { Skeleton } from '../ui/Card.js'
+
+/**
+ * How each notifiable audit action reads to a doctor.
+ *
+ * `linked: false` on `erased` is not cosmetic. The consultation is gone from
+ * every read path the moment it is tombstoned, so a link would take someone to
+ * a 404 they cannot act on. A notification that leads nowhere useful is worse
+ * than one that is plainly terminal.
+ */
+const SHAPE: Record<
+  NotificationAction,
+  { label: string; icon: typeof CheckCircle2; tone: string; linked: boolean }
+> = {
+  'consultation.analysis_completed': {
+    label: 'Analysis complete',
+    icon: Sparkles,
+    tone: 'text-accent',
+    linked: true,
+  },
+  'consultation.analysis_failed': {
+    label: 'Analysis failed',
+    icon: CircleAlert,
+    tone: 'text-emergency',
+    linked: true,
+  },
+  'consultation.approved': {
+    label: 'Note approved',
+    icon: CheckCircle2,
+    tone: 'text-accent',
+    linked: true,
+  },
+  'consultation.erased': {
+    label: 'Consultation erased',
+    icon: Trash2,
+    tone: 'text-ink-muted',
+    linked: false,
+  },
+}
+
+const UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ['day', 86_400_000],
+  ['hour', 3_600_000],
+  ['minute', 60_000],
+]
+
+const relative = new Intl.RelativeTimeFormat('en-MY', { numeric: 'auto' })
+
+function ago(value: Date) {
+  const elapsed = value.getTime() - Date.now()
+  for (const [unit, ms] of UNITS) {
+    if (Math.abs(elapsed) >= ms) return relative.format(Math.round(elapsed / ms), unit)
+  }
+  return 'just now'
+}
+
+export function NotificationPanel({ onSeen, close }: { onSeen: () => void; close: () => void }) {
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['notifications'],
+    queryFn: api.notifications,
+  })
+
+  // The panel is mounted only while it is open, so mounting *is* the doctor
+  // having looked. No separate open callback, and no state in the parent that
+  // can drift out of step with what is on screen.
+  useEffect(onSeen, [onSeen])
+
+  return (
+    <div className="flex max-h-96 flex-col">
+      <h2 className="border-b border-line px-4 py-3 text-sm font-semibold">Notifications</h2>
+
+      <div className="overflow-y-auto">
+        {isPending && (
+          <div className="flex flex-col gap-2 p-4">
+            {[0, 1, 2].map((key) => (
+              <Skeleton key={key} className="h-10 w-full rounded-control" />
+            ))}
+          </div>
+        )}
+
+        {isError && (
+          <p role="alert" className="px-4 py-6 text-center text-sm text-ink-muted">
+            Notifications could not be loaded.
+          </p>
+        )}
+
+        {data?.length === 0 && (
+          <p className="px-4 py-8 text-center text-sm text-ink-muted">
+            Nothing yet. Analysed, approved and erased consultations show up here.
+          </p>
+        )}
+
+        <ul>
+          {data?.map((item) => (
+            <NotificationRow key={item.id} item={item} close={close} />
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+function NotificationRow({ item, close }: { item: NotificationItem; close: () => void }) {
+  const { label, icon: Icon, tone, linked } = SHAPE[item.action]
+
+  const body = (
+    <>
+      <Icon aria-hidden className={`mt-0.5 size-4 shrink-0 ${tone}`} />
+      <span className="min-w-0">
+        <span className="block text-sm">{label}</span>
+        <span className="mt-0.5 block text-2xs text-ink-muted">
+          {ago(item.createdAt)}
+          {item.consultationId && (
+            <span className="font-mono"> · {item.consultationId.slice(0, 8)}</span>
+          )}
+        </span>
+      </span>
+    </>
+  )
+
+  return (
+    <li className="border-b border-line/60 last:border-0">
+      {linked && item.consultationId ? (
+        <Link
+          to={`/consultations/${item.consultationId}`}
+          onClick={close}
+          className="flex gap-3 px-4 py-3 transition-colors hover:bg-sunken"
+        >
+          {body}
+        </Link>
+      ) : (
+        <div className="flex gap-3 px-4 py-3">{body}</div>
+      )}
+    </li>
+  )
+}

--- a/frontend/src/shell/SidebarIsland.tsx
+++ b/frontend/src/shell/SidebarIsland.tsx
@@ -1,8 +1,7 @@
-import { BookMarked, FileText, Moon, PanelLeft, Plus, Sun } from 'lucide-react'
+import { BookMarked, FileText, PanelLeft, Plus } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { cn } from '../lib/cn.js'
-import { useTheme } from '../lib/theme.js'
 import { Mark } from '../ui/Mark.js'
 import { Wordmark } from '../ui/Wordmark.js'
 
@@ -46,7 +45,6 @@ export function SidebarIsland({
   const [focused, setFocused] = useState(false)
   const [pinned, setPinned] = useState(false)
   const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
-  const { resolved, setPreference } = useTheme()
 
   const expanded = pinned || hovered || focused
 
@@ -143,26 +141,6 @@ export function SidebarIsland({
       </ul>
 
       <div className="flex flex-col gap-1 border-t border-line/60 pt-2">
-        <button
-          type="button"
-          onClick={() => setPreference(resolved === 'dark' ? 'light' : 'dark')}
-          className="flex h-11 items-center gap-3 rounded-control px-3 text-sm font-medium text-ink-muted transition-colors duration-150 hover:bg-sunken/60 hover:text-ink"
-        >
-          {resolved === 'dark' ? (
-            <Sun aria-hidden className="size-5 shrink-0" />
-          ) : (
-            <Moon aria-hidden className="size-5 shrink-0" />
-          )}
-          <span
-            className={cn(
-              'whitespace-nowrap transition-opacity duration-150',
-              expanded ? 'opacity-100' : 'pointer-events-none opacity-0',
-            )}
-          >
-            {resolved === 'dark' ? 'Light Theme' : 'Dark Theme'}
-          </span>
-        </button>
-
         {/* Touch has no hover and a keyboard user should not have to hold
             focus to read a label. Pinning is the accessible equivalent. */}
         <button

--- a/frontend/src/ui/Toaster.tsx
+++ b/frontend/src/ui/Toaster.tsx
@@ -1,0 +1,53 @@
+import { Toaster as HotToaster } from 'react-hot-toast'
+
+/**
+ * The app's one transient-feedback surface (issue #116).
+ *
+ * **Top centre because every other edge is taken.** The chrome cluster holds
+ * the top right, the guided-tour button the bottom right, the mobile dock the
+ * bottom, and the sidebar island the left. Top centre is the only region no
+ * fixed element occupies at any breakpoint. The offset reuses
+ * `--live-banner-inset`, so toasts drop below the dev-only live-data banner and
+ * sit at the plain inset in production, where nothing defines that variable.
+ *
+ * Styling is by token rather than by this library's defaults, so a toast reads
+ * as part of the app in both themes instead of as a white card in dark mode.
+ *
+ * Motion needs no handling here: the blanket `prefers-reduced-motion` rule in
+ * index.css uses `!important`, which beats the inline animation this library
+ * sets.
+ *
+ * **Nothing clinical goes in a toast.** These are confirmations of actions the
+ * doctor just took, not a place to surface note content, a red flag or a
+ * finding: a message that fades after four seconds is the wrong carrier for
+ * anything a clinician has to act on.
+ */
+export function Toaster() {
+  return (
+    <HotToaster
+      position="top-center"
+      containerStyle={{ top: 'calc(1rem + var(--live-banner-inset, 0px))' }}
+      toastOptions={{
+        duration: 4000,
+        style: {
+          background: 'var(--color-surface)',
+          color: 'var(--color-ink)',
+          border: '1px solid var(--color-line)',
+          borderRadius: 'var(--radius-control)',
+          boxShadow: 'var(--shadow-raised)',
+          fontSize: '0.875rem',
+          maxWidth: '30rem',
+        },
+        success: {
+          iconTheme: { primary: 'var(--color-accent)', secondary: 'var(--color-surface)' },
+        },
+        error: {
+          // Longer, because a failure is the one a doctor may need to read
+          // twice and then act on.
+          duration: 6000,
+          iconTheme: { primary: 'var(--color-emergency)', secondary: 'var(--color-surface)' },
+        },
+      }}
+    />
+  )
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -484,6 +484,43 @@ export const ConsultationListItemSchema = ConsultationSchema.pick({
 })
 
 /**
+ * The events worth telling a doctor about after the fact (issue #116).
+ *
+ * A deliberate subset of the audit taxonomy, not all of it. `AuditEvent` records
+ * everything that happened, including starts, edits and per-finding
+ * dispositions; a feed of that is a log, and a log nobody reads is worse than no
+ * feed. These four are the ones with an outcome: work finished, work failed, a
+ * record was signed, a record was erased.
+ *
+ * Everything a notification carries is already constrained to an id and a member
+ * of this enum, because the audit row it comes from is. There is no free-text
+ * field to leak clinical content into, and that is a property of the substrate
+ * rather than a rule this feature has to remember to follow.
+ */
+export const NotificationActionSchema = z.enum([
+  'consultation.analysis_completed',
+  'consultation.analysis_failed',
+  'consultation.approved',
+  'consultation.erased',
+])
+
+/**
+ * `NotificationItem`, not `Notification`, because the DOM already has a
+ * `Notification` global for the Web Notifications API. A shared type shadowing
+ * it in browser code is a footgun for whoever later reaches for the real one.
+ */
+export const NotificationItemSchema = z.object({
+  id: z.string(),
+  action: NotificationActionSchema,
+  /** Absent only on a row written before consultations carried the link. */
+  consultationId: z.string().nullable(),
+  createdAt: z.coerce.date(),
+})
+
+/** How many notifications one request returns. */
+export const NOTIFICATION_FEED_LIMIT = 20
+
+/**
  * How many consultations one erase request may carry.
  *
  * The handler erases sequentially rather than concurrently, because every
@@ -660,6 +697,8 @@ export type SuggestionsAndRedFlagsResponse = z.infer<
 >
 export type ConsultationListItem = z.infer<typeof ConsultationListItemSchema>
 export type ConsultationDetail = z.infer<typeof ConsultationDetailSchema>
+export type NotificationAction = z.infer<typeof NotificationActionSchema>
+export type NotificationItem = z.infer<typeof NotificationItemSchema>
 export type EraseConsultationsInput = z.infer<typeof EraseConsultationsInputSchema>
 export type EraseConsultationsResult = z.infer<typeof EraseConsultationsResultSchema>
 export type ErrorEnvelope = z.infer<typeof ErrorEnvelopeSchema>


### PR DESCRIPTION
## What Changed

A glass cluster in the top right holding theme, notifications and account. `GET /api/notifications` is new. Toasts are new. **Sign out now exists**, which it did not before: `api.signOut` was defined and had zero callers anywhere in the frontend.

Closes #116

## Why

Three gaps, gathered because they belong in the same piece of chrome:

- No way to leave a session.
- No transient feedback surface at all, so actions succeeded silently.
- No history of a doctor's own completed work.

**The feed reads `AuditEvent` rather than adding a table.** That log is already a per-actor, append-only, indexed (`@@index([actorId, createdAt])`) stream whose rows carry an id and a member of a closed action enum. A notification built on it cannot carry clinical text because its substrate cannot, rather than because this feature remembers to be careful. `metadata` is never selected.

**Web Push is deliberately out of scope**, and this is the load-bearing scoping decision. There is no asynchronous work in this system: analysis runs inside the request the doctor is waiting on, and there is no queue, worker, cron, WebSocket or SSE anywhere in the backend. A push channel would have nothing to carry, and it would route through FCM, a processor in neither `docs/dpia.md` nor Singapore. In-app only.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — 425 passing, up from 419
- [x] Manually exercised the affected flow, against a local Postgres rather than the shared instance

Six tests in `backend/src/routes/notifications.test.ts`: another doctor's events never returned, only the four notifiable actions exposed, newest first, `metadata` never carried, the feed capped at the shared limit, and a source-scan pinning `/api/notifications` into `PROTECTED_PREFIXES` because a new top-level prefix is unauthenticated by default and that failure is silent.

Exercised in the browser:

- `GET /api/notifications` with no session returns **401**
- Bell opens, lists newest first, badge clears on open; the trigger's accessible name carries the count so the badge is not the only signal
- Escape and outside click both close, and Escape returns focus to the trigger
- Sign out redirects, and `/consultations` then bounces to `/login`, so the session really ended
- Erase raises a toast, and the bell picks up the new event
- Verified in dark mode and at 390px

Regression check for #113: the live-data banner text is still **absent** from the production bundle.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider — this feature makes no model call
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model — `redflags/` untouched
- [x] Citations remain ID-constrained
- [x] No transcript bodies, note contents, or vault entries written to logs, or into a notification
- [x] Fixtures added are synthetic — none added

## Notes For The Reviewer

**This replaces the inline erase notice added in #115.** That was a workaround for having no toast surface; keeping both would be two mechanisms saying one thing.

**Erased notifications deliberately do not link.** The consultation is gone from every read path the moment it is tombstoned, so the link would 404.

**The theme control moved rather than being duplicated.** It is gone from `SidebarIsland` and `MobileDock` and now lives only in the cluster.

**Unread state is per-session and in memory.** Persisting it would need either a migration or a second `localStorage` key, and that key is reserved for the theme.

**Known gap:** `analysis_completed` and `analysis_failed` are pinned by the backend test but not exercised end to end, because that needs a live LLM call. Only `erased` and the empty state were watched arriving in the browser.

**New dependency:** `react-hot-toast@2.6.0`, pinned exactly. Single well-known maintainer, last published a year ago rather than in the last few days, and `bun.lock` is committed with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated notifications feed with unread badges, timestamps, consultation links, and empty/loading states.
  * Added a signed-in control area for notifications, theme switching, and account access, including sign-out.
  * Added toast notifications for consultation approvals and erasure results.
  * Improved live-data banner positioning for overlays and toast messages.

* **Style**
  * Consolidated theme switching into the signed-in control area and mobile navigation adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->