### PR TITLE
feat(qa): add an evals harness for the AI pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ docs/assets/*.drawio.svg
 # already knows is a directory, so `git check-ignore .claude/worktrees` fails
 # before the directory exists, which is precisely when a skill tests it.
 .claude/worktrees
+
+# Eval reports are generated output, one per run
+evals/reports/

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,18 @@
         "vitest": "^3.2.4",
       },
     },
+    "evals": {
+      "name": "evals",
+      "dependencies": {
+        "@shared/types": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^24.7.2",
+        "tsx": "^4.19.2",
+        "typescript": "^5.9.2",
+        "vitest": "^3.2.7",
+      },
+    },
     "frontend": {
       "name": "frontend",
       "dependencies": {
@@ -752,6 +764,8 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "evals": ["evals@workspace:evals"],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,49 @@
+# Evals
+
+Runs every synthetic fixture through the **real** analysis pipeline and grades what comes back.
+
+## Why This Is Not `tests/`
+
+`bun run test` is deterministic, free, and gates every push. This is none of those things: it spends a real LLM call per fixture, and its results move when the provider does. Wiring the two together would either bankrupt CI or get the evals disabled, so they are kept apart by name.
+
+The **graders** are the exception. They are pure functions, so `graders.test.ts` runs in CI like any other test. A grader that silently always passes turns "we do not know" into "we checked", which is worse than having no harness, so the grading logic is the part that gets tested.
+
+## What It Grades
+
+| Grader | Severity | Asks |
+| --- | --- | --- |
+| `red-flag-recall` | Critical | Did every rule in `expectedRedFlagIds` fire? |
+| `rule-attribution` | Critical | Did any rule hit arrive re-badged as model output? |
+| `citation-validity` | Critical | Does every cited ID resolve to the corpus? |
+| `evidence-grounding` | Critical | Is every asserted span verbatim in the transcript? |
+| `fact-coverage` | Informational | How much of the fixed checklist was established? |
+| `model-contribution` | Informational | How many candidates did the model add? |
+
+**Recall is a subset check, not equality.** The model may add candidates and may never suppress a rule hit, so extra flags are legitimate output and a missing rule hit is a patient-safety defect. `rule-attribution` exists because those two fail differently: a suppression bug that re-badges a rule hit as model output would otherwise pass recall while the deterministic guarantee is gone.
+
+**`fact-coverage` is informational and must stay that way.** A field the consultation never touched is *correctly* `NOT_ASSESSED`, so there is no target to hit. It earns its place as a drift signal: the same fixture scoring materially lower after a prompt or model change means extraction got worse.
+
+**`evidence-grounding` is a backstop, not a discovery.** `applyEvidenceCheck` already discards ungrounded assertions inside the pipeline, so a healthy run scores 100% by construction. It is graded anyway because that is a Tier-2 control, and an unmeasured control regresses quietly. A failure here means the check broke, not that the model misbehaved.
+
+## Running It
+
+Needs a running API. It drives `POST /api/consultations/analyze-ephemeral`, which runs the same `runAnalysis` a doctor's request runs and **persists no `Consultation`**, so a run leaves the database as it found it.
+
+```bash
+bun run dev:backend          # in one shell
+bun run evals                # in another
+```
+
+Point it elsewhere with `EVAL_API_URL` (default `http://localhost:3001`) and `EVAL_ORIGIN` (default `http://localhost:5173`, which must satisfy the API's CORS origin).
+
+Exits non-zero if any fixture fails a critical grader. Writes a dated report to `evals/reports/`, which is gitignored: reports are generated output, one per run.
+
+## Cost And Data
+
+- One analysis per fixture, and an analysis is two concurrent LLM calls plus retrieval.
+- **Synthetic data only.** It reads `backend/src/fixtures/`, and nothing else is permitted here.
+- Every run writes `consultation.ephemeral_analyzed` audit rows, by design: the endpoint cannot tell demo content from real content, so an unaudited egress would be a hole in the PHI boundary.
+
+## Adding A Case
+
+Cases come from `backend/src/fixtures/`, not from a list here, so there is no second corpus to drift. Add the fixture to `corpus.ts` and its rubric to `rubrics.ts`, including `expectedRedFlagIds` derived by reading the transcript against the trigger list rather than from observed output. `fixtures.test.ts` keeps the two in lockstep.

--- a/evals/graders.test.ts
+++ b/evals/graders.test.ts
@@ -1,0 +1,211 @@
+import type { ConsultationAnalysis, Transcript } from '@shared/types'
+import { describe, expect, it } from 'vitest'
+import {
+  gradeCitationValidity,
+  gradeEvidenceGrounding,
+  gradeFactCoverage,
+  gradeRedFlagRecall,
+  gradeRuleAttribution,
+} from './graders.js'
+
+/**
+ * The graders are the part of this harness that can fail silently.
+ *
+ * A grader that always returns `passed: true` produces a green report on a
+ * broken pipeline, which is worse than having no harness at all: it converts
+ * "we do not know" into "we checked". So the graders are tested here, in CI,
+ * for free, and each one is given an input it must reject.
+ */
+
+const transcript: Transcript = {
+  source: 'fixture',
+  turns: [
+    { speaker: 'doctor', text: 'What brings you in today?' },
+    { speaker: 'patient', text: 'Sore throat for three days, and I cannot swallow properly.' },
+  ],
+}
+
+function analysis(over: Partial<ConsultationAnalysis> = {}): ConsultationAnalysis {
+  return {
+    note: { subjective: '', objective: '', assessment: '', plan: '' },
+    gaps: [],
+    redFlags: [],
+    suggestions: [],
+    ...over,
+  } as ConsultationAnalysis
+}
+
+const ruleFlag = (ruleId: string) => ({
+  id: `rf-${ruleId}`,
+  label: 'x',
+  severity: 'emergency' as const,
+  evidence: 'cannot swallow',
+  source: 'rule' as const,
+  ruleId,
+})
+
+describe('red-flag recall', () => {
+  it('fails when an expected rule hit is missing', () => {
+    const finding = gradeRedFlagRecall(analysis(), ['swallowing-difficulty'])
+
+    expect(finding.passed).toBe(false)
+    expect(finding.detail).toContain('swallowing-difficulty')
+  })
+
+  it('passes when every expected rule hit is present', () => {
+    const finding = gradeRedFlagRecall(
+      analysis({ redFlags: [ruleFlag('swallowing-difficulty')] }),
+      ['swallowing-difficulty'],
+    )
+
+    expect(finding.passed).toBe(true)
+  })
+
+  it('allows the model to add candidates beyond the expected set', () => {
+    // The invariant is that the model may add and may never suppress, so this
+    // is a subset check. Asserting equality here would turn legitimate output
+    // into a failure and train everyone to ignore the report.
+    const finding = gradeRedFlagRecall(
+      analysis({
+        redFlags: [
+          ruleFlag('swallowing-difficulty'),
+          { ...ruleFlag('extra'), source: 'model', ruleId: undefined },
+        ],
+      }),
+      ['swallowing-difficulty'],
+    )
+
+    expect(finding.passed).toBe(true)
+  })
+
+  it('does not count a model-sourced flag towards recall', () => {
+    // A suppression bug that re-badges a rule hit as model output would
+    // otherwise pass recall while the deterministic guarantee is gone.
+    const finding = gradeRedFlagRecall(
+      analysis({ redFlags: [{ ...ruleFlag('swallowing-difficulty'), source: 'model' }] }),
+      ['swallowing-difficulty'],
+    )
+
+    expect(finding.passed).toBe(false)
+  })
+})
+
+describe('rule attribution', () => {
+  it('fails when an expected rule hit arrives badged as model output', () => {
+    const finding = gradeRuleAttribution(
+      analysis({ redFlags: [{ ...ruleFlag('swallowing-difficulty'), source: 'model' }] }),
+      ['swallowing-difficulty'],
+    )
+
+    expect(finding.passed).toBe(false)
+  })
+
+  it('ignores model candidates that are not expected rules', () => {
+    const finding = gradeRuleAttribution(
+      analysis({ redFlags: [{ ...ruleFlag('something-else'), source: 'model' }] }),
+      ['swallowing-difficulty'],
+    )
+
+    expect(finding.passed).toBe(true)
+  })
+})
+
+describe('citation validity', () => {
+  it('fails on a citation outside the corpus', () => {
+    const finding = gradeCitationValidity(
+      analysis({
+        suggestions: [{ id: 's1', text: 'x', citations: [{ guidelineId: 'invented-2024' }] }],
+      }),
+      ['moh-nag-2024-urti'],
+    )
+
+    expect(finding.passed).toBe(false)
+    expect(finding.detail).toContain('invented-2024')
+  })
+
+  it('passes when every citation resolves', () => {
+    const finding = gradeCitationValidity(
+      analysis({
+        suggestions: [{ id: 's1', text: 'x', citations: [{ guidelineId: 'moh-nag-2024-urti' }] }],
+      }),
+      ['moh-nag-2024-urti'],
+    )
+
+    expect(finding.passed).toBe(true)
+  })
+})
+
+describe('evidence grounding', () => {
+  it('fails on an asserted span that is not in the transcript', () => {
+    const finding = gradeEvidenceGrounding(
+      analysis({
+        clinicalFacts: {
+          symptoms: { soreThroat: { state: 'PRESENT', evidence: 'high fever for a week' } },
+          history: {},
+          observations: {},
+          examination: {},
+        },
+      } as Partial<ConsultationAnalysis>),
+      transcript,
+    )
+
+    expect(finding.passed).toBe(false)
+    expect(finding.detail).toContain('symptoms.soreThroat')
+  })
+
+  it('passes on a verbatim span, ignoring whitespace and case', () => {
+    const finding = gradeEvidenceGrounding(
+      analysis({
+        clinicalFacts: {
+          symptoms: { soreThroat: { state: 'PRESENT', evidence: 'Sore   throat for THREE days' } },
+          history: {},
+          observations: {},
+          examination: {},
+        },
+      } as Partial<ConsultationAnalysis>),
+      transcript,
+    )
+
+    expect(finding.passed).toBe(true)
+  })
+
+  it('ignores NOT_ASSESSED fields, which carry no span by design', () => {
+    const finding = gradeEvidenceGrounding(
+      analysis({
+        clinicalFacts: {
+          symptoms: { soreThroat: { state: 'NOT_ASSESSED' } },
+          history: {},
+          observations: {},
+          examination: {},
+        },
+      } as Partial<ConsultationAnalysis>),
+      transcript,
+    )
+
+    expect(finding.passed).toBe(true)
+  })
+})
+
+describe('fact coverage', () => {
+  it('reports established over total and never fails', () => {
+    const finding = gradeFactCoverage(
+      analysis({
+        clinicalFacts: {
+          symptoms: {
+            soreThroat: { state: 'PRESENT', evidence: 'Sore throat for three days' },
+            fever: { state: 'NOT_ASSESSED' },
+          },
+          history: {},
+          observations: {},
+          examination: {},
+        },
+      } as Partial<ConsultationAnalysis>),
+    )
+
+    expect(finding.detail).toContain('1/2')
+    // Informational by design: a field the consultation never touched is
+    // correctly NOT_ASSESSED, so there is no threshold to fail against.
+    expect(finding.passed).toBe(true)
+    expect(finding.severity).toBe('informational')
+  })
+})

--- a/evals/graders.ts
+++ b/evals/graders.ts
@@ -1,0 +1,217 @@
+import type { ClinicalAssertion, ConsultationAnalysis, Transcript } from '@shared/types'
+
+/**
+ * Grading is pure, and deliberately separate from the harness that calls the
+ * model.
+ *
+ * These functions take an analysis and return a verdict. They spend nothing,
+ * they are deterministic, and so they are unit-tested in CI like any other
+ * code. `run.ts`, which spends real money against a real provider, is not.
+ *
+ * That split is the point. A grader that silently always passes is the exact
+ * failure this harness exists to prevent, so the grader is the part that gets
+ * tested.
+ */
+
+export type Severity = 'critical' | 'informational'
+
+export interface Finding {
+  grader: string
+  severity: Severity
+  passed: boolean
+  detail: string
+}
+
+/**
+ * Every red flag the deterministic engine must raise, did.
+ *
+ * **Critical, and the reason this harness exists.** `AGENTS.md` allows the
+ * model to add candidates and never to suppress a rule hit, so the assertion
+ * is a subset check rather than an equality one: extra model candidates are
+ * legitimate output, a missing rule hit is a patient-safety defect.
+ *
+ * Graded on `ruleId` rather than `id`, because `id` is per-analysis and
+ * `ruleId` is the stable identifier `FIXTURE_RUBRICS.expectedRedFlagIds` is
+ * written against.
+ */
+export function gradeRedFlagRecall(
+  analysis: ConsultationAnalysis,
+  expectedRedFlagIds: readonly string[],
+): Finding {
+  const raised = new Set(
+    analysis.redFlags
+      .filter((f) => f.source === 'rule')
+      .flatMap((f) => (f.ruleId ? [f.ruleId] : [])),
+  )
+  const missing = expectedRedFlagIds.filter((id) => !raised.has(id))
+
+  return {
+    grader: 'red-flag-recall',
+    severity: 'critical',
+    passed: missing.length === 0,
+    detail:
+      missing.length === 0
+        ? `all ${expectedRedFlagIds.length} expected rule hits raised`
+        : `MISSING rule hits: ${missing.join(', ')}`,
+  }
+}
+
+/**
+ * No rule hit arrived attributed to the model.
+ *
+ * A separate check from recall, because the two fail differently. Recall
+ * catches a rule that never fired; this catches one that fired and was then
+ * re-badged, which would let a suppression bug hide behind a passing recall
+ * count.
+ */
+export function gradeRuleAttribution(
+  analysis: ConsultationAnalysis,
+  expectedRedFlagIds: readonly string[],
+): Finding {
+  const misattributed = analysis.redFlags
+    .filter((f) => f.source === 'model' && f.ruleId !== undefined)
+    .filter((f) => f.ruleId !== undefined && expectedRedFlagIds.includes(f.ruleId))
+    .map((f) => f.ruleId)
+
+  return {
+    grader: 'rule-attribution',
+    severity: 'critical',
+    passed: misattributed.length === 0,
+    detail:
+      misattributed.length === 0
+        ? 'no expected rule hit is attributed to the model'
+        : `rule hits badged as model output: ${misattributed.join(', ')}`,
+  }
+}
+
+/**
+ * Every citation resolves to an ID in the supplied corpus.
+ *
+ * **Critical.** ID-constrained citation is what makes a hallucinated medical
+ * reference structurally impossible rather than merely unlikely, and it is a
+ * property of the whole pipeline rather than of the parser alone. Parse-time
+ * validation is the control; this is the end-to-end evidence that the control
+ * holds against a real model.
+ */
+export function gradeCitationValidity(
+  analysis: ConsultationAnalysis,
+  corpusIds: readonly string[],
+): Finding {
+  const known = new Set(corpusIds)
+  const invalid = analysis.suggestions
+    .flatMap((s) => s.citations.map((c) => c.guidelineId))
+    .filter((id) => !known.has(id))
+
+  return {
+    grader: 'citation-validity',
+    severity: 'critical',
+    passed: invalid.length === 0,
+    detail:
+      invalid.length === 0
+        ? `all citations resolve (${analysis.suggestions.length} suggestions)`
+        : `citations outside the corpus: ${[...new Set(invalid)].join(', ')}`,
+  }
+}
+
+const normalise = (value: string) => value.replace(/\s+/g, ' ').trim().toLowerCase()
+
+/** Every assertion in the analysis, flattened with its field id. */
+function assertions(analysis: ConsultationAnalysis): { fieldId: string; a: ClinicalAssertion }[] {
+  const facts = analysis.clinicalFacts
+  if (!facts) return []
+  const groups: [string, Record<string, ClinicalAssertion>][] = [
+    ['symptoms', facts.symptoms],
+    ['history', facts.history],
+    ['observations', facts.observations],
+    ['examination', facts.examination],
+  ]
+  return groups.flatMap(([name, group]) =>
+    Object.entries(group).map(([key, a]) => ({ fieldId: `${name}.${key}`, a })),
+  )
+}
+
+/**
+ * Every asserted span is verbatim in the transcript.
+ *
+ * A backstop rather than a discovery: `applyEvidenceCheck` already discards
+ * ungrounded assertions in the pipeline, so a healthy run scores 100% here by
+ * construction. It is graded anyway because that check is a Tier-2 control,
+ * and a control nobody measures end-to-end is a control that can regress
+ * quietly. A failure here means the check itself broke, not that the model
+ * misbehaved.
+ */
+export function gradeEvidenceGrounding(
+  analysis: ConsultationAnalysis,
+  transcript: Transcript,
+): Finding {
+  const haystack = normalise(transcript.turns.map((t) => t.text).join(' '))
+  const ungrounded = assertions(analysis)
+    .filter(({ a }) => a.state === 'PRESENT' || a.state === 'DENIED')
+    .filter(({ a }) => {
+      const span = a.evidence?.trim()
+      return !span || !haystack.includes(normalise(span))
+    })
+    .map(({ fieldId }) => fieldId)
+
+  return {
+    grader: 'evidence-grounding',
+    severity: 'critical',
+    passed: ungrounded.length === 0,
+    detail:
+      ungrounded.length === 0
+        ? 'every asserted span is verbatim in the transcript'
+        : `spans not found in the transcript: ${ungrounded.join(', ')}`,
+  }
+}
+
+/**
+ * How much of the fixed checklist the consultation established.
+ *
+ * **Informational, and must stay that way.** A field the consultation never
+ * touched is *correctly* `NOT_ASSESSED`, so there is no target to hit and a
+ * higher number is not automatically better. What it is good for is drift: the
+ * same fixture scoring materially lower after a prompt or model change means
+ * extraction got worse, or the evidence check is discarding more.
+ */
+export function gradeFactCoverage(analysis: ConsultationAnalysis): Finding {
+  const all = assertions(analysis)
+  const established = all.filter(({ a }) => a.state !== 'NOT_ASSESSED')
+
+  return {
+    grader: 'fact-coverage',
+    severity: 'informational',
+    passed: true,
+    detail:
+      all.length === 0
+        ? 'no clinical facts returned'
+        : `${established.length}/${all.length} checklist fields established`,
+  }
+}
+
+/** How many candidates the model contributed. Informational: adding is allowed. */
+export function gradeModelContribution(analysis: ConsultationAnalysis): Finding {
+  const added = analysis.redFlags.filter((f) => f.source === 'model')
+
+  return {
+    grader: 'model-contribution',
+    severity: 'informational',
+    passed: true,
+    detail: `${added.length} model-added red-flag candidate(s), ${analysis.gaps.length} gap(s)`,
+  }
+}
+
+export function gradeAll(
+  analysis: ConsultationAnalysis,
+  transcript: Transcript,
+  expectedRedFlagIds: readonly string[],
+  corpusIds: readonly string[],
+): Finding[] {
+  return [
+    gradeRedFlagRecall(analysis, expectedRedFlagIds),
+    gradeRuleAttribution(analysis, expectedRedFlagIds),
+    gradeCitationValidity(analysis, corpusIds),
+    gradeEvidenceGrounding(analysis, transcript),
+    gradeFactCoverage(analysis),
+    gradeModelContribution(analysis),
+  ]
+}

--- a/evals/package.json
+++ b/evals/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "evals",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "eval": "bunx tsx run.ts",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@shared/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.7"
+  }
+}

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -1,0 +1,182 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import {
+  type ConsultationAnalysis,
+  ConsultationAnalysisSchema,
+  type Transcript,
+} from '@shared/types'
+import { FIXTURE_RUBRICS, FIXTURES } from '../backend/src/fixtures/index.js'
+import { corpusIds } from '../backend/src/guidelines/index.js'
+import { type Finding, gradeAll } from './graders.js'
+
+/**
+ * Runs every synthetic fixture through the **real** analysis pipeline and
+ * grades what comes back.
+ *
+ * **This is not a test and must never become one.** It spends a real LLM call
+ * per fixture, its results move with the provider, and `bun run test` stays
+ * deterministic and free precisely because this lives outside it.
+ *
+ * It drives `POST /api/consultations/analyze-ephemeral` over HTTP rather than
+ * importing the pipeline, for two reasons. That endpoint runs the same
+ * `runAnalysis` a doctor's request runs, so there is no second copy of the
+ * pipeline here to drift from the first; and it persists no `Consultation`, so
+ * a run leaves the database as it found it.
+ */
+
+const API_URL = process.env.EVAL_API_URL ?? 'http://localhost:3001'
+const ORIGIN = process.env.EVAL_ORIGIN ?? 'http://localhost:5173'
+
+interface CaseResult {
+  fixtureId: string
+  label: string
+  ok: boolean
+  ms: number
+  findings: Finding[]
+  error?: string
+}
+
+/** Signs in as the guest account and returns the cookie header for later calls. */
+async function signIn(): Promise<string> {
+  const response = await fetch(`${API_URL}/api/auth/guest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Origin: ORIGIN },
+  })
+  if (!response.ok) {
+    throw new Error(`guest sign-in failed: ${response.status} ${await response.text()}`)
+  }
+  const cookies = response.headers.getSetCookie()
+  if (cookies.length === 0) throw new Error('guest sign-in returned no session cookie')
+  return cookies.map((c) => c.split(';')[0]).join('; ')
+}
+
+async function analyse(transcript: Transcript, cookie: string): Promise<ConsultationAnalysis> {
+  const response = await fetch(`${API_URL}/api/consultations/analyze-ephemeral`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Origin: ORIGIN, Cookie: cookie },
+    body: JSON.stringify({ transcript }),
+  })
+  if (!response.ok) {
+    throw new Error(`analyse failed: ${response.status} ${(await response.text()).slice(0, 300)}`)
+  }
+  const body = (await response.json()) as { analysis: unknown }
+  // Parsed rather than trusted. A harness that reports on a shape it never
+  // checked would report confidently on nothing.
+  return ConsultationAnalysisSchema.parse(body.analysis)
+}
+
+function render(results: CaseResult[], startedAt: string, wallMs: number): string {
+  const criticalFailures = results.flatMap((r) =>
+    r.findings.filter((f) => f.severity === 'critical' && !f.passed).map((f) => ({ r, f })),
+  )
+  const errored = results.filter((r) => r.error)
+
+  const lines = [
+    '# Eval Run',
+    '',
+    `- **Started:** ${startedAt}`,
+    `- **API:** ${API_URL}`,
+    `- **Fixtures:** ${results.length}`,
+    `- **Wall clock:** ${(wallMs / 1000).toFixed(1)}s`,
+    `- **Critical failures:** ${criticalFailures.length}`,
+    `- **Errored:** ${errored.length}`,
+    '',
+    '## Summary',
+    '',
+    '| Fixture | Result | Latency |',
+    '| --- | --- | --- |',
+    ...results.map((r) => {
+      const bad = r.findings.filter((f) => f.severity === 'critical' && !f.passed).length
+      const verdict = r.error ? 'ERROR' : bad > 0 ? `${bad} critical` : 'pass'
+      return `| \`${r.fixtureId}\` | ${verdict} | ${(r.ms / 1000).toFixed(1)}s |`
+    }),
+    '',
+    '## Detail',
+    '',
+  ]
+
+  for (const r of results) {
+    lines.push(`### \`${r.fixtureId}\``, '', r.label, '')
+    if (r.error) {
+      lines.push(`**ERROR:** ${r.error}`, '')
+      continue
+    }
+    lines.push('| Grader | Severity | Result | Detail |', '| --- | --- | --- | --- |')
+    for (const f of r.findings) {
+      lines.push(`| ${f.grader} | ${f.severity} | ${f.passed ? 'pass' : 'FAIL'} | ${f.detail} |`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+async function main() {
+  const startedAt = new Date().toISOString()
+  const started = Date.now()
+
+  console.log(`Evals against ${API_URL}`)
+  const cookie = await signIn()
+
+  const results: CaseResult[] = []
+
+  // Sequential on purpose. Concurrency here would measure the provider's rate
+  // limiter rather than the pipeline, and per-fixture latency is one of the
+  // numbers this exists to produce.
+  for (const fixture of FIXTURES) {
+    const rubric = FIXTURE_RUBRICS.find((r) => r.fixtureId === fixture.id)
+    if (!rubric) {
+      results.push({
+        fixtureId: fixture.id,
+        label: fixture.label,
+        ok: false,
+        ms: 0,
+        findings: [],
+        error: 'no rubric; fixtures.test.ts should have caught this',
+      })
+      continue
+    }
+
+    const at = Date.now()
+    try {
+      const analysis = await analyse(fixture.transcript, cookie)
+      const findings = gradeAll(analysis, fixture.transcript, rubric.expectedRedFlagIds, corpusIds)
+      const ok = findings.every((f) => f.severity !== 'critical' || f.passed)
+      results.push({
+        fixtureId: fixture.id,
+        label: fixture.label,
+        ok,
+        ms: Date.now() - at,
+        findings,
+      })
+      console.log(
+        `  ${ok ? 'pass' : 'FAIL'}  ${fixture.id}  ${((Date.now() - at) / 1000).toFixed(1)}s`,
+      )
+    } catch (cause) {
+      const error = cause instanceof Error ? cause.message : String(cause)
+      results.push({
+        fixtureId: fixture.id,
+        label: fixture.label,
+        ok: false,
+        ms: Date.now() - at,
+        findings: [],
+        error,
+      })
+      console.log(`  ERROR ${fixture.id}: ${error}`)
+    }
+  }
+
+  const report = render(results, startedAt, Date.now() - started)
+  await mkdir(new URL('reports/', import.meta.url), { recursive: true })
+  const path = new URL(`reports/${startedAt.replace(/[:.]/g, '-')}.md`, import.meta.url)
+  await writeFile(path, report, 'utf8')
+  console.log(`\nReport: ${path.pathname}`)
+
+  const failed = results.filter((r) => !r.ok)
+  if (failed.length > 0) {
+    console.error(`\n${failed.length}/${results.length} fixture(s) failed a critical grader.`)
+    process.exit(1)
+  }
+  console.log(`\nAll ${results.length} fixtures passed every critical grader.`)
+}
+
+await main()

--- a/evals/tsconfig.json
+++ b/evals/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts", "../backend/src/fixtures/**/*.ts", "../backend/src/guidelines/**/*.ts"],
+  "exclude": ["reports"],
+  "references": [{ "path": "../shared" }]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "workspaces": [
     "shared",
     "backend",
-    "frontend"
+    "frontend",
+    "evals"
   ],
   "scripts": {
     "dev": "concurrently -n shared,backend,frontend -c cyan,green,magenta \"bun run --cwd shared dev\" \"bun run --cwd backend dev\" \"bun run --cwd frontend dev\"",
@@ -25,20 +26,21 @@
     "lint:fix": "biome check --write .",
     "format": "biome format --write . && prettier --write --no-error-on-unmatched-pattern '*.{md,yml,yaml}' 'docs/**/*.md'",
     "format:check": "biome format . && prettier --check --no-error-on-unmatched-pattern '*.{md,yml,yaml}' 'docs/**/*.md'",
-    "typecheck": "bun run --cwd shared build && bun run --cwd shared typecheck && bun run --cwd backend typecheck && bun run --cwd frontend typecheck",
-    "test": "bun run --cwd shared build && bun run --cwd shared test && bun run --cwd backend test && bun run --cwd frontend test",
+    "typecheck": "bun run --cwd shared build && bun run --cwd shared typecheck && bun run --cwd backend typecheck && bun run --cwd frontend typecheck && bun run --cwd evals typecheck",
+    "test": "bun run --cwd shared build && bun run --cwd shared test && bun run --cwd backend test && bun run --cwd frontend test && bun run --cwd evals test",
     "build": "bun run --cwd shared build && bunx prisma generate --schema prisma/schema.prisma && bun run --cwd backend build && bun run --cwd frontend build",
     "start": "bun run --cwd backend start",
-    "prepare": "husky"
+    "prepare": "husky",
+    "evals": "bun run --cwd shared build && bun run --cwd evals eval"
   },
   "lint-staged": {
-    "{shared,backend,frontend}/**/*.{ts,tsx,js,json}": "biome check --write --no-errors-on-unmatched",
     "{docs,.github}/**/*.{md,yml,yaml}": "prettier --write",
     "package.json": "biome check --write --no-errors-on-unmatched",
     "biome.json": "biome check --write --no-errors-on-unmatched",
     "commitlint.config.js": "biome check --write --no-errors-on-unmatched",
     "AGENTS.md": "prettier --write",
-    "CLAUDE.md": "prettier --write"
+    "CLAUDE.md": "prettier --write",
+    "{shared,backend,frontend,evals}/**/*.{ts,tsx,js,json}": "biome check --write --no-errors-on-unmatched"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",


### PR DESCRIPTION
Closes #130.

## Why

`bun run test` runs 470 tests with the LLM mocked. That is correct for CI and says nothing about model behaviour. Nothing in the repo could answer **"did that prompt change quietly lose a red flag?"**, which for a system whose stated rule is zero tolerance for false negatives is the question that matters most.

## Why Not `tests/`

These spend a real LLM call per fixture and their results move when the provider does. Wiring them into `bun run test` would either bankrupt CI or get them disabled, so they are kept apart by name.

**The graders are the exception and do run in CI.** They are pure functions, and a grader that silently always passes turns "we do not know" into "we checked", which is worse than having no harness at all. 12 tests, each handing a grader an input it must reject.

## Design

- **Drives `POST /api/consultations/analyze-ephemeral`** rather than importing the pipeline. That endpoint runs the same `runAnalysis` a doctor's request runs, so there is no second copy of the pipeline here to drift from the first, and it persists no `Consultation`, so a run leaves the database as it found it.
- **Cases come from `backend/src/fixtures/`**, so there is no second corpus either. `expectedRedFlagIds` already exists in `FIXTURE_RUBRICS` and `fixtures.test.ts` keeps them in lockstep.

| Grader | Severity | Asks |
| --- | --- | --- |
| `red-flag-recall` | Critical | Did every rule in `expectedRedFlagIds` fire? |
| `rule-attribution` | Critical | Did any rule hit arrive re-badged as model output? |
| `citation-validity` | Critical | Does every cited ID resolve to the corpus? |
| `evidence-grounding` | Critical | Is every asserted span verbatim in the transcript? |
| `fact-coverage` | Informational | How much of the fixed checklist was established? |
| `model-contribution` | Informational | How many candidates did the model add? |

**Recall is a subset check, never equality.** The model may add candidates and may never suppress a rule hit, so extra flags are legitimate output. `rule-attribution` is a separate grader because the two fail differently: a suppression bug that re-badges a rule hit as model output would otherwise pass recall while the deterministic guarantee is gone.

**`fact-coverage` is informational and must stay that way.** A field the consultation never touched is correctly `NOT_ASSESSED`, so there is no target to hit. It earns its place as a drift signal.

## Verified End To End

Run against a real Qwen provider on a local stack, not just typechecked:

| Fixture | Result | Latency |
| --- | --- | --- |
| `urti-gap-heavy` | pass | 31.4s |
| `urti-hard-red-flag` | pass | 30.9s |
| `urti-diagnosis-not-assessed` | pass | 33.0s |
| `urti-hard-uncertain` | pass | 21.7s |
| `urti-identifier-dense-routine` | pass | 42.3s |

Not vacuous: the two fixtures carrying expected rule hits raised all four. One honest caveat, `urti-hard-red-flag` returned 0 suggestions, so its citation check passed trivially.

## Gates

482 tests (37 + 388 + 45 + 12), typecheck clean across four workspaces, lint clean. The 5 new `noConsole` warnings in `run.ts` match the existing precedent in `prisma/seed*.ts`, where a CLI legitimately prints.

## Clinical-Safety Checklist

Read-only with respect to clinical logic. No change to `deid/`, `lib/llm/`, `redflags/`, `guidelines/`, or logging. Reads synthetic fixtures only. Each run writes `consultation.ephemeral_analyzed` audit rows, which is the endpoint's existing designed behaviour.

https://claude.ai/code/session_01VQQGcjk9fUhxR9c9kGqv2A