### PR TITLE
fix(infra): allow blob: in script-src so ASR can load its backend

### DIFF
--- a/docs/trd.md
+++ b/docs/trd.md
@@ -1019,15 +1019,28 @@ Source: the `headers` block in `vercel.json`. The API is covered separately by `
 | `Permissions-Policy`         | `microphone=(self), camera=(), geolocation=(), ...` | **`microphone=(self)` is load-bearing**, see below.                                      |
 | `Cross-Origin-Opener-Policy` | `same-origin`                                       | Severs any opener relationship. Safe here because the app opens no cross-origin windows. |
 
-**Three entries look like they could be trimmed and cannot.** All three were established by loading the built app under the real policy and exercising the Record tab, not by reading documentation.
+**Four entries look like they could be trimmed and cannot.** All four were established by loading the built app under the real policy and exercising the Record tab, not by reading documentation.
 
 - **`'wasm-unsafe-eval'` in `script-src`.** The speech model is WebAssembly. Without this it cannot instantiate, and the failure appears as a broken Record tab rather than as an obvious policy error.
+- **`blob:` in `script-src`.** ONNX Runtime loads its execution backend by fetching it, wrapping the response in a `URL.createObjectURL` blob, and calling `import()` on that blob. A dynamic import is governed by `script-src`, not by `worker-src`, so `worker-src 'self' blob:` starts the worker and then the backend load inside it is blocked. The failure surfaces as `no available backend found. ERR: [wasm] TypeError: Failed to fetch dynamically imported module: blob:...`, **after** the model reports 100% downloaded, which reads as a model or network problem rather than a policy one.
 - **`microphone=(self)` in `Permissions-Policy`.** A policy that omits `microphone` denies it. Recording would be refused by the browser before any application code ran.
 - **`https://*.hf.co` in `connect-src`.** HuggingFace serves `huggingface.co` but **redirects model downloads to a different registrable path**, observed as `us.aws.cdn.hf.co`. Allowing only `huggingface.co` passes a superficial test, because the config and tokenizer files come from there, and then fails on the model weights.
 
 **`Cross-Origin-Embedder-Policy` is deliberately absent.** It would require every cross-origin response the speech model fetches to carry `Cross-Origin-Resource-Policy`, which the HuggingFace CDN does not send. Adding it would break transcription in exchange for a header this app gains nothing from, since it uses no `SharedArrayBuffer`.
 
-**How this was verified.** The production build was served locally under the exact policy string from `vercel.json`, same-origin with the API proxied, so that a CORS failure could not be mistaken for a CSP failure. The app was then exercised end to end including the Record tab. Zero violations were reported. A control run under `default-src *` behaved identically, which is what rules the policy out as the cause of any failure seen during that testing.
+**How this was verified.** The production build is served locally under the exact policy string from `vercel.json`, same-origin with the API proxied, so that a CORS failure cannot be mistaken for a CSP failure.
+
+**That method missed `blob:` once, and the reason is worth keeping.** The original verification drove the Record tab through the UI in a browser whose `transformers-cache` was already warm, so the backend load did not take the path that needs `blob:`. The policy then shipped and broke transcription for anyone arriving with a cold cache. Driving the UI is not a sufficient test of a policy, because the UI can be satisfied by cached state that a first-time visitor does not have.
+
+**So the check is now against the built worker directly**, which removes both the cache and the sign-in from the question:
+
+```js
+const w = new Worker('/assets/transcribe.worker-<hash>.js', { type: 'module' })
+w.onmessage = (e) => console.log(e.data) // expect { type: 'ready' }
+w.postMessage({ type: 'load' })
+```
+
+Run against two servers differing only in the policy string, this is a controlled A/B rather than an observation: without `blob:` in `script-src` it returns the `no available backend found` error above, with it the worker reports `ready`. `'unsafe-eval'` was checked the same way and is **not** required, so it stays out.
 
 ### Render Service Definition (`render.yaml`)
 

--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; media-src 'self' blob:; connect-src 'self' https://catatmd-api.onrender.com https://huggingface.co https://*.huggingface.co https://*.hf.co https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' blob: https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; media-src 'self' blob:; connect-src 'self' https://catatmd-api.onrender.com https://huggingface.co https://*.huggingface.co https://*.hf.co https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
         },
         {
           "key": "Strict-Transport-Security",


### PR DESCRIPTION
**Transcription is broken in production right now.** Reported from a real browser, reproduced and root-caused here.

## Symptom

The model downloads to 100%, then:

```
no available backend found. ERR: [wasm] TypeError: Failed to fetch
dynamically imported module: blob:https://catatmd.vercel.app/...
```

Because it fails *after* the download completes, it reads as a model or network problem. It is neither.

## Cause

ONNX Runtime loads its execution backend by fetching it, wrapping the response in a `createObjectURL` blob, and calling `import()` on that blob. Visible in the built bundle:

```js
e => { let t = await (await fetch(e, {credentials:"same-origin"})).blob(); return URL.createObjectURL(t) },
Su = async e => (await import(e)).default
```

A dynamic `import()` is governed by **`script-src`**, not `worker-src`. So `worker-src 'self' blob:` successfully starts the worker, and the backend load *inside* it is then blocked.

## Proven, Not Inferred

Drove the built worker directly against two servers differing **only** in the policy string. Same bundle, same worker, same browser:

| `script-src` | `postMessage({type:'load'})` |
| --- | --- |
| `'self' 'wasm-unsafe-eval' https://cdn.jsdelivr.net` | `no available backend found... blob:...` |
| `'self' 'wasm-unsafe-eval' blob: https://cdn.jsdelivr.net` | `{ type: 'ready' }` |

`'unsafe-eval'` was checked the same way and is **not** required, so it stays out. This is the minimum addition that works.

## Why The Original Verification Missed It

The first CSP verification drove the Record tab through the UI in a browser whose `transformers-cache` was already warm, so the backend load never took the path that needs `blob:`. It shipped working for that profile and broken for anyone arriving with a cold cache, which is every real first-time visitor.

The TRD now records the worker-level check instead, because **driving the UI can be satisfied by cached state a first-time visitor does not have**. That is the reusable lesson, so it is written down rather than left as tribal knowledge.

**Not dependency drift:** `onnxruntime-web` is exact-pinned by `@huggingface/transformers@4.2.0` and CI installs with `--frozen-lockfile`.

## Security Note

`blob:` in `script-src` permits executing script from blob URLs minted by same-origin script. `worker-src 'self' blob:` was already present, and an attacker who can mint and import a blob already has script execution, so this does not hand over a new capability so much as stop breaking a legitimate one. It is required for on-device ASR to function at all.

## Clinical-Safety Checklist

Not applicable. Header configuration and documentation only. No change to `deid/`, `lib/llm/`, `redflags/`, `guidelines/`, or logging.

https://claude.ai/code/session_01VQQGcjk9fUhxR9c9kGqv2A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated SPA security-header guidance to allow `blob:` scripts required for ONNX Runtime’s WASM backend.
  - Added verification steps confirming backend loading succeeds with `blob:` and fails without it.

- **Bug Fixes**
  - Updated the Content Security Policy to permit scripts loaded from `blob:` URLs, enabling the WASM backend to initialize correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->