### PR TITLE
perf(ui): use WebGPU for ASR when a real adapter exists

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,7 @@
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^5.0.4",
+        "@webgpu/types": "^0.1.71",
         "jsdom": "^27.0.0",
         "tailwindcss": "^4.1.14",
         "typescript": "^5.9.3",
@@ -558,6 +559,8 @@
     "@vitest/spy": ["@vitest/spy@3.2.7", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ=="],
 
     "@vitest/utils": ["@vitest/utils@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw=="],
+
+    "@webgpu/types": ["@webgpu/types@0.1.71", "", {}, "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.0.4",
+    "@webgpu/types": "^0.1.71",
     "jsdom": "^27.0.0",
     "tailwindcss": "^4.1.14",
     "typescript": "^5.9.3",

--- a/frontend/src/audio/transcribe.worker.ts
+++ b/frontend/src/audio/transcribe.worker.ts
@@ -1,4 +1,5 @@
 /// <reference lib="webworker" />
+/// <reference types="@webgpu/types" />
 import { type AutomaticSpeechRecognitionPipeline, env, pipeline } from '@huggingface/transformers'
 import type { WorkerRequest, WorkerResponse } from './protocol.js'
 
@@ -71,13 +72,20 @@ const post = (message: WorkerResponse) => self.postMessage(message)
 
 let transcriber: AutomaticSpeechRecognitionPipeline | null = null
 
-async function load() {
-  if (transcriber) return transcriber
-  transcriber = await pipeline('automatic-speech-recognition', MODEL, {
-    // WASM is first-class here rather than a fallback (docs/trd.md §20). WebGPU
-    // is faster where it exists, but availability across clinic desktops is not
-    // something this product can assume, and a path that works everywhere beats
-    // a faster one that strands some users.
+function onProgress(event: unknown) {
+  const p = event as { status?: string; file?: string; loaded?: number; total?: number }
+  if (p.status === 'progress' && p.total) {
+    post({ type: 'progress', loaded: p.loaded ?? 0, total: p.total, file: p.file ?? '' })
+  }
+}
+
+/**
+ * The path proven end to end in this product's own testing, and what WebGPU
+ * falls back to below. Kept byte-for-byte unchanged from the single-device
+ * version this replaced, precisely so this remains true.
+ */
+async function loadWasm() {
+  return pipeline('automatic-speech-recognition', MODEL, {
     device: 'wasm',
     /*
      * Split by module, and both halves are forced rather than tuned.
@@ -120,13 +128,61 @@ async function load() {
      * `_quantized` one, so switching dtype was never going to help either.
      */
     session_options: { graphOptimizationLevel: 'disabled' },
-    progress_callback: (event: unknown) => {
-      const p = event as { status?: string; file?: string; loaded?: number; total?: number }
-      if (p.status === 'progress' && p.total) {
-        post({ type: 'progress', loaded: p.loaded ?? 0, total: p.total, file: p.file ?? '' })
-      }
-    },
+    progress_callback: onProgress,
   })
+}
+
+/**
+ * Whether a real WebGPU adapter exists, not just the API surface (issue #129).
+ *
+ * `'gpu' in navigator` is not the check, and that is measured rather than a
+ * style preference: this project's own testing (14/08/26) found an
+ * environment where `navigator.gpu` exists and `requestAdapter()` resolves to
+ * `null`. Testing for the API's presence would select WebGPU on a machine it
+ * cannot run on.
+ */
+async function hasWebGpuAdapter(): Promise<boolean> {
+  if (typeof navigator === 'undefined' || !('gpu' in navigator)) return false
+  try {
+    return (await navigator.gpu.requestAdapter()) !== null
+  } catch {
+    return false
+  }
+}
+
+/**
+ * WebGPU when a real adapter exists, WASM otherwise (issue #129).
+ *
+ * The two are not offered the same options. `dtype: 'q8'` and the disabled
+ * graph-optimisation pass in `loadWasm` are measured fixes for a bug in the
+ * WASM execution provider specifically, never checked against WebGPU's, so
+ * carrying them across backends would be a guess wearing the shape of a fix.
+ * `dtype` is left unset for WebGPU instead: this library's own default for it
+ * is `fp32`, `q8` is a WASM-only default, and the q8 decoder is independently
+ * known not to load at all on this runtime (see `loadWasm`).
+ *
+ * A WebGPU adapter existing is not proof every operator this model needs is
+ * implemented in it, so a failure here still falls back to the WASM path
+ * rather than surfacing an error a plain WASM run would never have had. That
+ * fallback has not been exercised against real WebGPU hardware by this
+ * product's own testing; only the detection-finds-nothing path has.
+ */
+async function load() {
+  if (transcriber) return transcriber
+
+  if (!(await hasWebGpuAdapter())) {
+    transcriber = await loadWasm()
+    return transcriber
+  }
+
+  try {
+    transcriber = await pipeline('automatic-speech-recognition', MODEL, {
+      device: 'webgpu',
+      progress_callback: onProgress,
+    })
+  } catch {
+    transcriber = await loadWasm()
+  }
   return transcriber
 }
 


### PR DESCRIPTION
Progress on #129.

## Why

On-device transcription has always run single threaded. Measured on production today: a 5-minute recording took roughly 17 minutes, renderer pegged at 100% of one core out of sixteen, `crossOriginIsolated: false`. WebGPU is the fix that does not need the cross-origin isolation headers this project is deliberately holding off on until after the demo recording.

## What

`hasWebGpuAdapter()` requests a real adapter rather than testing for the API's presence. That distinction is not theoretical: this project's own testing today found an environment where `navigator.gpu` exists and `requestAdapter()` resolves to `null`. Testing `'gpu' in navigator` would have selected WebGPU on exactly the machine it cannot run on, from inside a worker with no user to notice before the model finishes downloading.

**The WASM path is untouched, not just similar.** `loadWasm()` carries the exact same `dtype: 'q8'` and `session_options: { graphOptimizationLevel: 'disabled' }` as before, because both are measured fixes for a bug in the WASM execution provider specifically (documented in the surrounding comments), and this project has already been burned once by assuming a workaround generalises across backends when it did not.

**WebGPU gets neither workaround.** Checked against the library's own source (`@huggingface/transformers/src/utils/dtypes.js`): `q8` is the WASM-only default dtype; every other device, WebGPU included, defaults to `fp32` unless told otherwise. Forcing `q8` onto WebGPU would be a guess wearing the shape of a fix, and the q8 decoder is independently known not to open a session at all on this runtime.

**Failure still falls back.** A WebGPU adapter existing is not proof every operator this model needs is implemented in it, so a `pipeline()` failure under WebGPU retries once on the WASM path rather than surfacing an error a plain WASM run would never have had.

## What This Does Not Do, And Why

- **Graph optimisation stays disabled.** That flag is documented as the fix for a real session-creation failure, not a tuning knob, and I could not currently verify a change to it (see below). Touching it without verification would be the same mistake as forcing `q8` onto WebGPU.
- **`return_timestamps` stays unconditional**, pending #131. Whether long recordings lose their timestamps by design or by a discardable bug decides whether this is even safe to make conditional.
- **COEP is untouched**, on explicit instruction, until after the recording.

## Verification, Stated Precisely

Typecheck, lint, and the full suite (482 tests, unaffected by this branch since it is not stacked on the evals harness) are clean.

**Browser verification is partial, and I want to be exact about the boundary rather than round it up.** This project's test environment has no working WebGPU adapter anywhere I could reach today, on the production origin or a local one. That means only the detection-finds-nothing branch has actually been exercised:

- Confirmed on localhost, post-refactor: `hasWebGpuAdapter()` correctly resolved `false`, fell through to `loadWasm()`, and produced a correct transcription. Byte-for-byte the same options as the pre-existing, already-proven path, so this is a real regression check, not a smoke test.
- The WebGPU branch itself has not been exercised end to end by me. The code comment says so directly rather than leaving it to a commit message nobody reads later. It needs a real GPU-backed browser before its numbers should be trusted.

Separately, and not blocking this: production intermittently returned `no available backend found... Failed to fetch dynamically imported module: blob:...` on the WASM path today, reproducing 4/4 in this same sandboxed browser against the production origin, while succeeding on localhost against the identical model host. Root cause undetermined; a real-browser check against production is outstanding and unrelated to whether this diff is safe to merge, since it changes nothing about that failure mode either way.

## Clinical-Safety Checklist

Not applicable. No change to `deid/`, `lib/llm/`, `redflags/`, `guidelines/`, or logging. Client-side ASR device selection only; the "transcribed on this device, never uploaded" property is unaffected either branch takes.

https://claude.ai/code/session_01VQQGcjk9fUhxR9c9kGqv2A