### PR TITLE
fix(api): bound transcript size and rate-limit guest sign-in

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,7 @@ import {
   analyzeRateLimit,
   ephemeralAnalyzeRateLimit,
   eraseRateLimit,
+  guestSignInRateLimit,
 } from './middleware/rate-limit.js'
 import { requestContext } from './middleware/request-context.js'
 import { requireSession } from './middleware/require-session.js'
@@ -41,6 +42,12 @@ export function createApp() {
   app.use(helmet())
   app.use(compression())
   app.use(cors({ origin: env.CORS_ORIGIN, credentials: true }))
+
+  // Ahead of the auth router, for the same reason the clinical limiters sit
+  // ahead of theirs. `/api/auth/guest` is registered before better-auth's
+  // catch-all and so never reaches that router's own limiter, which left the
+  // cheapest way to mint an actor unbounded.
+  app.post('/api/auth/guest', guestSignInRateLimit)
 
   // Before express.json() — better-auth consumes the raw request stream.
   app.use('/api', authRouter)

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -65,6 +65,31 @@ export const ephemeralAnalyzeRateLimit = rateLimit({
 })
 
 /**
+ * Per-IP limiter for `POST /api/auth/guest`.
+ *
+ * This endpoint was limited by neither `express-rate-limit` nor better-auth,
+ * because it is registered ahead of the better-auth catch-all and so never
+ * reaches that router's own limiter. It mints a session for a shared account
+ * with no credential of the caller's own, which makes it the cheapest way in
+ * the system to obtain an actor that can then spend an analysis budget.
+ *
+ * Twenty a minute, which is loose enough for a demo audience arriving together
+ * behind one clinic NAT and tight enough that minting actors in bulk is not
+ * free. It sits on its own bucket so guest traffic cannot exhaust a signed-in
+ * doctor's allowance.
+ */
+export const guestSignInRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 20,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  keyGenerator: clientKey,
+  message: {
+    error: { code: 'rate_limited', message: 'Too many sign-in attempts. Please retry shortly.' },
+  },
+})
+
+/**
  * Per-IP limiter for `POST /api/consultations/erase` (#114).
  *
  * Erasure spends no LLM call, so this is not a cost control. It is here because

--- a/backend/src/routes/auth.test.ts
+++ b/backend/src/routes/auth.test.ts
@@ -122,3 +122,42 @@ describe('sign-up (docs/trd.md §14, §19 row 4)', () => {
     expect(res.status).toBeGreaterThanOrEqual(400)
   })
 })
+
+describe('guest sign-in rate limit', () => {
+  /**
+   * `/api/auth/guest` is registered ahead of better-auth's catch-all, so it
+   * never reaches that router's own limiter and was bounded by nothing. It
+   * mints a session for a shared account without any credential of the
+   * caller's, which makes it the cheapest actor in the system to obtain.
+   *
+   * Driven from one fixed address, because the thing under test is precisely
+   * that requests from a single caller are counted together.
+   */
+  const CALLER = '203.0.113.77'
+
+  const guest = () =>
+    fetch(`${origin}/api/auth/guest`, {
+      method: 'POST',
+      headers: { 'x-forwarded-for': CALLER },
+    })
+
+  it('returns 429 once one caller exceeds the window', async () => {
+    let limited: Response | undefined
+
+    // One over the limit. Every earlier response is allowed to be anything the
+    // route decides, including the 404 it returns when no guest is configured:
+    // what matters is that the limiter counts requests rather than successes.
+    for (let attempt = 0; attempt <= 20; attempt += 1) {
+      const response = await guest()
+      if (response.status === 429) {
+        limited = response
+        break
+      }
+    }
+
+    expect(limited?.status, 'a 21st request in the window must be refused').toBe(429)
+    await expect(limited?.json()).resolves.toMatchObject({
+      error: { code: 'rate_limited' },
+    })
+  })
+})

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -12,9 +12,28 @@ import { z } from 'zod'
 
 export const SpeakerSchema = z.enum(['doctor', 'patient'])
 
+/**
+ * Bounds on how much text may enter the pipeline in one consultation.
+ *
+ * Until these existed the 1 MB request-body limit was the only ceiling, which
+ * is the wrong instrument: a body that size is roughly 300,000 words, and every
+ * one of them would be de-identified, sent to a model priced per token, and
+ * scanned again on the way back. The cost of an oversized transcript lands on
+ * the LLM bill and the request timeout rather than on the JSON parser, so the
+ * bound belongs on the shape rather than on the transport (OWASP LLM10,
+ * Unbounded Consumption).
+ *
+ * Sized well above any real GP consultation and well below anything expensive.
+ * The longest transcript measured during development ran about 3,000 words
+ * across roughly 120 turns, so a 600-turn ceiling is several times the real
+ * ceiling, and a turn longer than 4,000 characters is not a turn.
+ */
+export const MAX_TRANSCRIPT_TURNS = 600
+export const MAX_TURN_CHARACTERS = 4_000
+
 export const TranscriptTurnSchema = z.object({
   speaker: SpeakerSchema,
-  text: z.string().min(1),
+  text: z.string().min(1).max(MAX_TURN_CHARACTERS),
   /** Seconds from consultation start, when the source provides timing. */
   offsetSeconds: z.number().nonnegative().optional(),
 })
@@ -37,7 +56,7 @@ export const TranscriptSourceSchema = z.enum([
 
 export const TranscriptSchema = z.object({
   source: TranscriptSourceSchema,
-  turns: z.array(TranscriptTurnSchema).min(1),
+  turns: z.array(TranscriptTurnSchema).min(1).max(MAX_TRANSCRIPT_TURNS),
 })
 
 // ─── Structured clinical note (SOAP) ─────────────────────────────────────────

--- a/shared/src/transcript-bounds.test.ts
+++ b/shared/src/transcript-bounds.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_TRANSCRIPT_TURNS, MAX_TURN_CHARACTERS, TranscriptSchema } from './index.js'
+
+/**
+ * The bound exists to cap what reaches the de-identifier and the model, not to
+ * cap what fits in a request. Pinning it here rather than in a route test keeps
+ * it true for every caller of the shared contract, including the ephemeral
+ * demo path that takes a transcript straight from the body.
+ */
+const turn = (text: string) => ({ speaker: 'patient' as const, text })
+const transcript = (turns: { speaker: 'patient'; text: string }[]) => ({
+  source: 'paste' as const,
+  turns,
+})
+
+describe('transcript bounds', () => {
+  it('accepts a transcript far longer than any real consultation', () => {
+    // ~120 turns was the longest measured in development; this is well past it
+    // and must still pass, because the bound is a runaway guard rather than a
+    // product limit.
+    const long = transcript(Array.from({ length: 300 }, () => turn('Still coughing at night.')))
+
+    expect(TranscriptSchema.safeParse(long).success).toBe(true)
+  })
+
+  it('rejects more turns than the cap', () => {
+    const tooMany = transcript(
+      Array.from({ length: MAX_TRANSCRIPT_TURNS + 1 }, () => turn('cough')),
+    )
+
+    expect(TranscriptSchema.safeParse(tooMany).success).toBe(false)
+  })
+
+  it('rejects a single turn longer than the cap', () => {
+    // The other half of the bound. Without it, one turn of 900,000 characters
+    // passes a turn-count check and costs exactly as much to process.
+    const huge = transcript([turn('a'.repeat(MAX_TURN_CHARACTERS + 1))])
+
+    expect(TranscriptSchema.safeParse(huge).success).toBe(false)
+  })
+
+  it('still rejects an empty transcript and an empty turn', () => {
+    expect(TranscriptSchema.safeParse(transcript([])).success).toBe(false)
+    expect(TranscriptSchema.safeParse(transcript([turn('')])).success).toBe(false)
+  })
+})


### PR DESCRIPTION
## What Changed

Two unbounded inputs now have bounds. `TranscriptSchema` caps turn count and turn length; `POST /api/auth/guest` has a rate limiter.

## Why

Both were reachable without any credential of the caller's own, and both were listed as open items in the requirements audit.

**Transcript size.** The schema capped neither turn count nor turn length, so `express.json({ limit: '1mb' })` was the only ceiling. That is the wrong instrument. A 1 MB body is roughly 300,000 words, and every one of them would be de-identified, sent to a model priced per token, and scanned again on the way back. The cost of an oversized transcript lands on the LLM bill and the request timeout, not on the JSON parser, so the bound belongs on the shape rather than on the transport.

Sized as a runaway guard, not a product limit: the longest transcript measured during development ran about 3,000 words across roughly 120 turns, so 600 turns is several times the real ceiling.

**Guest sign-in.** `/api/auth/guest` is registered ahead of better-auth's catch-all and therefore never reaches that router's own limiter, so it was bounded by nothing. It mints a session for a shared account without any credential, which made it the cheapest way in the system to obtain an actor that can then spend an analysis budget. Its own bucket, so guest traffic cannot exhaust a signed-in doctor's allowance.

Both are OWASP LLM10 Unbounded Consumption in different clothes.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — 465 passing

Four bound tests in `shared/src/transcript-bounds.test.ts`, including one asserting a 300-turn transcript still passes, so the cap cannot quietly become a product limit.

One test in `backend/src/routes/auth.test.ts` driving 21 requests from a single fixed address and asserting the 429, with the error envelope checked. It counts requests rather than successes, which is the property that matters for an endpoint whose failure mode is being called repeatedly.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable
- [x] Citations remain ID-constrained
- [x] No transcript bodies or note contents written to logs
- [x] Fixtures added are synthetic — none added

## Notes For The Reviewer

The turn-length cap and the turn-count cap are both needed. Either alone leaves the other open: one turn of 900,000 characters passes a turn-count check and costs exactly as much to process.

Twenty guest sign-ins a minute is deliberately loose, so a demo audience arriving together behind one clinic NAT is not locked out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added rate limiting for guest sign-in requests, allowing up to 20 requests per minute per IP.
  * Rate-limited requests now return a clear `rate_limited` error response.

* **Bug Fixes**
  * Added validation to prevent transcripts exceeding 600 turns or 4,000 characters per turn.
  * Preserved validation for empty transcripts and empty turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->