### PR TITLE
docs(design): record that glass inside glass is always flat

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -158,7 +158,7 @@ list screens hand-roll the same styling rather than using it. Those exist and mu
 be changed in step; a sitewide shape rule that holds in the component and not on
 the landing page is worse than no rule.
 
-**Two implementation notes that have each already cost a shipped bug.**
+**Three implementation notes that have each already cost a shipped bug.**
 
 The glass needs **texture behind it**. `backdrop-filter` blurs whatever is behind
 it, so over a flat fill it has nothing to operate on and the chrome reads as merely
@@ -172,6 +172,14 @@ property declared twice, keeps the last, and ships the prefix alone: the frost
 degrades to flat translucency in the production build while dev, which does not
 minify, looks perfect. Verify glass changes against `vite build`, never against
 the dev server.
+
+**Glass inside glass is always flat.** An element with `backdrop-filter` establishes a
+backdrop root, and a descendant's own `backdrop-filter` may only sample within it. A
+panel nested inside the chrome cluster therefore blurs the cluster's flat fill rather
+than the page, which is the first note's "nothing to operate on" arriving through the
+DOM instead of through a missing dot grid. Floating panels are portalled to `body` for
+this reason. Modals escape it already: a `<dialog>` renders in the top layer, which is
+outside any backdrop root.
 
 ### Z-Index Scale
 


### PR DESCRIPTION
## What Changed

A third entry in DESIGN.md's "implementation notes that have each already cost a shipped bug" block. This one cost #125.

> **Glass inside glass is always flat.** An element with `backdrop-filter` establishes a backdrop root, and a descendant's own `backdrop-filter` may only sample within it. A panel nested inside the chrome cluster therefore blurs the cluster's flat fill rather than the page, which is the first note's "nothing to operate on" arriving through the DOM instead of through a missing dot grid. Floating panels are portalled to `body` for this reason. Modals escape it already: a `<dialog>` renders in the top layer, which is outside any backdrop root.

## Why It Is A Separate PR

It should not have been. AGENTS.md wants the prose describing a change to ship with the change, and @AlaskanTuna asked me to carry this in #125 for exactly that reason.

**#125 had already merged by the time the wording arrived**, so a follow-up is the closest available thing. Flagging it rather than quietly splitting it.

## Attribution

Wording is @AlaskanTuna's, who verified the diagnosis independently on live production before writing it rather than taking mine on trust. Their walk of the ancestor chain matched mine, and they additionally confirmed `panelIsDialog: false` for the dropover panel and that every other `.glass-panel` sits on a `<dialog>`, which is what makes the "only instance" claim safe to state.

One em dash was replaced with a comma clause to satisfy the repo's house-style hook. No other change to their text.

## Notes For The Reviewer

Clinical-Safety section deleted: documentation only.

Docs-only, so the deploy filter skips this and it costs no Vercel slot.