### PR TITLE
feat(ui): add a settings page and refine the chrome

### DIFF
--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -264,10 +264,37 @@ export async function getAuditHistory(consultationId: string) {
  * it.
  */
 export async function getActorNotifications(actorId: string, limit: number) {
+  // "Cleared" is a read cursor, not a delete. `AuditEvent` is append-only and
+  // is the tamper-evident record, so clearing the feed moves this mark forward
+  // and the rows behind it stay exactly where they were.
+  const actor = await prisma.user.findUnique({
+    where: { id: actorId },
+    select: { notificationsClearedAt: true },
+  })
+
   return prisma.auditEvent.findMany({
-    where: { actorId, action: { in: NotificationActionSchema.options } },
+    where: {
+      actorId,
+      action: { in: NotificationActionSchema.options },
+      ...(actor?.notificationsClearedAt ? { createdAt: { gt: actor.notificationsClearedAt } } : {}),
+    },
     orderBy: { createdAt: 'desc' },
     take: limit,
     select: { id: true, action: true, consultationId: true, createdAt: true },
+  })
+}
+
+/**
+ * Moves the actor's feed cursor to now, hiding everything currently in it.
+ *
+ * Deliberately not an audited event. It changes nothing about the clinical
+ * record and nothing about what happened; it is a per-user view preference, and
+ * writing an audit row for dismissing a list would add noise to the one table
+ * whose value depends on every row mattering.
+ */
+export async function clearActorNotifications(actorId: string): Promise<void> {
+  await prisma.user.update({
+    where: { id: actorId },
+    data: { notificationsClearedAt: new Date() },
   })
 }

--- a/backend/src/routes/notifications.test.ts
+++ b/backend/src/routes/notifications.test.ts
@@ -26,8 +26,17 @@ vi.mock('../middleware/require-session.js', () => ({
   },
 }))
 
+let clearedAt: Date | null = null
+
 vi.mock('../lib/prisma.js', () => ({
   prisma: {
+    user: {
+      findUnique: vi.fn(async () => ({ notificationsClearedAt: clearedAt })),
+      update: vi.fn(async ({ data }: { data: { notificationsClearedAt: Date } }) => {
+        clearedAt = data.notificationsClearedAt
+        return {}
+      }),
+    },
     auditEvent: {
       findMany: vi.fn(
         async ({
@@ -35,12 +44,17 @@ vi.mock('../lib/prisma.js', () => ({
           take,
           select,
         }: {
-          where: { actorId: string; action: { in: string[] } }
+          where: { actorId: string; action: { in: string[] }; createdAt?: { gt: Date } }
           take: number
           select: Record<string, boolean>
         }) => {
           const matched = rows
-            .filter((r) => r.actorId === where.actorId && where.action.in.includes(r.action))
+            .filter(
+              (r) =>
+                r.actorId === where.actorId &&
+                where.action.in.includes(r.action) &&
+                (where.createdAt === undefined || r.createdAt > where.createdAt.gt),
+            )
             .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
             .slice(0, take)
           // Mirrors Prisma's `select`, so a column the route never asked for
@@ -70,6 +84,7 @@ afterAll(() => server.close())
 
 beforeEach(() => {
   rows.length = 0
+  clearedAt = null
 })
 
 let clock = 0
@@ -171,5 +186,34 @@ describe('route protection', () => {
     )
 
     expect(prefixes).toContain("'/api/notifications'")
+  })
+})
+
+describe('clearing the feed', () => {
+  it('hides what is in the feed without deleting any audit row', async () => {
+    seed('consultation.approved')
+    seed('consultation.erased')
+    expect((await feed()).body.notifications).toHaveLength(2)
+
+    const cleared = await fetch(`${origin}/api/notifications/clear`, { method: 'POST' })
+
+    expect(cleared.status).toBe(204)
+    expect((await feed()).body.notifications).toHaveLength(0)
+    // The point of the whole design: the feed is empty, the log is not.
+    // `AuditEvent` is append-only and is the tamper-evident record, so a clear
+    // that removed rows would be a defect rather than a feature.
+    expect(rows).toHaveLength(2)
+  })
+
+  it('still shows anything that happens after the clear', async () => {
+    seed('consultation.approved')
+    await fetch(`${origin}/api/notifications/clear`, { method: 'POST' })
+
+    // Stamped explicitly rather than through `seed`'s counter. The cursor is a
+    // real wall-clock time, so a row from the fixture clock is always behind it
+    // and this test would pass for the wrong reason.
+    seed('consultation.erased', { id: 'after', createdAt: new Date(Date.now() + 60_000) })
+
+    expect((await feed()).body.notifications.map((n) => n.id)).toEqual(['after'])
   })
 })

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -1,7 +1,7 @@
 import { NOTIFICATION_FEED_LIMIT, NotificationItemSchema } from '@shared/types'
 import { Router } from 'express'
 import { z } from 'zod'
-import { getActorNotifications } from '../audit/index.js'
+import { clearActorNotifications, getActorNotifications } from '../audit/index.js'
 import { HttpError } from '../lib/http-error.js'
 
 export const notificationsRouter = Router()
@@ -33,4 +33,18 @@ notificationsRouter.get('/notifications', async (req, res) => {
   // above: anything that ever appeared in `metadata` would fail here rather
   // than reach a client.
   res.json(FeedEnvelope.parse({ notifications: rows }))
+})
+
+/**
+ * Clears the feed for the calling doctor.
+ *
+ * **This does not delete anything, and the wording in the UI must not claim it
+ * does.** The feed is a read over `AuditEvent`, which is append-only and is the
+ * tamper-evident record of what the system did. Clearing moves a per-user
+ * cursor forward so the rows stop appearing; every one of them is still in the
+ * log, still chained, and still verifiable.
+ */
+notificationsRouter.post('/notifications/clear', async (req, res) => {
+  await clearActorNotifications(doctorId(req))
+  res.status(204).end()
 })

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -126,13 +126,17 @@ This is where the Apple influence lives, and it is deliberately confined.
 
 The reasoning is not aesthetic. A translucent surface has a contrast ratio that depends on whatever scrolls behind it, so it cannot be verified once. Chrome carries icons and short labels at large sizes; content carries the clinical record.
 
+**Floating surfaces are chrome, and that includes modals** (settled 15/08/26). An earlier revision of the table below said modals were opaque, which contradicted the sentence above listing them under glass; the contradiction is resolved in favour of glass. What keeps it safe is that everything floating sits over the scrim, which is already blurring and dimming whatever is behind it, so the backdrop a modal composites against is a controlled one rather than arbitrary scrolling content. Text on these surfaces stays at full-strength ink: a destructive confirmation is the last place to trade contrast for texture.
+
+**A selected row is still content.** Selection is expressed as a tint layered _over_ the opaque surface, never by replacing it. Setting an `--color-accent` alpha as the row's `background-color` removes the surface instead of tinting it, and the row goes translucent over the page's dot grid. That shipped once and read as muddy rather than selected.
+
 | Layer                            | Treatment                                                                                                |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | Content                          | Opaque `--color-surface`, radius 16px, shadow rather than a border at rest                               |
-| Raised content (menus, popovers) | Opaque, radius 16px, `--shadow-float`                                                                    |
+| Raised content (menus, popovers) | `--color-glass`, radius 22px. These float above the page and carry chrome, not the record                |
 | Chrome (sidebar, top bar, dock)  | `--color-glass`, 58% alpha light and 60% dark, `backdrop-filter: blur(20px) saturate(150%)`, radius 22px |
 | Scrim                            | Single fixed layer, `blur(8px)` plus 32% dim light, 50% dark                                             |
-| Modal                            | Opaque content on a scrim, radius 22px                                                                   |
+| Modal                            | `--color-glass` on a scrim, radius 22px. Text on it stays full-strength ink                              |
 
 Radii: **10px controls, 16px cards, 22px floating chrome, 999px chips.** Roundness
 is a brand property here, not a default. The references this was built against carry

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { Guidelines } from './routes/Guidelines.js'
 import { Landing } from './routes/Landing.js'
 import { Login } from './routes/Login.js'
 import { Privacy } from './routes/Privacy.js'
+import { Settings } from './routes/Settings.js'
 import { AppShell } from './shell/AppShell.js'
 import { MarketingShell } from './shell/MarketingShell.js'
 import { Skeleton } from './ui/Card.js'
@@ -54,6 +55,7 @@ export function App() {
           <Route path="/consultations/new" element={<ConsultationNew />} />
           <Route path="/consultations/:id" element={<ConsultationReview />} />
           <Route path="/guidelines" element={<Guidelines />} />
+          <Route path="/settings" element={<Settings />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/frontend/src/demo/HelpButton.tsx
+++ b/frontend/src/demo/HelpButton.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Play, X } from 'lucide-react'
+import { Bot, Loader2, Play, X } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { useMatch } from 'react-router-dom'
 import { cn } from '../lib/cn.js'
@@ -20,10 +20,11 @@ export function HelpButton() {
   const { active, preparing, start } = useDemoTour()
   const dialog = useRef<HTMLDialogElement>(null)
 
-  // The review screen is the one place with a sticky bar under this button, and
-  // `new` is excluded because the intake screen shares the route but not the bar.
+  // On a consultation record the corner belongs to the assistant rather than to
+  // the tour. `new` is excluded because the intake screen shares the route
+  // shape but is not a record.
   const review = useMatch('/consultations/:id')
-  const overApproveBar = review !== null && review.params.id !== 'new'
+  const onRecord = review !== null && review.params.id !== 'new'
 
   // A native <dialog> gives focus trapping, Escape, inertness of the page
   // behind it and the top layer for free. Hand-rolling those is how a modal
@@ -42,12 +43,16 @@ export function HelpButton() {
           layout, and the circle is what separates it from the interface it
           floats above. A bare glyph rather than lucide's `HelpCircle`, whose
           own ring would sit inside this one and read as a double border. */}
+      {/* The assistant's corner on a record, the tour's everywhere else. The
+          assistant has no behaviour yet, so it is disabled and says so rather
+          than accepting a click and doing nothing. */}
       <button
         type="button"
+        disabled={onRecord}
         onClick={() => dialog.current?.showModal()}
         data-print="hide"
-        aria-label="Take the guided tour"
-        title="Guided Tour"
+        aria-label={onRecord ? 'Assistant, not available yet' : 'Take the guided tour'}
+        title={onRecord ? 'Assistant (coming soon)' : 'Guided Tour'}
         style={{ zIndex: 'var(--z-sticky)' }}
         /*
          * Bottom-right corner, lifted only where something is genuinely under
@@ -66,17 +71,19 @@ export function HelpButton() {
          * the one screen where a help button must not compete with it.
          */
         className={cn(
-          'glass fixed right-4 flex size-12 items-center justify-center rounded-full text-lg font-semibold text-accent transition-[transform,color] duration-150 ease-out-quart hover:text-accent-hover active:scale-[0.94] md:right-6',
-          overApproveBar ? 'bottom-24' : 'bottom-24 md:bottom-6',
+          'glass fab-anchor fixed flex size-12 items-center justify-center rounded-full text-lg font-semibold text-accent transition-[transform,color] duration-150 ease-out-quart',
+          onRecord
+            ? 'cursor-not-allowed text-ink-muted'
+            : 'hover:text-accent-hover active:scale-[0.94]',
         )}
       >
-        <span aria-hidden>?</span>
+        {onRecord ? <Bot aria-hidden className="size-5" /> : <span aria-hidden>?</span>}
       </button>
 
       <dialog
         ref={dialog}
         data-print="hide"
-        className="m-auto w-[26rem] max-w-[calc(100vw-2rem)] rounded-card border border-line bg-surface p-0 text-ink backdrop:bg-scrim backdrop:backdrop-blur-sm"
+        className="glass-panel m-auto w-[26rem] max-w-[calc(100vw-2rem)] rounded-float p-0 text-ink backdrop:bg-scrim backdrop:backdrop-blur-sm"
       >
         <div className="p-6">
           <div className="flex items-start justify-between gap-3">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,12 +63,30 @@
   --color-advisory: oklch(0.457 0.164 258);
   --color-advisory-rule: oklch(0.457 0.164 258);
 
+  /* The unread-count dot, and deliberately NOT `--color-emergency`.
+   *
+   * The clinical palette means something: emergency, urgent and advisory are
+   * severities a doctor reads off a red flag. Painting a chrome badge with one
+   * of them spends that vocabulary on "you have mail" and makes the severity
+   * colours mean less everywhere they actually matter. This is a chrome red at
+   * hue 25, near the emergency red but its own token, so the two can move
+   * independently. `--color-urgent` was the previous value and reads brown:
+   * hue 60 at that lightness is amber, not red. */
+  --color-notify: oklch(0.55 0.2 25);
+  --color-notify-ink: oklch(1 0 0);
+
   /* Faint enough to disappear against the ground until the eye looks for it. */
   --color-scrollbar: oklch(0.245 0.008 160 / 0.22);
   --color-scrollbar-hover: oklch(0.245 0.008 160 / 0.38);
 
   /* Chrome only. Never behind text a doctor acts on. */
   --color-glass: oklch(1 0 0 / 0.58);
+  /* The same frost, backed more heavily, for floating surfaces that carry a
+   * list or a paragraph rather than a row of icons. 58% is right for a sidebar
+   * of glyphs and too thin under sentences: whatever is behind shows through as
+   * competing shapes. Raising the alpha keeps the material and gives the text a
+   * predictable ground. */
+  --color-glass-panel: oklch(1 0 0 / 0.86);
   --color-glass-line: oklch(1 0 0 / 0.55);
   --color-scrim: oklch(0.245 0.008 160 / 0.32);
 
@@ -172,10 +190,14 @@
     --color-advisory: oklch(0.76 0.115 245);
     --color-advisory-rule: oklch(0.76 0.115 245);
 
+    --color-notify: oklch(0.68 0.19 25);
+    --color-notify-ink: oklch(0.16 0.01 25);
+
     --color-scrollbar: oklch(0.945 0.004 160 / 0.2);
     --color-scrollbar-hover: oklch(0.945 0.004 160 / 0.34);
 
     --color-glass: oklch(0.225 0.007 160 / 0.6);
+    --color-glass-panel: oklch(0.225 0.007 160 / 0.88);
     --color-glass-line: oklch(1 0 0 / 0.1);
     --color-scrim: oklch(0.12 0.005 160 / 0.5);
   }
@@ -292,6 +314,15 @@
    * translucent surface has a contrast ratio that depends on whatever scrolls
    * behind it, so it cannot be verified once and held.
    */
+  /* Floating surfaces carrying text. Same frost, heavier ground. */
+  .glass-panel {
+    background-color: var(--color-glass-panel);
+    -webkit-backdrop-filter: blur(20px) saturate(150%);
+    backdrop-filter: blur(20px) saturate(150%);
+    border: 1px solid var(--color-glass-line);
+    box-shadow: var(--shadow-float);
+  }
+
   .glass {
     background-color: var(--color-glass);
     /*
@@ -625,5 +656,29 @@
 
   .page-break-avoid {
     break-inside: avoid;
+  }
+}
+
+@layer components {
+  /*
+   * Where floating chrome parks in the bottom-right corner.
+   *
+   * Two offsets, because two different things can be under it. Below `md` the
+   * mobile dock occupies the bottom edge and the button has to clear it; from
+   * `md` up the dock is gone and the corner is free. `--approve-bar-inset` is
+   * added on top and is set only while the review screen's sticky approve bar
+   * is actually rendered, so the button drops back into the corner the moment
+   * a consultation is approved and that bar is replaced.
+   */
+  .fab-anchor {
+    right: calc(var(--spacing) * 4);
+    bottom: calc(5.5rem + var(--approve-bar-inset, 0px));
+  }
+
+  @media (width >= 48rem) {
+    .fab-anchor {
+      right: calc(var(--spacing) * 6);
+      bottom: calc(1.5rem + var(--approve-bar-inset, 0px));
+    }
   }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -208,6 +208,12 @@ export const api = {
   notifications: (): Promise<NotificationItem[]> =>
     request('/notifications', NotificationsEnvelope).then((r) => r.notifications),
 
+  /**
+   * Hides the feed. Deletes nothing: it moves a per-user cursor, and every
+   * audit row it stops showing is still in the append-only log.
+   */
+  clearNotifications: () => request('/notifications/clear', z.null(), { method: 'POST' }),
+
   guidelines: (): Promise<GuidelineChunk[]> =>
     request('/guidelines', GuidelinesEnvelope).then((r) => r.guidelines),
 

--- a/frontend/src/review/ApproveBar.tsx
+++ b/frontend/src/review/ApproveBar.tsx
@@ -1,7 +1,7 @@
 import type { ConsultationDetail } from '@shared/types'
 import { useMutation } from '@tanstack/react-query'
 import { CheckCircle2 } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ApiError } from '../lib/api.js'
 import { Button } from '../ui/Button.js'
 
@@ -44,6 +44,24 @@ export function ApproveBar({
   onApproved: (next: ConsultationDetail) => void
 }) {
   const [confirming, setConfirming] = useState(false)
+
+  /*
+   * Publishes this bar's footprint so floating chrome can sit above it.
+   *
+   * It is set here rather than inferred from the route, because the route
+   * cannot tell the difference: an approved consultation renders the summary
+   * below instead of this bar, and a FAB lifted by route match then floats
+   * clear of nothing. Tying the offset to the bar's own lifetime makes it
+   * correct in both states without either component importing the other.
+   */
+  useEffect(() => {
+    if (approved) return
+    const root = document.documentElement
+    root.style.setProperty('--approve-bar-inset', '4rem')
+    return () => {
+      root.style.removeProperty('--approve-bar-inset')
+    }
+  }, [approved])
 
   const approve = useMutation({
     mutationFn: performApproval,

--- a/frontend/src/routes/ConsultationList.tsx
+++ b/frontend/src/routes/ConsultationList.tsx
@@ -1,13 +1,14 @@
 import type { ConsultationListItem, ConsultationStatus } from '@shared/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Plus, Trash2 } from 'lucide-react'
-import { useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
 import { Link } from 'react-router-dom'
 import { ApiError, api } from '../lib/api.js'
 import { cn } from '../lib/cn.js'
 import { Button } from '../ui/Button.js'
 import { EmptyState, Skeleton } from '../ui/Card.js'
+import { Checkbox } from '../ui/Checkbox.js'
 import { PageHeader } from '../ui/PageHeader.js'
 
 /**
@@ -44,9 +45,6 @@ const formatDate = (value: Date) =>
     minute: '2-digit',
   }).format(value)
 
-const CHECKBOX =
-  'size-4 shrink-0 cursor-pointer accent-accent disabled:cursor-not-allowed disabled:opacity-40'
-
 const count = (n: number, noun: string) => `${n} ${noun}${n === 1 ? '' : 's'}`
 
 export function ConsultationList() {
@@ -57,6 +55,9 @@ export function ConsultationList() {
   })
   const [picked, setPicked] = useState<ReadonlySet<string>>(new Set())
   const dialog = useRef<HTMLDialogElement>(null)
+  // Associated explicitly rather than by wrapping. The input lives inside the
+  // `Checkbox` component, so a wrapping label reads as having no control in it.
+  const selectAllId = useId()
 
   const consultations = data ?? []
 
@@ -112,14 +113,13 @@ export function ConsultationList() {
       />
 
       {consultations.length > 0 && (
-        <div
-          data-print="hide"
-          className="mt-8 flex min-h-9 items-center justify-between gap-4 border-b border-line pb-3"
-        >
-          <label className="flex cursor-pointer items-center gap-3 text-sm text-ink-muted">
-            <input
-              type="checkbox"
-              className={CHECKBOX}
+        <div data-print="hide" className="mt-8 flex min-h-9 items-center justify-between gap-4">
+          <label
+            htmlFor={selectAllId}
+            className="flex cursor-pointer items-center gap-3 text-sm text-ink-muted"
+          >
+            <Checkbox
+              id={selectAllId}
               checked={allSelected}
               // A DOM property rather than an attribute: there is no
               // `indeterminate` in HTML, only on the element.
@@ -183,17 +183,18 @@ export function ConsultationList() {
               key={consultation.id}
               className={cn(
                 'flex items-center gap-3 rounded-card border bg-surface pl-4 transition-colors',
+                // The tint is a layer over the surface, not a replacement for
+                // it: as a `background-color` it won the cascade and left the
+                // row translucent over the page's dot grid.
                 picked.has(consultation.id)
-                  ? 'border-accent/50 bg-accent/4'
+                  ? 'border-accent/50 bg-linear-to-r from-accent/8 to-accent/8'
                   : 'border-line hover:border-ink-muted/50',
               )}
             >
               {/* A sibling of the link, never a child of it: a control nested
                   inside an anchor is not reachable as its own target. */}
-              <input
-                type="checkbox"
+              <Checkbox
                 data-print="hide"
-                className={CHECKBOX}
                 checked={picked.has(consultation.id)}
                 onChange={() => toggle(consultation.id)}
                 aria-label={`Select consultation from ${when}`}
@@ -250,7 +251,10 @@ export function ConsultationList() {
  * discover that afterwards.
  *
  * A native <dialog>, for the same reason as the tour's: focus trapping, Escape
- * and inertness of the page behind it, none of them hand-rolled.
+ * and inertness of the page behind it, none of them hand-rolled. It is glass
+ * over the scrim, matching every other floating surface; the text on it stays
+ * at full-strength ink because a destructive confirmation is the last place to
+ * trade contrast for texture.
  */
 function EraseDialog({
   ref,
@@ -277,7 +281,7 @@ function EraseDialog({
       ref={ref}
       data-print="hide"
       aria-labelledby="erase-title"
-      className="m-auto w-[26rem] max-w-[calc(100vw-2rem)] rounded-card border border-line bg-surface p-0 text-ink backdrop:bg-scrim backdrop:backdrop-blur-sm"
+      className="glass-panel m-auto w-[26rem] max-w-[calc(100vw-2rem)] rounded-float p-0 text-ink backdrop:bg-scrim backdrop:backdrop-blur-sm"
     >
       <div className="p-6">
         <h2 id="erase-title" className="text-lg font-semibold">

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -1,0 +1,197 @@
+import { DEMO_PLAN, ERASE_BATCH_LIMIT, type Fixture } from '@shared/types'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Trash2 } from 'lucide-react'
+import { useRef, useState } from 'react'
+import toast from 'react-hot-toast'
+import { ApiError, api } from '../lib/api.js'
+import { useTheme } from '../lib/theme.js'
+import { Button } from '../ui/Button.js'
+import { PageHeader } from '../ui/PageHeader.js'
+
+const GUEST_EMAIL = 'guest@catatmd.demo'
+
+/**
+ * Account settings (issue #123).
+ *
+ * **There is deliberately no "reset to factory".** This app stores no
+ * server-side preferences: `User` carries an identity and nothing else, and the
+ * only thing a doctor has ever chosen is the theme, which lives in
+ * `localStorage`. A button promising to reset settings would have exactly one
+ * of them to reset, and would imply a preferences system that does not exist.
+ * The theme control is right here instead, in the chrome, where it already was.
+ *
+ * What the page does carry is erasure, which is not a convenience feature.
+ * `docs/dpia.md` lists the data-subject erasure right under "Retention,
+ * Deletion, And Access Requests" as designed but unimplemented; this is the
+ * implementation.
+ */
+export function Settings() {
+  const queryClient = useQueryClient()
+  const { resolved, setPreference } = useTheme()
+  const dialog = useRef<HTMLDialogElement>(null)
+  const [progress, setProgress] = useState<string | null>(null)
+
+  const session = useQuery({ queryKey: ['session'], queryFn: api.session, retry: false })
+  const consultations = useQuery({ queryKey: ['consultations'], queryFn: api.listConsultations })
+  const fixtures = useQuery({ queryKey: ['fixtures'], queryFn: api.fixtures })
+
+  const isGuest = session.data?.user.email === GUEST_EMAIL
+  const owned = consultations.data ?? []
+
+  const wipe = useMutation({
+    mutationFn: async () => {
+      const ids = owned.map((c) => c.id)
+      let erased = 0
+
+      // Chunked because the erase endpoint is bounded, and sequential because
+      // each erasure appends to the audit hash chain, whose head cannot be
+      // raced. Same reasoning as the batch route itself.
+      for (let i = 0; i < ids.length; i += ERASE_BATCH_LIMIT) {
+        setProgress(`Erasing ${erased + 1} of ${ids.length}`)
+        const result = await api.eraseConsultations(ids.slice(i, i + ERASE_BATCH_LIMIT))
+        erased += result.erased.length
+      }
+
+      if (isGuest) await reseed(fixtures.data ?? [], setProgress)
+      return erased
+    },
+    onSuccess: (erased) => {
+      setProgress(null)
+      dialog.current?.close()
+      toast.success(
+        isGuest
+          ? `${erased} erased, and the demo account has been rebuilt.`
+          : `${erased} consultation${erased === 1 ? '' : 's'} erased.`,
+      )
+      void queryClient.invalidateQueries({ queryKey: ['notifications'] })
+      return queryClient.invalidateQueries({ queryKey: ['consultations'] })
+    },
+    onError: () => setProgress(null),
+  })
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <PageHeader
+        title="Settings"
+        subtitle="Appearance and your data."
+        art="/art/consultations.webp"
+      />
+
+      <section className="mt-8 rounded-card border border-line bg-surface p-5">
+        <h2 className="text-base font-semibold">Appearance</h2>
+        <p className="mt-1 text-sm text-ink-muted">
+          Stored in this browser only, and never sent to the server.
+        </p>
+        <div className="mt-4 flex gap-2">
+          <Button
+            variant={resolved === 'light' ? 'primary' : 'secondary'}
+            size="sm"
+            onClick={() => setPreference('light')}
+          >
+            Light
+          </Button>
+          <Button
+            variant={resolved === 'dark' ? 'primary' : 'secondary'}
+            size="sm"
+            onClick={() => setPreference('dark')}
+          >
+            Dark
+          </Button>
+        </div>
+      </section>
+
+      <section className="mt-5 rounded-card border border-emergency/30 bg-surface p-5">
+        <h2 className="text-base font-semibold">Delete My Data</h2>
+        <p className="mt-1 max-w-prose text-sm leading-relaxed text-ink-muted">
+          Erases every consultation on this account: {owned.length} right now. The transcript,
+          analysis and edited note are permanently erased. A tamper-evident audit record that each
+          consultation existed and was erased is retained, and cannot be removed.
+        </p>
+        {isGuest && (
+          <p className="mt-3 max-w-prose rounded-control border border-urgent/40 bg-urgent/8 px-3 py-2 text-sm">
+            This is the shared demo account, so it will be rebuilt afterwards from the bundled
+            synthetic cases. That runs the real analysis pipeline and takes a few minutes.
+          </p>
+        )}
+        <Button
+          variant="danger"
+          size="sm"
+          className="mt-4"
+          icon={<Trash2 aria-hidden className="size-3.5" />}
+          disabled={owned.length === 0 && !isGuest}
+          onClick={() => {
+            wipe.reset()
+            dialog.current?.showModal()
+          }}
+        >
+          Delete My Data
+        </Button>
+      </section>
+
+      <dialog
+        ref={dialog}
+        data-print="hide"
+        aria-labelledby="wipe-title"
+        className="glass-panel m-auto w-[28rem] max-w-[calc(100vw-2rem)] rounded-float p-0 text-ink backdrop:bg-scrim backdrop:backdrop-blur-sm"
+      >
+        <div className="p-6">
+          <h2 id="wipe-title" className="text-lg font-semibold">
+            Erase everything on this account?
+          </h2>
+          <p className="mt-3 text-sm leading-relaxed text-ink-muted">
+            {owned.length} consultation{owned.length === 1 ? '' : 's'} will be erased.
+            {isGuest
+              ? ' The demo account will then be rebuilt from the bundled synthetic cases, which spends a real analysis for each one.'
+              : ' Their clinical content goes permanently; the audit record that they existed stays.'}
+          </p>
+          <p className="mt-2 text-sm font-medium">This cannot be undone.</p>
+
+          {progress && (
+            <p role="status" className="mt-3 text-sm text-ink-muted">
+              {progress}
+            </p>
+          )}
+          {wipe.error != null && (
+            <p role="alert" className="mt-3 text-sm text-emergency">
+              {wipe.error instanceof ApiError ? wipe.error.message : 'Nothing was erased.'}
+            </p>
+          )}
+
+          <div className="mt-6 flex justify-end gap-2">
+            <Button onClick={() => dialog.current?.close()} disabled={wipe.isPending}>
+              Cancel
+            </Button>
+            <Button variant="danger" loading={wipe.isPending} onClick={() => wipe.mutate()}>
+              Erase Everything
+            </Button>
+          </div>
+        </div>
+      </dialog>
+    </div>
+  )
+}
+
+/**
+ * Rebuilds the shared demo account by driving the same endpoints a doctor would.
+ *
+ * **From the browser, one request at a time, deliberately.** Rebuilding runs a
+ * full analysis per fixture, which is minutes of model time in total. A single
+ * server-side request doing that would sit far past the edge timeout in front
+ * of the API, and there is no queue or worker to hand it to. Driving it from
+ * here keeps every request short, makes the progress observable, and adds no
+ * infrastructure. `prisma/seed-demo.ts` already works exactly this way over
+ * HTTP; `DEMO_PLAN` is shared so the two cannot drift.
+ */
+async function reseed(fixtures: Fixture[], onProgress: (message: string) => void) {
+  for (const [index, step] of DEMO_PLAN.entries()) {
+    const fixture = fixtures.find((f) => f.id === step.fixtureId)
+    if (!fixture) continue
+
+    onProgress(`Rebuilding ${index + 1} of ${DEMO_PLAN.length}`)
+    const created = await api.createConsultation(fixture.transcript)
+    if (step.target === 'draft') continue
+
+    const analysed = await api.analyze(created.id)
+    if (step.target === 'approved' && analysed.analysis) await api.approve(created.id)
+  }
+}

--- a/frontend/src/shell/ChromeCluster.tsx
+++ b/frontend/src/shell/ChromeCluster.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Bell, LogOut, Moon, Sun, UserRound } from 'lucide-react'
+import { Bell, LogOut, Moon, Settings as SettingsIcon, Sun, UserRound } from 'lucide-react'
 import { useCallback, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { api } from '../lib/api.js'
 import { useTheme } from '../lib/theme.js'
 import { Button } from '../ui/Button.js'
@@ -73,13 +73,13 @@ export function ChromeCluster() {
       </Dropover>
 
       <Dropover label="Account" icon={<UserRound aria-hidden className="size-4.5" />}>
-        {() => <AccountPanel />}
+        {(close) => <AccountPanel close={close} />}
       </Dropover>
     </div>
   )
 }
 
-function AccountPanel() {
+function AccountPanel({ close }: { close: () => void }) {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const session = useQuery({ queryKey: ['session'], queryFn: api.session, retry: false })
@@ -106,16 +106,26 @@ function AccountPanel() {
         <p className="text-sm text-ink-muted">Signed in.</p>
       )}
 
-      <Button
-        size="sm"
-        variant="secondary"
-        icon={<LogOut aria-hidden className="size-3.5" />}
-        loading={signOut.isPending}
-        onClick={() => signOut.mutate()}
-        className="mt-4 w-full"
-      >
-        Sign Out
-      </Button>
+      <div className="mt-4 flex flex-col gap-2">
+        <Link
+          to="/settings"
+          onClick={close}
+          className="flex h-8 items-center justify-center gap-1.5 rounded-control bg-surface text-xs font-medium text-ink shadow-raised transition-colors hover:bg-sunken"
+        >
+          <SettingsIcon aria-hidden className="size-3.5" />
+          Settings
+        </Link>
+        <Button
+          size="sm"
+          variant="secondary"
+          icon={<LogOut aria-hidden className="size-3.5" />}
+          loading={signOut.isPending}
+          onClick={() => signOut.mutate()}
+          className="w-full"
+        >
+          Sign Out
+        </Button>
+      </div>
 
       {signOut.error != null && (
         <p role="alert" className="mt-2 text-2xs text-emergency">

--- a/frontend/src/shell/Dropover.tsx
+++ b/frontend/src/shell/Dropover.tsx
@@ -76,7 +76,7 @@ export function Dropover({
             // The count is on the trigger's accessible name rather than only in
             // this dot, so it is not a purely visual signal.
             aria-hidden
-            className="absolute -top-0.5 -right-0.5 flex min-w-4 items-center justify-center rounded-pill bg-urgent px-1 text-[0.625rem] leading-4 font-semibold text-ink"
+            className="absolute -top-0.5 -right-0.5 flex min-w-4 items-center justify-center rounded-pill bg-notify px-1 text-[0.625rem] leading-4 font-semibold text-notify-ink"
           >
             {badge > 9 ? '9+' : badge}
           </span>
@@ -93,10 +93,12 @@ export function Dropover({
           // and `role="group"` would be a name repeated from the trigger.
           style={{ zIndex: 'var(--z-modal)' }}
           className={cn(
-            // Opaque, not glass. docs/DESIGN.md reserves translucency for
-            // chrome, and the moment a panel carries a list a doctor reads, it
-            // is content sitting in chrome rather than chrome.
-            'absolute top-11 w-80 max-w-[calc(100vw-2rem)] rounded-card border border-line bg-surface shadow-raised',
+            // Glass, matching every other floating surface in the app. These
+            // panels carry chrome (a status feed, an account menu) rather than
+            // clinical content, so docs/DESIGN.md's solid-panels-for-content
+            // rule does not bind here. The blur is what stops the page behind
+            // showing through as noise under the text.
+            'glass-panel absolute top-11 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-float',
             align === 'right' ? 'right-0' : 'left-0',
           )}
         >

--- a/frontend/src/shell/NotificationPanel.tsx
+++ b/frontend/src/shell/NotificationPanel.tsx
@@ -1,9 +1,10 @@
 import type { NotificationAction, NotificationItem } from '@shared/types'
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { CheckCircle2, CircleAlert, Sparkles, Trash2 } from 'lucide-react'
 import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../lib/api.js'
+import { Button } from '../ui/Button.js'
 import { Skeleton } from '../ui/Card.js'
 
 /**
@@ -61,9 +62,15 @@ function ago(value: Date) {
 }
 
 export function NotificationPanel({ onSeen, close }: { onSeen: () => void; close: () => void }) {
+  const queryClient = useQueryClient()
   const { data, isPending, isError } = useQuery({
     queryKey: ['notifications'],
     queryFn: api.notifications,
+  })
+
+  const clear = useMutation({
+    mutationFn: api.clearNotifications,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['notifications'] }),
   })
 
   // The panel is mounted only while it is open, so mounting *is* the doctor
@@ -73,7 +80,24 @@ export function NotificationPanel({ onSeen, close }: { onSeen: () => void; close
 
   return (
     <div className="flex max-h-96 flex-col">
-      <h2 className="border-b border-line px-4 py-3 text-sm font-semibold">Notifications</h2>
+      <div className="flex items-center justify-between gap-2 border-b border-line/60 py-2 pr-2 pl-4">
+        <h2 className="text-sm font-semibold">Notifications</h2>
+        {(data?.length ?? 0) > 0 && (
+          <Button
+            size="sm"
+            variant="ghost"
+            loading={clear.isPending}
+            onClick={() => clear.mutate()}
+            // "Clear", not "Delete". The rows are audit events and they survive
+            // this: what changes is where this doctor's feed starts reading
+            // from. Wording that promised deletion would be a lie about the one
+            // table whose value is that nothing in it can be removed.
+            title="Stop showing these. The audit record is kept."
+          >
+            Clear All
+          </Button>
+        )}
+      </div>
 
       <div className="overflow-y-auto">
         {isPending && (

--- a/frontend/src/shell/SidebarIsland.tsx
+++ b/frontend/src/shell/SidebarIsland.tsx
@@ -1,4 +1,4 @@
-import { BookMarked, FileText, PanelLeft, Plus } from 'lucide-react'
+import { BookMarked, FileText, PanelLeft, Plus, Settings } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { cn } from '../lib/cn.js'
@@ -141,6 +141,28 @@ export function SidebarIsland({
       </ul>
 
       <div className="flex flex-col gap-1 border-t border-line/60 pt-2">
+        <NavLink
+          to="/settings"
+          className={({ isActive }) =>
+            cn(
+              'flex h-11 items-center gap-3 rounded-control px-3 text-sm font-medium transition-colors duration-150',
+              isActive
+                ? 'bg-accent/16 text-accent'
+                : 'text-ink-muted hover:bg-sunken/60 hover:text-ink',
+            )
+          }
+        >
+          <Settings aria-hidden className="size-5 shrink-0" />
+          <span
+            className={cn(
+              'whitespace-nowrap transition-opacity duration-150',
+              expanded ? 'opacity-100' : 'pointer-events-none opacity-0',
+            )}
+          >
+            Settings
+          </span>
+        </NavLink>
+
         {/* Touch has no hover and a keyboard user should not have to hold
             focus to read a label. Pinning is the accessible equivalent. */}
         <button

--- a/frontend/src/ui/Checkbox.tsx
+++ b/frontend/src/ui/Checkbox.tsx
@@ -1,0 +1,59 @@
+import { Check, Minus } from 'lucide-react'
+import type { InputHTMLAttributes, Ref } from 'react'
+import { cn } from '../lib/cn.js'
+
+/**
+ * A checkbox that belongs to this design system rather than to the operating
+ * system (issue #123).
+ *
+ * The native control cannot be restyled past its accent colour in any engine
+ * that matters, so a browser checkbox sitting beside `Button` and `Select` reads
+ * as an OS widget dropped into a designed interface. Same reasoning as
+ * `ui/Select.tsx`, and the same construction: a rounded square with the app's
+ * radius, not a pill and not the platform's shape.
+ *
+ * **The real input is still there**, visually hidden but present and focusable.
+ * That is what keeps the label association, the tab order, the `indeterminate`
+ * property, form participation and every assistive-technology behaviour that a
+ * `div` with `role="checkbox"` has to reimplement and usually gets wrong. The
+ * square is decoration painted next to it, marked `aria-hidden`, and it reacts
+ * through `peer-*` so no state has to be mirrored in JavaScript.
+ */
+export function Checkbox({
+  className,
+  ref,
+  ...props
+}: Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> & {
+  /**
+   * Forwarded to the real input, which is the only thing that can carry
+   * `indeterminate`: it exists as a DOM property and has no HTML attribute, so
+   * a caller showing a partial selection has to reach the element itself.
+   */
+  ref?: Ref<HTMLInputElement>
+}) {
+  return (
+    <span className={cn('relative inline-flex shrink-0 items-center justify-center', className)}>
+      <input
+        ref={ref}
+        type="checkbox"
+        // `appearance-none` rather than `sr-only`: the input keeps its own box
+        // and sits exactly under the square, so the hit target is the control a
+        // pointer aims at rather than a 1px point elsewhere.
+        className="peer size-4.5 cursor-pointer appearance-none rounded-[6px] border border-line bg-surface transition-colors duration-150 checked:border-accent checked:bg-accent indeterminate:border-accent indeterminate:bg-accent disabled:cursor-not-allowed disabled:opacity-40"
+        {...props}
+      />
+      {/* Both marks are painted; which one shows is decided by the input's own
+          state, so the tick and the dash can never disagree with it. */}
+      <Check
+        aria-hidden
+        strokeWidth={3}
+        className="pointer-events-none absolute size-3 text-accent-ink opacity-0 transition-opacity duration-150 peer-checked:opacity-100 peer-indeterminate:opacity-0"
+      />
+      <Minus
+        aria-hidden
+        strokeWidth={3}
+        className="pointer-events-none absolute size-3 text-accent-ink opacity-0 transition-opacity duration-150 peer-indeterminate:opacity-100"
+      />
+    </span>
+  )
+}

--- a/prisma/migrations/20260814160920_add_notifications_cleared_at/migration.sql
+++ b/prisma/migrations/20260814160920_add_notifications_cleared_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "notificationsClearedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,15 @@ model User {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
+  /// When this doctor last cleared their notification feed (issue #123).
+  ///
+  /// The feed is a read over `AuditEvent`, which is append-only, so "clear"
+  /// cannot mean "delete": the audit rows are the tamper-evident record and
+  /// must survive. This marks a point in time and the feed returns only what
+  /// happened after it, which hides the notifications without touching the
+  /// log they are derived from.
+  notificationsClearedAt DateTime?
+
   sessions      Session[]
   accounts      Account[]
   consultations Consultation[]

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -540,6 +540,24 @@ export const NotificationItemSchema = z.object({
 export const NOTIFICATION_FEED_LIMIT = 20
 
 /**
+ * The demo account's target state, shared so the seed script and the in-app
+ * restore cannot drift (issue #123).
+ *
+ * It lives here rather than in `prisma/seed-demo.ts` because two things now
+ * rebuild the demo: that script, and Settings for the guest account. If they
+ * disagreed, the account restored from the UI would not be the account the
+ * script produces, and only one of them would match what a demo was rehearsed
+ * against.
+ */
+export const DEMO_PLAN = [
+  { fixtureId: 'urti-gap-heavy', target: 'awaiting_review' },
+  { fixtureId: 'urti-hard-red-flag', target: 'awaiting_review' },
+  { fixtureId: 'urti-diagnosis-not-assessed', target: 'awaiting_review' },
+  { fixtureId: 'urti-identifier-dense-routine', target: 'approved' },
+  { fixtureId: 'urti-hard-uncertain', target: 'draft' },
+] as const satisfies readonly { fixtureId: string; target: ConsultationStatus }[]
+
+/**
  * How many consultations one erase request may carry.
  *
  * The handler erases sequentially rather than concurrently, because every


### PR DESCRIPTION
## What Changed

A `/settings` page, and the six chrome refinements requested with it.

## Settings

Two sections: the theme control, and **Delete My Data**.

**There is deliberately no "Reset Account".** The app stores no server-side preferences. `User` carries an identity and nothing else, and the only thing a doctor has ever chosen is the theme, in `localStorage`. A reset button would have exactly one thing to reset and would advertise a preferences system that does not exist.

Erasure is the half that earns the page. `docs/dpia.md` lists the data-subject erasure right under "Retention, Deletion, And Access Requests" as designed but unimplemented; this implements it.

**The guest rebuild runs from the browser, one request at a time.** Rebuilding spends a full analysis per fixture, minutes of model time in total. One server-side request doing that would sit far past the edge timeout in front of the API, and there is no queue or worker to hand it to. `prisma/seed-demo.ts` already drives the same endpoints over HTTP; `DEMO_PLAN` moved to `shared/` so the script and the page cannot drift.

## The Six Refinements

1. **Checkboxes are a component now.** Rounded squares on the app's radius. The real input stays underneath rather than being replaced by a `div` with `role="checkbox"`, so label association, tab order, form participation and `indeterminate` remain the browser's. Associated by `htmlFor`/`id` rather than by wrapping, because the input is inside a component and a wrapping label reads as empty.
2. **Selected rows keep their surface.** This was my bug from #115: `bg-accent/4` is a `background-color` and *replaced* `bg-surface` rather than tinting it, so a selected row went genuinely translucent over the dot grid. Triaged the rest of the app: every other selected state tints an element sitting on a solid parent, so this was the only one affected.
3. **Robot FAB on a consultation record**, reserved for the assistant. Disabled and labelled "not available yet", because it has no behaviour and a control that accepts a click and does nothing is worse than one that says so. **Its position was also wrong**, and the cause was structural: the lift was inferred from the route, but an approved consultation renders a summary instead of the sticky approve bar, so the button floated clear of nothing. The bar now publishes its own footprint and the FAB reads it.
4. **The unread badge is red.** It was `--color-urgent`, which is hue 60: amber, and brown at that lightness. It gets **its own chrome token** rather than borrowing `--color-emergency`, because that palette means clinical severity and spending it on an unread count devalues it everywhere it actually matters. **Clear All** added.
5. **Settings reachable** from the account menu and a gear at the foot of the sidebar.
6. **Floating surfaces are glass.** Modals and dropovers.

## Notes For The Reviewer

**"Clear All" cannot delete anything, and the wording reflects that.** `AuditEvent` is append-only and is the tamper-evident record. Clearing moves a per-user cursor (`User.notificationsClearedAt`, additive migration) so the rows stop appearing; every one is still in the log, still chained, still verifiable. Two tests pin exactly that: the feed empties and the rows survive.

**`docs/DESIGN.md` contradicted itself on modals** — prose listed them under "glass is chrome only", the table said "opaque content on a scrim". Resolved in favour of glass and the doc updated, including a new note that a selected row is still content and its tint layers over the surface rather than replacing it.

**Panels carrying text use a heavier glass than icon chrome.** At the sidebar's 58% alpha, the page art behind the notification list showed through as competing shapes. `--color-glass-panel` keeps the frost and gives text a predictable ground, which is the contrast concern `DESIGN.md` raises about translucency, addressed rather than waived.

## Verification

- [x] `bun run lint` (9 pre-existing `noConsole` warnings in `prisma/seed*.ts`, untouched)
- [x] `bun run typecheck`
- [x] `bun run test` — 467 passing
- [x] Manually exercised against a local Postgres, not the shared instance

Browser-verified: custom checkboxes including the indeterminate dash, no divider, selected rows opaque, red badge, Clear All, glass modal and dropovers, Settings from both entry points, robot FAB lifted over the approve bar and dropping to the corner without it. Confirmed in Postgres that clearing the feed left all audit rows in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Settings page with light/dark theme controls and consultation data-erasure workflows.
  - Added Settings navigation from the account menu and sidebar.
  - Added “Clear All” notifications, keeping historical audit records intact.
  - Added a reusable checkbox with accessible checked, unchecked, disabled, and indeterminate states.

- **UI Improvements**
  - Updated floating panels, dialogs, notification badges, and selection states with refreshed glass styling.
  - Improved floating action button positioning around approval bars and mobile navigation.
  - Consultation records now indicate when guided help is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->