### PR TITLE
feat(ui): show real transcription progress, and unfreeze the spinner

### DIFF
--- a/frontend/src/audio/AudioCapture.tsx
+++ b/frontend/src/audio/AudioCapture.tsx
@@ -66,6 +66,28 @@ async function toMono16k(blob: Blob): Promise<Float32Array> {
 
 type Phase = 'idle' | 'recording' | 'loading-model' | 'transcribing'
 
+/**
+ * Roughly how much longer, from how long the finished chunks actually took.
+ *
+ * **Silent until it has two chunks to reason from.** One chunk is not a rate:
+ * the first carries the session warm-up, so extrapolating from it overstates
+ * the total badly, and a countdown that starts at nine minutes and then drops
+ * to four teaches people to disbelieve it. No estimate reads better than a
+ * wrong one.
+ *
+ * Rounded up to whole minutes above a minute, because the underlying rate is
+ * not steady enough to justify "3:47" and displaying seconds would imply a
+ * precision this cannot deliver.
+ */
+function estimateRemaining(done: number, total: number, elapsedMs: number): string | null {
+  if (done < 2 || done >= total) return null
+
+  const remainingMs = (elapsedMs / done) * (total - done)
+  if (remainingMs < 45_000) return 'under a minute left'
+
+  return `about ${Math.ceil(remainingMs / 60_000)} min left`
+}
+
 export function AudioCapture({
   onTranscript,
 }: {
@@ -76,6 +98,10 @@ export function AudioCapture({
   const [error, setError] = useState<string | null>(null)
   const [overridden, setOverridden] = useState(false)
   const [seconds, setSeconds] = useState(0)
+  const [chunkProgress, setChunkProgress] = useState<{ done: number; total: number } | null>(null)
+
+  /** When the current transcription started, for the remaining-time estimate. */
+  const startedAt = useRef<number | null>(null)
 
   const worker = useRef<Worker | null>(null)
   const recorder = useRef<MediaRecorder | null>(null)
@@ -109,15 +135,23 @@ export function AudioCapture({
       if (message.type === 'ready') {
         setProgress(null)
         setPhase('transcribing')
+        startedAt.current = Date.now()
+      }
+      if (message.type === 'transcribing') {
+        setChunkProgress({ done: message.done, total: message.total })
       }
       if (message.type === 'result') {
         setPhase('idle')
         setProgress(null)
+        setChunkProgress(null)
+        startedAt.current = null
         onTranscriptRef.current({ text: message.text, segments: message.segments })
       }
       if (message.type === 'error') {
         setPhase('idle')
         setProgress(null)
+        setChunkProgress(null)
+        startedAt.current = null
         setError(message.message)
       }
     }
@@ -139,6 +173,7 @@ export function AudioCapture({
     async (blob: Blob) => {
       setError(null)
       setPhase('loading-model')
+      setChunkProgress(null)
       try {
         const audio = await toMono16k(blob)
         const request: WorkerRequest = { type: 'transcribe', audio }
@@ -180,6 +215,33 @@ export function AudioCapture({
   }, [])
 
   const busy = phase === 'loading-model' || phase === 'transcribing'
+
+  /*
+   * One line that always says what is actually happening, and a bar only when
+   * there is a measured number behind it.
+   *
+   * The download half already had a real percentage. The transcribe half had
+   * nothing but prose, which on a consultation-length recording meant several
+   * minutes of a screen that could not be told apart from a hung one.
+   */
+  const percent =
+    chunkProgress === null ? null : Math.round((chunkProgress.done / chunkProgress.total) * 100)
+
+  const remaining =
+    chunkProgress === null || startedAt.current === null
+      ? null
+      : estimateRemaining(chunkProgress.done, chunkProgress.total, Date.now() - startedAt.current)
+
+  const status =
+    phase === 'loading-model'
+      ? progress === null
+        ? 'Preparing the speech model. The first run downloads it once and the browser caches it.'
+        : `Downloading the speech model, ${progress}%. This happens once.`
+      : percent === null
+        ? 'Transcribing on this device. Longer recordings take a few minutes.'
+        : `Transcribing on this device, ${percent}%${remaining === null ? '' : `, ${remaining}`}.`
+
+  const bar = phase === 'loading-model' ? progress : percent
 
   return (
     <div className="flex flex-col gap-3">
@@ -243,14 +305,35 @@ export function AudioCapture({
       )}
 
       {busy && (
-        <p className="flex items-center gap-2 text-sm text-ink-muted">
-          <Loader2 aria-hidden className="size-4 animate-spin" />
-          {phase === 'loading-model'
-            ? progress === null
-              ? 'Preparing the speech model. The first run downloads it once and the browser caches it.'
-              : `Downloading the speech model, ${progress}%. This happens once.`
-            : 'Transcribing on this device. Longer recordings take a few minutes.'}
-        </p>
+        <div className="flex flex-col gap-2">
+          <p className="flex items-center gap-2 text-sm text-ink-muted">
+            {/* `busy-spinner` exempts this from the blanket reduced-motion rule
+                in index.css. A spinner frozen mid-turn reads as hung, which is
+                the opposite of what it exists to say. */}
+            <Loader2 aria-hidden className="busy-spinner size-4 animate-spin" />
+            <span role="status">{status}</span>
+          </p>
+
+          {/* A real bar, driven by measured chunk completions rather than by an
+              animation, so its position means something. Width is a transition
+              rather than an animation, which the reduced-motion rule leaves
+              alone, so it still moves for everyone. */}
+          {bar !== null && (
+            <div
+              className="h-1 w-full overflow-hidden rounded-full bg-sunken"
+              role="progressbar"
+              aria-valuenow={bar}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label="Transcription progress"
+            >
+              <div
+                className="h-full rounded-full bg-accent transition-[width] duration-500 ease-out"
+                style={{ width: `${bar}%` }}
+              />
+            </div>
+          )}
+        </div>
       )}
 
       {error && (

--- a/frontend/src/audio/protocol.test.ts
+++ b/frontend/src/audio/protocol.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { CHUNK_LENGTH_S, countChunks, STRIDE_LENGTH_S, TARGET_SAMPLE_RATE } from './protocol.js'
+
+/**
+ * `countChunks` predicts how many times the model will run, and the progress
+ * bar divides by it. If it disagrees with the pipeline's own windowing the bar
+ * finishes early or stalls short of the end, which is worse than showing
+ * nothing, so the prediction is pinned against a transcription of the
+ * library's loop rather than against observed output.
+ */
+
+/** `_call_whisper`'s loop, transcribed. The oracle this is checked against. */
+function actualChunks(samples: number): number {
+  const window = TARGET_SAMPLE_RATE * CHUNK_LENGTH_S
+  const stride = TARGET_SAMPLE_RATE * STRIDE_LENGTH_S
+  const jump = window - 2 * stride
+
+  let offset = 0
+  let count = 0
+  while (true) {
+    count += 1
+    if (offset + window >= samples) break
+    offset += jump
+  }
+  return count
+}
+
+const seconds = (s: number) => s * TARGET_SAMPLE_RATE
+
+describe('countChunks', () => {
+  it('is one chunk for audio inside a single window', () => {
+    expect(countChunks(seconds(4))).toBe(1)
+    expect(countChunks(seconds(30))).toBe(1)
+  })
+
+  it('counts a 20 second advance per chunk, not a full window', () => {
+    // The stride overlaps both ends, so each step advances window - 2*stride,
+    // which is 20s and not 30s. Assuming 30 would under-count every long
+    // recording and the bar would reach 100% while work continued.
+    expect(countChunks(seconds(50))).toBe(2)
+    expect(countChunks(seconds(70))).toBe(3)
+  })
+
+  it('matches the pipeline loop across the range a consultation spans', () => {
+    for (let s = 1; s <= 900; s += 1) {
+      expect({ s, n: countChunks(seconds(s)) }).toEqual({ s, n: actualChunks(seconds(s)) })
+    }
+  })
+
+  it('never returns zero, so a division by it cannot produce Infinity', () => {
+    expect(countChunks(0)).toBe(1)
+    expect(countChunks(1)).toBe(1)
+  })
+})

--- a/frontend/src/audio/protocol.ts
+++ b/frontend/src/audio/protocol.ts
@@ -27,9 +27,41 @@ export type WorkerRequest = { type: 'load' } | { type: 'transcribe'; audio: Floa
  */
 export type TranscriptSegment = { text: string; start: number; end: number | null }
 
+/**
+ * How Whisper is chunked, and the numbers the progress count is derived from.
+ *
+ * These live here rather than inline at the call site because the chunk count
+ * has to be predicted on one side and consumed on the other, and two copies of
+ * a windowing calculation is how a progress bar starts lying.
+ */
+export const CHUNK_LENGTH_S = 30
+export const STRIDE_LENGTH_S = 5
+
+/**
+ * How many times the model will run over an audio of this length.
+ *
+ * Mirrors the pipeline's own windowing exactly (`_call_whisper`): a window of
+ * `CHUNK_LENGTH_S`, overlapping by `STRIDE_LENGTH_S` at each end, so each step
+ * advances `window - 2 * stride` rather than a full window. Getting this wrong
+ * does not fail loudly, it produces a percentage that finishes early or stalls
+ * near the end, which is worse than showing nothing.
+ */
+export function countChunks(samples: number, sampleRate = TARGET_SAMPLE_RATE): number {
+  const window = sampleRate * CHUNK_LENGTH_S
+  const jump = window - 2 * (sampleRate * STRIDE_LENGTH_S)
+  if (samples <= window) return 1
+  return Math.ceil((samples - window) / jump) + 1
+}
+
 export type WorkerResponse =
   | { type: 'progress'; loaded: number; total: number; file: string }
   | { type: 'ready' }
+  /**
+   * One chunk of audio finished transcribing. `done` counts completed chunks,
+   * `total` is fixed for the recording, so `done / total` is real measured
+   * progress rather than an animation.
+   */
+  | { type: 'transcribing'; done: number; total: number }
   /** `segments` empty means no usable timing; callers fall back to plain prose. */
   | { type: 'result'; text: string; segments: readonly TranscriptSegment[] }
   | { type: 'error'; message: string }

--- a/frontend/src/audio/transcribe.worker.test.ts
+++ b/frontend/src/audio/transcribe.worker.test.ts
@@ -13,17 +13,31 @@ import type { WorkerResponse } from './protocol.js'
  * shape of bug a type checker and a passing suite both wave through.
  */
 
-const asr = vi.fn(async () => ({ text: 'hello', chunks: [] }) as unknown)
+/**
+ * Stands in for the pipeline. `chunkRuns` is how many times it pretends the
+ * model ran, which is what drives `streamer.end()` and therefore the progress
+ * messages.
+ */
+let chunkRuns = 1
+
+const asr = vi.fn(async (_audio: unknown, options?: { streamer?: { end: () => void } }) => {
+  for (let i = 0; i < chunkRuns; i += 1) options?.streamer?.end()
+  return { text: 'hello', chunks: [] } as unknown
+})
 
 vi.mock('@huggingface/transformers', () => ({
   pipeline: vi.fn(async () => asr),
   env: {},
+  // The real one throws from both methods so subclasses must override, which
+  // `ChunkCounter` does. A bare class is enough to stand in for that here.
+  BaseStreamer: class {},
 }))
 
 let posted: WorkerResponse[]
 
 beforeEach(async () => {
   posted = []
+  chunkRuns = 1
   vi.spyOn(self, 'postMessage').mockImplementation(((message: WorkerResponse) => {
     posted.push(message)
   }) as typeof self.postMessage)
@@ -38,10 +52,8 @@ afterEach(() => {
 })
 
 /** Drives the worker the way the component does, and waits for it to settle. */
-async function transcribe() {
-  self.onmessage?.(
-    new MessageEvent('message', { data: { type: 'transcribe', audio: new Float32Array(16) } }),
-  )
+async function transcribe(audio = new Float32Array(16)) {
+  self.onmessage?.(new MessageEvent('message', { data: { type: 'transcribe', audio } }))
   await vi.waitFor(() =>
     expect(posted.some((m) => m.type === 'result' || m.type === 'error')).toBe(true),
   )
@@ -59,13 +71,44 @@ describe('the transcribe path', () => {
     // satisfy the test above and still leave the misleading copy on screen for
     // the entire transcription.
     //
-    // Asserted as an exact sequence rather than by comparing indexes. With the
-    // fix reverted, `indexOf('ready')` is -1 and `-1 < 0` passes, so the
-    // obvious form of this test is vacuous. That was not hypothetical: it is
-    // what the first draft did, and deleting the fix left it green.
+    // Asserted by position rather than by comparing indexes. With the fix
+    // reverted, `indexOf('ready')` is -1 and `-1 < 0` passes, so the obvious
+    // form of this test is vacuous. That was not hypothetical: it is what the
+    // first draft did, and deleting the fix left it green. Here, removing the
+    // `ready` post makes the first message `transcribing` and this fails.
     await transcribe()
 
-    expect(posted.map((m) => m.type)).toEqual(['ready', 'result'])
+    expect(posted.at(0)?.type).toBe('ready')
+    expect(posted.at(-1)?.type).toBe('result')
+  })
+
+  it('reports one progress message per chunk the model runs', async () => {
+    const { TARGET_SAMPLE_RATE, countChunks } = await import('./protocol.js')
+    const audio = new Float32Array(TARGET_SAMPLE_RATE * 70)
+    const total = countChunks(audio.length)
+    chunkRuns = total
+
+    await transcribe(audio)
+
+    const ticks = posted.filter((m) => m.type === 'transcribing')
+
+    expect(ticks).toEqual(
+      Array.from({ length: total }, (_, i) => ({ type: 'transcribing', done: i + 1, total })),
+    )
+  })
+
+  it('never reports more chunks done than the total', async () => {
+    // The total is a prediction of the pipeline's windowing. If it ever
+    // under-counts, the bar should sit at 100% rather than report 3 of 2 and
+    // render a width above full.
+    chunkRuns = 5
+
+    await transcribe()
+
+    const ticks = posted.flatMap((m) => (m.type === 'transcribing' ? [m] : []))
+
+    expect(ticks.every((t) => t.done <= t.total)).toBe(true)
+    expect(ticks.at(-1)).toEqual({ type: 'transcribing', done: 1, total: 1 })
   })
 
   it('reports a failure as an error rather than a silent stall', async () => {

--- a/frontend/src/audio/transcribe.worker.ts
+++ b/frontend/src/audio/transcribe.worker.ts
@@ -1,7 +1,18 @@
 /// <reference lib="webworker" />
 /// <reference types="@webgpu/types" />
-import { type AutomaticSpeechRecognitionPipeline, env, pipeline } from '@huggingface/transformers'
-import type { WorkerRequest, WorkerResponse } from './protocol.js'
+import {
+  type AutomaticSpeechRecognitionPipeline,
+  BaseStreamer,
+  env,
+  pipeline,
+} from '@huggingface/transformers'
+import {
+  CHUNK_LENGTH_S,
+  countChunks,
+  STRIDE_LENGTH_S,
+  type WorkerRequest,
+  type WorkerResponse,
+} from './protocol.js'
 
 /**
  * On-device speech recognition (issue #2, docs/trd.md §20).
@@ -204,7 +215,55 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
      * downloading a model it had already cached.
      */
     post({ type: 'ready' })
-    const output = await asr(event.data.audio, {
+
+    /*
+     * Real per-chunk progress, not an animation.
+     *
+     * The pipeline calls `generate()` once per audio chunk and `generate()`
+     * calls `streamer.end()` exactly once before it returns, so `end()` is a
+     * precise "one chunk finished" tick. `streamer` is a documented generation
+     * parameter and every kwarg here is spread into the generation config by
+     * `_call_whisper`, so this rides a public API rather than a private hook.
+     *
+     * `put` is required by the interface and deliberately does nothing: it
+     * fires per token, and posting at that rate would flood the main thread
+     * with messages to render a number that changes too fast to read.
+     */
+    const total = countChunks(event.data.audio.length)
+    let done = 0
+
+    class ChunkCounter extends BaseStreamer {
+      /** Required by the interface, and deliberately empty. See above. */
+      override put() {}
+      override end() {
+        done += 1
+        // Clamped because the count is a prediction of the pipeline's own
+        // windowing. If it is ever wrong, a progress bar that stops at 100 is a
+        // much smaller lie than one that reports 14 of 13.
+        post({ type: 'transcribing', done: Math.min(done, total), total })
+      }
+    }
+
+    /*
+     * The declared type for `streamer` is wrong, and it is the only thing
+     * corrected here.
+     *
+     * The library types it as `BaseStreamer & TextStreamer`, which demands a
+     * tokenizer and nine other members. But `generation/parameters.js`
+     * documents the parameter as a plain `BaseStreamer`, and `generate()` only
+     * ever calls `put()` and `end()` on it, both of which `ChunkCounter`
+     * implements by extending the exported base class.
+     *
+     * So the field is replaced rather than the object cast: every other option
+     * below stays fully checked, and exactly one documented cast bridges the
+     * bad declaration at the call.
+     */
+    type AsrOptions = Omit<NonNullable<Parameters<typeof asr>[1]>, 'streamer'> & {
+      streamer?: BaseStreamer
+    }
+
+    const options: AsrOptions = {
+      streamer: new ChunkCounter(),
       /*
        * Pinned to English, never read from a locale or from the patient's
        * recorded language (docs/prd.md §12).
@@ -219,8 +278,11 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       task: 'transcribe',
       // A consultation runs far past Whisper's 30-second window, so it is
       // chunked, with overlap so a word spoken across a boundary is not lost.
-      chunk_length_s: 30,
-      stride_length_s: 5,
+      // Shared with `countChunks`, which predicts how many times the model will
+      // run so progress can be a real fraction. Two copies of these numbers is
+      // how a progress bar starts lying.
+      chunk_length_s: CHUNK_LENGTH_S,
+      stride_length_s: STRIDE_LENGTH_S,
       /*
        * Segment timestamps feed the draft speaker labels (docs/trd.md §20.2).
        * Measured on this exact config before being relied on: 17 clean,
@@ -230,7 +292,9 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
        * still refuses anything malformed rather than trusting the type.
        */
       return_timestamps: true,
-    })
+    }
+
+    const output = await asr(event.data.audio, options as NonNullable<Parameters<typeof asr>[1]>)
 
     /*
      * Every part is joined, as before #118: a multi-part result must never

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -587,6 +587,28 @@
       animation-duration: 6s !important;
       animation-iteration-count: infinite !important;
     }
+
+    /*
+     * A busy spinner keeps spinning, for the same reason and a sharper one.
+     *
+     * The blanket rule collapses it to a single 0.01ms rotation, so it stops
+     * mid-turn and sits there. A frozen spinner does not read as "motion was
+     * politely reduced", it reads as **hung**, which is the exact opposite of
+     * the one thing it exists to say. Reported from a real Windows machine with
+     * animations switched off, during a transcription that was running fine.
+     *
+     * Safe on the merits, like the ring above: WCAG 2.3.3 exempts animation
+     * that is essential to the information being conveyed, and a 16px glyph
+     * rotating in place moves no content and no viewport.
+     *
+     * The percentage and remaining-time text next to it carry the same
+     * information without any motion at all, so this is belt and braces rather
+     * than the only signal. `data-motion="reduced"` still wins.
+     */
+    :root:not([data-motion='full']):not([data-motion='reduced']) .busy-spinner {
+      animation-duration: 1s !important;
+      animation-iteration-count: infinite !important;
+    }
   }
 
   :root[data-motion='reduced'] *,


### PR DESCRIPTION
Two reports from a real Windows machine after the CSP fix landed.

## 1. Blind Waiting

The download half had a percentage. The transcribe half had prose, so a consultation-length recording meant several minutes of a screen that could not be told apart from a hung one.

**Progress is now measured, not animated.** The pipeline calls `generate()` once per audio chunk, and `generate()` calls `streamer.end()` exactly once before returning, so `end()` is a precise per-chunk tick. `streamer` is a documented generation parameter and `_call_whisper` spreads every kwarg into the generation config, so this rides a public API rather than a private hook.

`countChunks` predicts the denominator from the library's own windowing. Its test checks that prediction against a transcription of the actual loop for **every duration from 1s to 15 minutes**, rather than against observed output, because a bar built on a wrong count finishes early or stalls near the end.

**The ETA stays silent until two chunks are done.** One chunk is not a rate: it carries the session warm-up, and a countdown that opens at nine minutes then drops to four teaches people to disbelieve it. Rounded to whole minutes, because the underlying rate is not steady enough to justify "3:47".

Measured on a 95s clip:

```
"Transcribing on this device. Longer recordings take a few minutes."   <- before chunk 1
"Transcribing on this device, 20%."                                     <- ETA correctly withheld
"Transcribing on this device, 40%, about 2 min left."
"Transcribing on this device, 60%, about 1 min left."
"Transcribing on this device, 80%, under a minute left."
```

Monotonic throughout, and `aria-valuenow` tracked 20/40/60/80.

## 2. Frozen Spinner

The blanket reduced-motion rule collapses every animation to `0.01ms` with one iteration, so the spinner stopped mid-turn and sat there. Windows "animations off" makes Chromium report `prefers-reduced-motion: reduce`, and that setting is commonly chosen for performance rather than for vestibular need.

**A frozen spinner does not read as motion politely reduced. It reads as hung**, which is the exact opposite of the one thing it exists to say. Reported during a transcription that was running fine.

Exempted the same way `.tour-ring` already is in this file, and on the same merits: WCAG 2.3.3 carves out animation essential to the information being conveyed, and a 16px glyph rotating in place moves no content and no viewport. The explicit in-app `data-motion="reduced"` still wins over the exemption, so someone who asks this product for stillness gets it.

The percentage and remaining-time text carry the same information with no motion at all, so the spinner is belt and braces rather than the only signal. The progress bar uses a width **transition**, which that rule does not touch, so it moves for everyone regardless.

## Notes

- One documented cast: the library types `streamer` as `BaseStreamer & TextStreamer`, demanding a tokenizer and nine members `generate()` never touches, while its own `parameters.js` documents it as a plain `BaseStreamer`. The field is replaced via `Omit` so every other option stays fully checked, rather than casting the whole options object.
- `chunk_length_s` / `stride_length_s` now come from shared constants used by both the pipeline call and `countChunks`. Two copies of a windowing calculation is how a progress bar starts lying.
- The pre-existing exact-sequence ordering test was updated (there is now a `transcribing` between `ready` and `result`) and re-confirmed non-vacuous: with the `ready` fix reverted, both ordering tests still fail.

488 tests (+6), typecheck and lint clean, verified in a browser end to end.

## Clinical-Safety Checklist

Not applicable. Progress reporting and CSS only. No change to `deid/`, `lib/llm/`, `redflags/`, `guidelines/`, or logging. No transcript content is posted through the new message; it carries two integers.

https://claude.ai/code/session_01VQQGcjk9fUhxR9c9kGqv2A