### PR TITLE
fix(ui): report transcription instead of a model download

### DIFF
--- a/frontend/src/audio/transcribe.worker.test.ts
+++ b/frontend/src/audio/transcribe.worker.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkerResponse } from './protocol.js'
+
+/**
+ * The worker's *message* contract, not its transcription quality.
+ *
+ * These pin the handshake the component depends on to tell "still loading the
+ * model" apart from "transcribing". That distinction was silently broken:
+ * `ready` was posted only for an explicit `load` request, nothing in the app
+ * ever sends one, and so `AudioCapture`'s `transcribing` phase was unreachable
+ * dead code. A long recording spent its entire run claiming to be downloading
+ * a model it had already cached, and nothing failed, which is exactly the
+ * shape of bug a type checker and a passing suite both wave through.
+ */
+
+const asr = vi.fn(async () => ({ text: 'hello', chunks: [] }) as unknown)
+
+vi.mock('@huggingface/transformers', () => ({
+  pipeline: vi.fn(async () => asr),
+  env: {},
+}))
+
+let posted: WorkerResponse[]
+
+beforeEach(async () => {
+  posted = []
+  vi.spyOn(self, 'postMessage').mockImplementation(((message: WorkerResponse) => {
+    posted.push(message)
+  }) as typeof self.postMessage)
+
+  vi.resetModules()
+  await import('./transcribe.worker.js')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  self.onmessage = null
+})
+
+/** Drives the worker the way the component does, and waits for it to settle. */
+async function transcribe() {
+  self.onmessage?.(
+    new MessageEvent('message', { data: { type: 'transcribe', audio: new Float32Array(16) } }),
+  )
+  await vi.waitFor(() =>
+    expect(posted.some((m) => m.type === 'result' || m.type === 'error')).toBe(true),
+  )
+}
+
+describe('the transcribe path', () => {
+  it('announces ready once the model is loaded', async () => {
+    await transcribe()
+
+    expect(posted.map((m) => m.type)).toContain('ready')
+  })
+
+  it('announces ready before the result, so the caller can leave the loading phase', async () => {
+    // Ordering is the whole point. A `ready` posted alongside the result would
+    // satisfy the test above and still leave the misleading copy on screen for
+    // the entire transcription.
+    //
+    // Asserted as an exact sequence rather than by comparing indexes. With the
+    // fix reverted, `indexOf('ready')` is -1 and `-1 < 0` passes, so the
+    // obvious form of this test is vacuous. That was not hypothetical: it is
+    // what the first draft did, and deleting the fix left it green.
+    await transcribe()
+
+    expect(posted.map((m) => m.type)).toEqual(['ready', 'result'])
+  })
+
+  it('reports a failure as an error rather than a silent stall', async () => {
+    asr.mockRejectedValueOnce(new Error('session failed'))
+
+    await transcribe()
+
+    expect(posted.at(-1)).toEqual({ type: 'error', message: 'session failed' })
+  })
+})

--- a/frontend/src/audio/transcribe.worker.ts
+++ b/frontend/src/audio/transcribe.worker.ts
@@ -139,6 +139,15 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
     }
 
     const asr = await load()
+    /*
+     * The model is loaded; everything after this is inference. Without this
+     * the caller never leaves `loading-model`, because `ready` was only ever
+     * posted for an explicit `load` request and nothing sends one. The
+     * component's "Transcribing on this device" copy was therefore
+     * unreachable, and a long recording spent its whole run claiming to be
+     * downloading a model it had already cached.
+     */
+    post({ type: 'ready' })
     const output = await asr(event.data.audio, {
       /*
        * Pinned to English, never read from a locale or from the patient's

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -11,7 +11,7 @@ import { PageHeader } from '../ui/PageHeader.js'
 const GUEST_EMAIL = 'guest@catatmd.demo'
 
 /**
- * Account settings (issue #123).
+ * Account settings (PR #124).
  *
  * **There is deliberately no "reset to factory".** This app stores no
  * server-side preferences: `User` carries an identity and nothing else, and the

--- a/frontend/src/ui/Checkbox.tsx
+++ b/frontend/src/ui/Checkbox.tsx
@@ -4,7 +4,7 @@ import { cn } from '../lib/cn.js'
 
 /**
  * A checkbox that belongs to this design system rather than to the operating
- * system (issue #123).
+ * system (PR #124).
  *
  * The native control cannot be restyled past its accent colour in any engine
  * that matters, so a browser checkbox sitting beside `Button` and `Select` reads


### PR DESCRIPTION
## What

The Record tab claimed to be downloading a speech model for the entire duration of every transcription, including runs where the model was already cached.

## Why It Happened

`transcribe.worker.ts` posted `ready` only in the `{type:'load'}` branch. Nothing in the app ever sends that message: the only `postMessage` call in `frontend/src/` is `AudioCapture.tsx:145`, and the only `WorkerRequest` ever constructed is `{type:'transcribe'}` at `:144`.

So the chain was:

- `ready` never posted
- `setPhase('transcribing')` at `AudioCapture.tsx:111` unreachable
- `busy` only ever true via `loading-model`
- the ternary at `:248` always took the download branch
- `"Transcribing on this device. Longer recordings take a few minutes."` at `:252` was dead code

With a warm cache no progress events fire, so `progress` stays `null` and the message keeps claiming a download that is not happening.

## Measured

A 5 minute recording on production spent over 14 minutes under "Preparing the speech model", single threaded, renderer pegged at 100% of one core. It completed correctly with good output; only the status text was wrong.

## Tests

`transcribe.worker.test.ts` pins the message handshake rather than transcription quality, since a type checker and a green suite both waved this through.

Both new assertions were confirmed to fail with the fix reverted. Worth noting: the first draft of the ordering test did **not** fail, because `indexOf('ready')` returns `-1` when absent and `-1 < 0` passes. It now asserts the exact sequence.

## Also

Repoints two comment references from `issue #123` to `PR #124`. #123 is an unrelated Qwen quota issue, now closed; there was never an issue for that work, so the PR is the accurate record.

## Clinical-Safety Checklist

Not applicable. No change to `deid/`, `lib/llm/`, `redflags/`, `guidelines/`, or logging. The diff is one `postMessage` on the transcribe path, two comment references, and a new test file.

https://claude.ai/code/session_01VQQGcjk9fUhxR9c9kGqv2A