### PR TITLE
fix(ui): bound transcription stalls with a silence budget, cancel and honest phases

### DIFF
--- a/docs/trd.md
+++ b/docs/trd.md
@@ -1298,6 +1298,25 @@ The residency argument needs **one disclosed origin, not zero**, and is stronger
 
 `asr_local` is **`Built`** as of issue #2, so this describes shipping behaviour rather than a contract to hold to. Measured on a real Malaysian English sample: 25 seconds of audio transcribed in 33 seconds on WASM, with the weights fetched once (~240 MB) and browser-cached after. The register held: the output keeps `lah` and renders "aunties" correctly, which is the exact word §20.1 recorded `whisper-base` mangling into "until".
 
+### Bounding The Wait: The Worker Speaks, Silence Is Terminated
+
+Shipping behaviour as of issues #138 and #139. The contract in one line: **the worker speaks continuously from the first request to the result, and the component terminates any worker silent for `STALL_TIMEOUT_MS` (180 s), tells the doctor what happened, and points at typing or pasting.** A wedged weight fetch, a hung `requestAdapter()`, a dead worker and a malformed audio container all end the same way: bounded, visible, and recoverable, never an infinite spinner.
+
+| Rule                        | Mechanism                                                                                                                                                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Every phase is on screen    | Aggregate download bytes (the library's `progress_total`, whose denominator covers every file from its first event), a `ready` stage change, a per-chunk `transcribing` tick, an `alive` token heartbeat, and `finishing` once before the merge tail |
+| Silence is bounded          | One timer armed before the audio decode and rearmed by every worker message; expiry terminates the worker and surfaces the typing-or-pasting sentence                                                                                                |
+| The doctor can always leave | A Cancel control that terminates the worker; after a failure, Try Again reruns the retained audio rather than asking for the consultation again                                                                                                      |
+| Failure degrades to paste   | The stall and worker-death sentences point at typing or pasting and never mention hosted ASR (the governing rule above)                                                                                                                              |
+
+Three properties are load-bearing and worth defending against future edits:
+
+- **The budget is on silence, not duration.** §20.1 measures an RTF of 1.5 to 3.0, so a consultation-length recording legitimately transcribes for many minutes; a deadline on the whole job would abort exactly the recordings most expensive to lose. 180 s is floored by ONNX session creation, which blocks the worker thread on a ~240 MB decoder and is legitimately silent throughout.
+- **The heartbeat rides on tokens, not Whisper timestamps.** Timestamps go silent over stride overlaps, quiet audio and repetition loops, any of which would let the budget kill a healthy run; tokens fire per decoding step whatever the audio contains (`HEARTBEAT_TOKENS`, one `alive` per eight).
+- **`finishing` clears the budget rather than rearming it.** After the last chunk the tokenizer merge blocks the worker thread, so no heartbeat is physically possible until the result. The phase is named on screen, the spinner carries liveness, and Cancel remains the doctor's bound. A cap here would have to be sized for the slowest legitimate merge, at which point it protects nothing Cancel does not, while a wrong one destroys a finished transcription, the worst outcome this feature has.
+
+Cancel is a `terminate()`, never a message: a worker wedged inside a fetch that never settles will not read one. Every exit, whether expiry, cancel, worker death or unmount, leaves no worker running and no timer armed. The bar also stopped claiming a finished download: at 100% the copy reads "Opening the speech model", because the ORT backend import and the session open both happen after the last byte, which is the same stretch where a blocked backend used to surface only after a finished-looking download.
+
 ### Deciding Whether To Offer Audio — The Two-Stage Capability Probe
 
 The probe's job is to decide **whether to offer audio on this device at all** — not to silently pick a mode. Mode selection is the doctor's (see the governing rule); capability is a fact about the machine.

--- a/frontend/src/audio/AudioCapture.test.tsx
+++ b/frontend/src/audio/AudioCapture.test.tsx
@@ -1,0 +1,367 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AudioCapture, STALL_TIMEOUT_MS } from './AudioCapture.js'
+import type { WorkerResponse } from './protocol.js'
+
+/**
+ * The component's side of the wedge contract (issues #138 and #139): every
+ * wait on the record path is bounded by a silence budget, the doctor can
+ * cancel without reloading, no exit leaves a worker or a timer behind, and
+ * the status never claims completion while work is still running.
+ *
+ * jsdom has no Worker, no audio pipeline and reports thin hardware, so all
+ * three are stubbed. The stubs are driven, not observed: tests reply as the
+ * worker would and advance the fake clock, then assert what the doctor sees.
+ */
+
+/** Every worker the component builds, so tests can drive replies into each. */
+const workers: FakeWorker[] = []
+
+class FakeWorker {
+  onmessage: ((event: MessageEvent<WorkerResponse>) => void) | null = null
+  onerror: ((event: ErrorEvent) => void) | null = null
+  onmessageerror: ((event: MessageEvent) => void) | null = null
+  postMessage = vi.fn()
+  terminate = vi.fn()
+
+  constructor() {
+    workers.push(this)
+  }
+
+  /** Delivers a worker message the way the browser would, inside act. */
+  reply(message: WorkerResponse) {
+    act(() => {
+      this.onmessage?.(new MessageEvent('message', { data: message }))
+    })
+  }
+
+  /** The global error event a worker emits when its module fails or it dies. */
+  die() {
+    act(() => {
+      this.onerror?.(new ErrorEvent('error', { message: 'worker died' }))
+    })
+  }
+}
+
+/** Indexed access under noUncheckedIndexedAccess, asserted present. */
+function spawned(index = 0): FakeWorker {
+  const instance = workers[index]
+  if (!instance) throw new Error(`expected worker ${index} to exist`)
+  return instance
+}
+
+/** Swappable per test, so a decode can be made to hang or settle late. */
+let decodeAudioData: () => Promise<unknown>
+
+class FakeAudioContext {
+  decodeAudioData(_bytes: ArrayBuffer) {
+    return decodeAudioData()
+  }
+  close = vi.fn(async () => {})
+}
+
+class FakeOfflineAudioContext {
+  destination = {}
+  createBufferSource() {
+    return { buffer: null as unknown, connect: () => {}, start: () => {} }
+  }
+  async startRendering() {
+    return { getChannelData: () => new Float32Array(16) }
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  workers.length = 0
+  decodeAudioData = async () => ({ duration: 1 })
+  vi.stubGlobal('Worker', FakeWorker)
+  vi.stubGlobal('AudioContext', FakeAudioContext)
+  vi.stubGlobal('OfflineAudioContext', FakeOfflineAudioContext)
+  // jsdom reports few cores and no memory, and the hardware floor would hide
+  // the whole control cluster, so pin the machine capable.
+  Object.defineProperty(navigator, 'hardwareConcurrency', { value: 8, configurable: true })
+  // jsdom's Blob has no arrayBuffer at all, so this defines rather than spies.
+  Object.defineProperty(Blob.prototype, 'arrayBuffer', {
+    value: async () => new ArrayBuffer(8),
+    configurable: true,
+    writable: true,
+  })
+})
+
+afterEach(() => {
+  // cleanup() must run while the fake clock is still installed: unmount
+  // clears timer handles, and clearing fake handles with the real function
+  // leaks them into the next test's vi.getTimerCount().
+  cleanup()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+/** Fake timers hold macrotasks but not microtasks; this drains the awaits. */
+async function settle() {
+  await act(async () => {
+    for (let i = 0; i < 8; i += 1) await Promise.resolve()
+  })
+}
+
+function renderCapture() {
+  const onTranscript = vi.fn()
+  const view = render(<AudioCapture onTranscript={onTranscript} />)
+  return { onTranscript, ...view }
+}
+
+function pickFile() {
+  fireEvent.change(screen.getByLabelText(/use an audio file/i), {
+    target: { files: [new File(['audio'], 'clip.wav', { type: 'audio/wav' })] },
+  })
+}
+
+const startButton = () =>
+  screen.getByRole('button', { name: /start recording/i }) as HTMLButtonElement
+
+describe('the silence budget', () => {
+  it('terminates a worker that stays silent and points at typing or pasting', async () => {
+    renderCapture()
+    pickFile()
+    await settle()
+    expect(workers).toHaveLength(1)
+
+    act(() => {
+      vi.advanceTimersByTime(STALL_TIMEOUT_MS)
+    })
+
+    expect(spawned().terminate).toHaveBeenCalled()
+    expect(screen.getByRole('alert').textContent).toMatch(/type or paste/i)
+    expect(startButton().disabled).toBe(false)
+  })
+
+  it('bounds the audio decode too, before any worker exists', async () => {
+    decodeAudioData = () => new Promise(() => {})
+    renderCapture()
+    pickFile()
+    await settle()
+    expect(workers).toHaveLength(0)
+
+    act(() => {
+      vi.advanceTimersByTime(STALL_TIMEOUT_MS)
+    })
+
+    expect(screen.getByRole('alert').textContent).toMatch(/type or paste/i)
+    expect(workers).toHaveLength(0)
+  })
+
+  it('is rearmed by every worker message, so a slow healthy run is never cut off', async () => {
+    renderCapture()
+    pickFile()
+    await settle()
+    const worker = spawned()
+
+    const feed: WorkerResponse[] = [
+      { type: 'progress', loaded: 1, total: 10 },
+      { type: 'ready' },
+      { type: 'alive' },
+      { type: 'transcribing', done: 1, total: 9 },
+      { type: 'alive' },
+    ]
+    for (const message of feed) {
+      act(() => {
+        vi.advanceTimersByTime(STALL_TIMEOUT_MS - 1000)
+      })
+      worker.reply(message)
+    }
+
+    expect(worker.terminate).not.toHaveBeenCalled()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('is cleared by a result, so no alert lands after success', async () => {
+    const { onTranscript } = renderCapture()
+    pickFile()
+    await settle()
+    const worker = spawned()
+    worker.reply({ type: 'ready' })
+    worker.reply({ type: 'result', text: 'hello', segments: [] })
+
+    act(() => {
+      vi.advanceTimersByTime(STALL_TIMEOUT_MS * 2)
+    })
+
+    expect(onTranscript).toHaveBeenCalledWith({ text: 'hello', segments: [] })
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(worker.terminate).not.toHaveBeenCalled()
+  })
+
+  it('is cleared by finishing, so a long merge tail is never killed', async () => {
+    renderCapture()
+    pickFile()
+    await settle()
+    const worker = spawned()
+    worker.reply({ type: 'ready' })
+    worker.reply({ type: 'transcribing', done: 15, total: 15 })
+    worker.reply({ type: 'finishing' })
+
+    act(() => {
+      vi.advanceTimersByTime(STALL_TIMEOUT_MS * 3)
+    })
+
+    expect(worker.terminate).not.toHaveBeenCalled()
+    expect(screen.queryByRole('alert')).toBeNull()
+    screen.getAllByText(/finishing up/i)
+    expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('100')
+    expect(screen.queryByText(/left/)).toBeNull()
+    expect(document.querySelector('.busy-spinner')).not.toBeNull()
+  })
+})
+
+describe('cancel', () => {
+  it('terminates immediately, shows no error, and restores the controls', async () => {
+    renderCapture()
+    pickFile()
+    await settle()
+    const worker = spawned()
+
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    expect(worker.terminate).toHaveBeenCalled()
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(startButton().disabled).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('during the decode builds no worker and leaves no timer', async () => {
+    let releaseDecode: () => void = () => {}
+    decodeAudioData = () =>
+      new Promise((resolve) => {
+        releaseDecode = () => resolve({ duration: 1 })
+      })
+    renderCapture()
+    pickFile()
+    await settle()
+
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    releaseDecode()
+    await settle()
+
+    expect(workers).toHaveLength(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('drops a message already queued behind the cancel', async () => {
+    const { onTranscript } = renderCapture()
+    pickFile()
+    await settle()
+    const worker = spawned()
+
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    worker.reply({ type: 'result', text: 'late', segments: [] })
+
+    expect(onTranscript).not.toHaveBeenCalled()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})
+
+describe('unmount', () => {
+  it('mid-run terminates the worker and leaves no timer', async () => {
+    const { unmount } = renderCapture()
+    pickFile()
+    await settle()
+    const worker = spawned()
+
+    unmount()
+
+    expect(worker.terminate).toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('mid-decode builds no worker and leaves no timer', async () => {
+    let releaseDecode: () => void = () => {}
+    decodeAudioData = () =>
+      new Promise((resolve) => {
+        releaseDecode = () => resolve({ duration: 1 })
+      })
+    const { unmount } = renderCapture()
+    pickFile()
+    await settle()
+
+    unmount()
+    releaseDecode()
+    await settle()
+
+    expect(workers).toHaveLength(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe('a dying worker', () => {
+  it('surfaces as a visible, actionable error instead of an endless spinner', async () => {
+    renderCapture()
+    pickFile()
+    await settle()
+    const worker = spawned()
+
+    worker.die()
+
+    expect(worker.terminate).toHaveBeenCalled()
+    expect(screen.getByRole('alert').textContent).toMatch(/try again, or type or paste/i)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe('what the status claims', () => {
+  it('switches to opening copy at 100 per cent instead of claiming a finished download', async () => {
+    renderCapture()
+    pickFile()
+    await settle()
+
+    spawned().reply({ type: 'progress', loaded: 500, total: 500 })
+
+    screen.getAllByText(/opening the speech model/i)
+    expect(screen.queryByText(/downloading the speech model, 100/i)).toBeNull()
+  })
+
+  it('shows no bar when the host reported no sizes', async () => {
+    renderCapture()
+    pickFile()
+    await settle()
+
+    spawned().reply({ type: 'progress', loaded: 42, total: 0 })
+
+    expect(screen.queryByRole('progressbar')).toBeNull()
+    screen.getAllByText(/preparing the speech model/i)
+  })
+
+  it('resets stale download progress when a second run starts', async () => {
+    renderCapture()
+    pickFile()
+    await settle()
+    const worker = spawned()
+    worker.reply({ type: 'progress', loaded: 500, total: 500 })
+    worker.reply({ type: 'ready' })
+    worker.reply({ type: 'result', text: 'one', segments: [] })
+
+    pickFile()
+    await settle()
+
+    screen.getAllByText(/preparing the speech model/i)
+    expect(screen.queryByText(/opening the speech model/i)).toBeNull()
+  })
+})
+
+describe('try again', () => {
+  it('retries the same recording on a fresh worker after a stall', async () => {
+    renderCapture()
+    pickFile()
+    await settle()
+    act(() => {
+      vi.advanceTimersByTime(STALL_TIMEOUT_MS)
+    })
+    expect(workers).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    await settle()
+
+    expect(workers).toHaveLength(2)
+    expect(spawned(1).postMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/audio/AudioCapture.tsx
+++ b/frontend/src/audio/AudioCapture.tsx
@@ -51,8 +51,9 @@ function belowHardwareFloor() {
 async function toMono16k(blob: Blob): Promise<Float32Array> {
   const bytes = await blob.arrayBuffer()
   const decoder = new AudioContext()
-  const decoded = await decoder.decodeAudioData(bytes)
-  await decoder.close()
+  // Closed in a finally: browsers cap live AudioContexts, so one leaked by a
+  // throwing decode would cost a later recording its decoder.
+  const decoded = await decoder.decodeAudioData(bytes).finally(() => void decoder.close())
 
   const frames = Math.ceil(decoded.duration * TARGET_SAMPLE_RATE)
   const offline = new OfflineAudioContext(1, frames, TARGET_SAMPLE_RATE)
@@ -64,7 +65,32 @@ async function toMono16k(blob: Blob): Promise<Float32Array> {
   return rendered.getChannelData(0)
 }
 
-type Phase = 'idle' | 'recording' | 'loading-model' | 'transcribing'
+/**
+ * The silence budget: how long the record path may go without a worker
+ * message before the run is declared wedged and terminated (issue #139).
+ *
+ * A budget on silence rather than on the whole job, because a
+ * consultation-length recording legitimately transcribes for many minutes
+ * (docs/trd.md section 20.1 measures a real-time factor of 1.5 to 3.0) and a
+ * total deadline would abort exactly the recordings most expensive to lose.
+ * The floor is set by ONNX session creation, which blocks the worker thread
+ * on a roughly 240 MB decoder and is legitimately silent throughout.
+ */
+export const STALL_TIMEOUT_MS = 180_000
+
+type Phase = 'idle' | 'recording' | 'loading-model' | 'transcribing' | 'finishing'
+
+/**
+ * What the doctor is told when the budget expires or the worker dies. Both
+ * point back at typing or pasting: on-device failure degrades to the paste
+ * path, never to a hosted fallback (docs/trd.md section 20).
+ */
+const STALL_ERROR = `Transcription was stopped after ${Math.round(
+  STALL_TIMEOUT_MS / 60_000,
+)} minutes with no sign of progress. The speech model may be unreachable from this network. Try again, or type or paste the transcript instead.`
+
+const WORKER_DIED_ERROR =
+  'Speech recognition stopped unexpectedly. Try again, or type or paste the transcript instead.'
 
 /**
  * Roughly how much longer, from how long the finished chunks actually took.
@@ -99,9 +125,21 @@ export function AudioCapture({
   const [overridden, setOverridden] = useState(false)
   const [seconds, setSeconds] = useState(0)
   const [chunkProgress, setChunkProgress] = useState<{ done: number; total: number } | null>(null)
+  /** The audio behind the current or failed run, so Try Again can rerun it. */
+  const [retryBlob, setRetryBlob] = useState<Blob | null>(null)
 
   /** When the current transcription started, for the remaining-time estimate. */
   const startedAt = useRef<number | null>(null)
+
+  /** The armed silence-budget timer, if any. */
+  const stall = useRef<number | null>(null)
+  /**
+   * Which run is current. Bumped by every abort and by unmount, and
+   * snapshotted by everything asynchronous, so a cancelled run's late decode
+   * or queued worker message can never resurrect state or build an orphan
+   * worker.
+   */
+  const attempt = useRef(0)
 
   const worker = useRef<Worker | null>(null)
   const recorder = useRef<MediaRecorder | null>(null)
@@ -121,45 +159,129 @@ export function AudioCapture({
 
   const thin = belowHardwareFloor() && !overridden
 
+  const clearStall = useCallback(() => {
+    if (stall.current !== null) {
+      window.clearTimeout(stall.current)
+      stall.current = null
+    }
+  }, [])
+
+  /**
+   * The only way out of a run other than the worker answering. Terminate, not
+   * a cancel message: a worker wedged inside a fetch that never settles will
+   * not read one. A null message is the doctor cancelling; a string is a
+   * failure they need to hear about.
+   */
+  const abort = useCallback(
+    (message: string | null) => {
+      attempt.current += 1
+      clearStall()
+      worker.current?.terminate()
+      worker.current = null
+      setPhase('idle')
+      setProgress(null)
+      setChunkProgress(null)
+      startedAt.current = null
+      setError(message)
+    },
+    [clearStall],
+  )
+
+  /** Rearms the silence budget. Every worker message buys another window. */
+  const watchForStall = useCallback(() => {
+    clearStall()
+    stall.current = window.setTimeout(() => abort(STALL_ERROR), STALL_TIMEOUT_MS)
+  }, [abort, clearStall])
+
   const ensureWorker = useCallback(() => {
     if (worker.current) return worker.current
+    const id = attempt.current
     const instance = new Worker(new URL('./transcribe.worker.js', import.meta.url), {
       type: 'module',
     })
     instance.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      // A terminated worker's already-queued message must not resurrect
+      // state: a result racing a cancel loses to the cancel.
+      if (attempt.current !== id) return
       const message = event.data
-      if (message.type === 'progress') {
-        setProgress(Math.round((message.loaded / message.total) * 100))
-        setPhase('loading-model')
+      switch (message.type) {
+        case 'progress':
+          watchForStall()
+          setProgress(message.total > 0 ? Math.round((message.loaded / message.total) * 100) : null)
+          setPhase('loading-model')
+          break
+        case 'ready':
+          watchForStall()
+          setProgress(null)
+          setPhase('transcribing')
+          startedAt.current = Date.now()
+          break
+        case 'transcribing':
+          watchForStall()
+          setChunkProgress({ done: message.done, total: message.total })
+          break
+        case 'alive':
+          watchForStall()
+          break
+        case 'finishing':
+          // The merge tail blocks the worker thread, so nothing can rearm the
+          // budget until the result. Cleared rather than capped: any safe cap
+          // would sit minutes past what Cancel already offers, and a wrong
+          // one destroys a finished transcription.
+          clearStall()
+          setPhase('finishing')
+          break
+        case 'result':
+          clearStall()
+          setPhase('idle')
+          setProgress(null)
+          setChunkProgress(null)
+          startedAt.current = null
+          setRetryBlob(null)
+          onTranscriptRef.current({ text: message.text, segments: message.segments })
+          break
+        case 'error':
+          // The worker survives an inference error with the model warm, so a
+          // retry is cheap. A stalled or dead worker is terminated in `abort`
+          // instead, and its retry rebuilds one.
+          clearStall()
+          setPhase('idle')
+          setProgress(null)
+          setChunkProgress(null)
+          startedAt.current = null
+          setError(message.message)
+          break
+        default: {
+          const unhandled: never = message
+          void unhandled
+        }
       }
-      if (message.type === 'ready') {
-        setProgress(null)
-        setPhase('transcribing')
-        startedAt.current = Date.now()
-      }
-      if (message.type === 'transcribing') {
-        setChunkProgress({ done: message.done, total: message.total })
-      }
-      if (message.type === 'result') {
-        setPhase('idle')
-        setProgress(null)
-        setChunkProgress(null)
-        startedAt.current = null
-        onTranscriptRef.current({ text: message.text, segments: message.segments })
-      }
-      if (message.type === 'error') {
-        setPhase('idle')
-        setProgress(null)
-        setChunkProgress(null)
-        startedAt.current = null
-        setError(message.message)
-      }
+    }
+    // The only channels a dying worker has: a failed module fetch, a CSP
+    // block or an out-of-memory kill fires no `message`, only these. Without
+    // them a death is indistinguishable from a slow load.
+    instance.onerror = () => {
+      if (attempt.current === id) abort(WORKER_DIED_ERROR)
+    }
+    instance.onmessageerror = () => {
+      if (attempt.current === id) abort(WORKER_DIED_ERROR)
     }
     worker.current = instance
     return instance
-  }, [])
+  }, [abort, clearStall, watchForStall])
 
-  useEffect(() => () => worker.current?.terminate(), [])
+  useEffect(
+    () => () => {
+      // Closing the record tab mid-run must strand nothing: no timer left
+      // armed, no worker left running, and a decode still in flight sees the
+      // bumped attempt and builds nothing.
+      attempt.current += 1
+      if (stall.current !== null) window.clearTimeout(stall.current)
+      worker.current?.terminate()
+      worker.current = null
+    },
+    [],
+  )
 
   // A visible elapsed counter, because a recording with no indication it is
   // running is how a consultation gets captured that nobody meant to capture.
@@ -173,21 +295,35 @@ export function AudioCapture({
     async (blob: Blob) => {
       setError(null)
       setPhase('loading-model')
+      setProgress(null)
       setChunkProgress(null)
+      startedAt.current = null
+      setRetryBlob(blob)
+      const id = attempt.current
+      // Armed before the decode: a malformed container can hang
+      // `decodeAudioData` before any worker exists, and that wait is bounded
+      // like every other one on this path.
+      watchForStall()
       try {
         const audio = await toMono16k(blob)
+        if (attempt.current !== id) return
         const request: WorkerRequest = { type: 'transcribe', audio }
         ensureWorker().postMessage(request, [audio.buffer as ArrayBuffer])
       } catch (cause) {
+        if (attempt.current !== id) return
+        clearStall()
         setPhase('idle')
         setError(cause instanceof Error ? cause.message : 'Could not read that audio.')
       }
     },
-    [ensureWorker],
+    [clearStall, ensureWorker, watchForStall],
   )
 
   const start = useCallback(async () => {
     setError(null)
+    // A stale blob must not survive into a fresh microphone run: a refused
+    // microphone would otherwise offer Try Again on the previous recording.
+    setRetryBlob(null)
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
       const media = new MediaRecorder(stream)
@@ -214,7 +350,7 @@ export function AudioCapture({
     recorder.current = null
   }, [])
 
-  const busy = phase === 'loading-model' || phase === 'transcribing'
+  const busy = phase === 'loading-model' || phase === 'transcribing' || phase === 'finishing'
 
   /*
    * One line that always says what is actually happening, and a bar only when
@@ -228,20 +364,44 @@ export function AudioCapture({
     chunkProgress === null ? null : Math.round((chunkProgress.done / chunkProgress.total) * 100)
 
   const remaining =
-    chunkProgress === null || startedAt.current === null
+    phase !== 'transcribing' || chunkProgress === null || startedAt.current === null
       ? null
       : estimateRemaining(chunkProgress.done, chunkProgress.total, Date.now() - startedAt.current)
 
+  /*
+   * Download-complete is not ready: the backend import and the ONNX session
+   * open both happen after the last byte, and a bar claiming a finished
+   * download through them is how a healthy load reads as a hang. So 100 gets
+   * its own honest sentence, as does the merge tail after the last chunk.
+   */
   const status =
     phase === 'loading-model'
       ? progress === null
         ? 'Preparing the speech model. The first run downloads it once and the browser caches it.'
-        : `Downloading the speech model, ${progress}%. This happens once.`
-      : percent === null
-        ? 'Transcribing on this device. Longer recordings take a few minutes.'
-        : `Transcribing on this device, ${percent}%${remaining === null ? '' : `, ${remaining}`}.`
+        : progress >= 100
+          ? 'Opening the speech model. On a first run this can take a couple of minutes.'
+          : `Downloading the speech model, ${progress}%. This happens once.`
+      : phase === 'finishing'
+        ? 'Finishing up. Joining the transcribed chunks into one transcript.'
+        : percent === null
+          ? 'Transcribing on this device. Longer recordings take a few minutes.'
+          : `Transcribing on this device, ${percent}%${remaining === null ? '' : `, ${remaining}`}.`
 
-  const bar = phase === 'loading-model' ? progress : percent
+  const bar = phase === 'loading-model' ? progress : phase === 'finishing' ? 100 : percent
+
+  /** The short phase headline the live region announces; sentences stay visual. */
+  const headline =
+    phase === 'loading-model'
+      ? progress === null
+        ? 'Preparing the speech model'
+        : progress >= 100
+          ? 'Opening the speech model'
+          : 'Downloading the speech model'
+      : phase === 'transcribing'
+        ? 'Transcribing on this device'
+        : phase === 'finishing'
+          ? 'Finishing up'
+          : ''
 
   return (
     <div className="flex flex-col gap-3">
@@ -304,15 +464,29 @@ export function AudioCapture({
         </div>
       )}
 
+      {/* Mounted before it has anything to say: a live region inserted into
+          the DOM already populated is not announced, so the container is
+          permanent and only its text changes. It carries the short phase
+          headline rather than the full sentence, so screen readers hear state
+          changes, not every percentage tick. */}
+      <span aria-live="polite" className="sr-only">
+        {headline}
+      </span>
+
       {busy && (
         <div className="flex flex-col gap-2">
-          <p className="flex items-center gap-2 text-sm text-ink-muted">
-            {/* `busy-spinner` exempts this from the blanket reduced-motion rule
-                in index.css. A spinner frozen mid-turn reads as hung, which is
-                the opposite of what it exists to say. */}
-            <Loader2 aria-hidden className="busy-spinner size-4 animate-spin" />
-            <span role="status">{status}</span>
-          </p>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="flex items-center gap-2 text-sm text-ink-muted">
+              {/* `busy-spinner` exempts this from the blanket reduced-motion rule
+                  in index.css. A spinner frozen mid-turn reads as hung, which is
+                  the opposite of what it exists to say. */}
+              <Loader2 aria-hidden className="busy-spinner size-4 animate-spin" />
+              <span>{status}</span>
+            </p>
+            <Button size="sm" variant="ghost" onClick={() => abort(null)}>
+              Cancel
+            </Button>
+          </div>
 
           {/* A real bar, driven by measured chunk completions rather than by an
               animation, so its position means something. Width is a transition
@@ -337,9 +511,19 @@ export function AudioCapture({
       )}
 
       {error && (
-        <p role="alert" className="text-sm text-emergency">
-          {error}
-        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <p role="alert" className="text-sm text-emergency">
+            {error}
+          </p>
+          {/* Only when there is audio to rerun. A consultation recording is
+              unrecoverable, so a failed run keeps its blob rather than
+              pointing the doctor at recording the consultation again. */}
+          {retryBlob !== null && (
+            <Button size="sm" variant="ghost" onClick={() => void transcribe(retryBlob)}>
+              Try Again
+            </Button>
+          )}
+        </div>
       )}
     </div>
   )

--- a/frontend/src/audio/protocol.ts
+++ b/frontend/src/audio/protocol.ts
@@ -53,8 +53,34 @@ export function countChunks(samples: number, sampleRate = TARGET_SAMPLE_RATE): n
   return Math.ceil((samples - window) / jump) + 1
 }
 
+/**
+ * How many decoded tokens between `alive` heartbeats.
+ *
+ * Chunk ticks alone cannot carry liveness: at a real-time factor of 3, a 30 s
+ * window is roughly 90 s between ticks on a slow machine. Whisper's timestamps
+ * go silent over stride overlaps, quiet audio and repetition loops, so the
+ * heartbeat rides on tokens, which fire per decoding step whatever the audio
+ * contains. Eight keeps the rate to a few messages per second at worst, which
+ * the caller absorbs without a render.
+ */
+export const HEARTBEAT_TOKENS = 8
+
+/**
+ * What the worker says, in order:
+ * `progress* -> ready -> (transcribing | alive)* -> finishing -> (result | error)`,
+ * with `error` possible at any point. The worker speaks continuously from the
+ * moment a request arrives until it answers, and the caller arms a silence
+ * budget against these messages, so a new phase that stays quiet for minutes
+ * is a regression even when it ends well.
+ */
 export type WorkerResponse =
-  | { type: 'progress'; loaded: number; total: number; file: string }
+  /**
+   * Aggregate model-download bytes, from the library's `progress_total`
+   * event. Its denominator covers every expected file from the first event,
+   * so the fraction never walks backwards the way a per-file figure does.
+   * `total` 0 means the host reported no sizes; callers must not divide.
+   */
+  | { type: 'progress'; loaded: number; total: number }
   | { type: 'ready' }
   /**
    * One chunk of audio finished transcribing. `done` counts completed chunks,
@@ -62,6 +88,18 @@ export type WorkerResponse =
    * progress rather than an animation.
    */
   | { type: 'transcribing'; done: number; total: number }
+  /**
+   * Liveness only. Carries nothing and is never rendered; it exists so the
+   * caller's silence budget can tell a slow chunk apart from a wedged worker.
+   */
+  | { type: 'alive' }
+  /**
+   * Every chunk is transcribed and the merge and decode tail is running.
+   * Posted at most once. The tail blocks the worker thread, so no further
+   * heartbeat is possible: callers must stop claiming a percentage and stop
+   * expecting messages until `result` or `error`.
+   */
+  | { type: 'finishing' }
   /** `segments` empty means no usable timing; callers fall back to plain prose. */
   | { type: 'result'; text: string; segments: readonly TranscriptSegment[] }
   | { type: 'error'; message: string }

--- a/frontend/src/audio/transcribe.worker.test.ts
+++ b/frontend/src/audio/transcribe.worker.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { WorkerResponse } from './protocol.js'
+import { HEARTBEAT_TOKENS, type WorkerResponse } from './protocol.js'
 
 /**
  * The worker's *message* contract, not its transcription quality.
@@ -16,20 +16,47 @@ import type { WorkerResponse } from './protocol.js'
 /**
  * Stands in for the pipeline. `chunkRuns` is how many times it pretends the
  * model ran, which is what drives `streamer.end()` and therefore the progress
- * messages.
+ * messages. `tokensPerChunk` drives `streamer.put()` before each `end()`, the
+ * way `generate()` calls it once per decoding step, which is what the alive
+ * heartbeat rides on.
  */
 let chunkRuns = 1
+let tokensPerChunk = 0
 
-const asr = vi.fn(async (_audio: unknown, options?: { streamer?: { end: () => void } }) => {
-  for (let i = 0; i < chunkRuns; i += 1) options?.streamer?.end()
-  return { text: 'hello', chunks: [] } as unknown
-})
+const asr = vi.fn(
+  async (
+    _audio: unknown,
+    options?: { streamer?: { put: (value: unknown) => void; end: () => void } },
+  ) => {
+    for (let i = 0; i < chunkRuns; i += 1) {
+      for (let t = 0; t < tokensPerChunk; t += 1) options?.streamer?.put([[0]])
+      options?.streamer?.end()
+    }
+    return { text: 'hello', chunks: [] } as unknown
+  },
+)
+
+/** Download events the pipeline replays into `progress_callback` while loading. */
+let progressEvents: unknown[] = []
 
 vi.mock('@huggingface/transformers', () => ({
-  pipeline: vi.fn(async () => asr),
+  pipeline: vi.fn(
+    async (
+      _task: unknown,
+      _model: unknown,
+      options?: { progress_callback?: (event: unknown) => void },
+    ) => {
+      for (const event of progressEvents) options?.progress_callback?.(event)
+      return asr
+    },
+  ),
   env: {},
   // The real one throws from both methods so subclasses must override, which
   // `ChunkCounter` does. A bare class is enough to stand in for that here.
+  // Deliberately no `WhisperTextStreamer` or `TextStreamer` export: outside
+  // Node those default `callback_function` to `console.log` of decoded text,
+  // so a swap toward them should fail loudly here before it can ever log a
+  // transcript.
   BaseStreamer: class {},
 }))
 
@@ -38,6 +65,8 @@ let posted: WorkerResponse[]
 beforeEach(async () => {
   posted = []
   chunkRuns = 1
+  tokensPerChunk = 0
+  progressEvents = []
   vi.spyOn(self, 'postMessage').mockImplementation(((message: WorkerResponse) => {
     posted.push(message)
   }) as typeof self.postMessage)
@@ -117,5 +146,121 @@ describe('the transcribe path', () => {
     await transcribe()
 
     expect(posted.at(-1)).toEqual({ type: 'error', message: 'session failed' })
+  })
+})
+
+describe('download progress', () => {
+  it('forwards only the aggregate figure, never per-file bytes', async () => {
+    // Per-file events drive a bar to 100 once per artefact and reset it for
+    // the next. The aggregate event's denominator covers every expected file
+    // from the first event, so it is the only one worth forwarding.
+    progressEvents = [
+      { status: 'progress', file: 'encoder.onnx', loaded: 10, total: 100 },
+      { status: 'progress_total', loaded: 10, total: 500 },
+      { status: 'progress', file: 'decoder.onnx', loaded: 90, total: 400 },
+      { status: 'progress_total', loaded: 100, total: 500 },
+      { status: 'done', file: 'encoder.onnx' },
+    ]
+
+    await transcribe()
+
+    expect(posted.filter((m) => m.type === 'progress')).toEqual([
+      { type: 'progress', loaded: 10, total: 500 },
+      { type: 'progress', loaded: 100, total: 500 },
+    ])
+  })
+
+  it('still posts when the host reports no sizes, as a zero-total heartbeat', async () => {
+    // A mirror without content-length gives no denominator. The message still
+    // matters: it rearms the caller's silence budget even when it cannot
+    // render as a percentage.
+    progressEvents = [{ status: 'progress_total', loaded: 42, total: 0 }]
+
+    await transcribe()
+
+    expect(posted.filter((m) => m.type === 'progress')).toEqual([
+      { type: 'progress', loaded: 42, total: 0 },
+    ])
+  })
+})
+
+describe('liveness', () => {
+  it('posts alive on the token cadence', async () => {
+    tokensPerChunk = HEARTBEAT_TOKENS * 2 + 1
+
+    await transcribe()
+
+    expect(posted.filter((m) => m.type === 'alive')).toHaveLength(2)
+  })
+
+  it('posts no alive for a chunk under the heartbeat interval', async () => {
+    tokensPerChunk = HEARTBEAT_TOKENS - 1
+
+    await transcribe()
+
+    expect(posted.filter((m) => m.type === 'alive')).toHaveLength(0)
+  })
+
+  it('never writes to the console while decoding', async () => {
+    // `WhisperTextStreamer` and `TextStreamer` default `callback_function` to
+    // `console.log` outside Node, which would print decoded consultation text.
+    // AGENTS.md bans logging transcript bodies, so the streamer must stay a
+    // `BaseStreamer` subclass that decodes nothing and logs nothing.
+    const spies = (['log', 'info', 'warn', 'error'] as const).map((name) =>
+      vi.spyOn(console, name).mockImplementation(() => {}),
+    )
+    tokensPerChunk = 20
+
+    await transcribe()
+
+    for (const spy of spies) expect(spy).not.toHaveBeenCalled()
+  })
+})
+
+describe('the finishing signal', () => {
+  it('is posted exactly once, after the last chunk tick and before the result', async () => {
+    const { TARGET_SAMPLE_RATE, countChunks } = await import('./protocol.js')
+    const audio = new Float32Array(TARGET_SAMPLE_RATE * 70)
+    chunkRuns = countChunks(audio.length)
+
+    await transcribe(audio)
+
+    const types = posted.map((m) => m.type)
+    expect(types.filter((t) => t === 'finishing')).toHaveLength(1)
+    expect(types.indexOf('finishing')).toBeGreaterThan(types.lastIndexOf('transcribing'))
+    expect(types.indexOf('finishing')).toBeLessThan(types.indexOf('result'))
+  })
+
+  it('is still posted once when the model runs more often than predicted', async () => {
+    chunkRuns = 5
+
+    await transcribe()
+
+    expect(posted.filter((m) => m.type === 'finishing')).toHaveLength(1)
+  })
+})
+
+describe('overlapping requests', () => {
+  it('drops a second transcribe while one is in flight', async () => {
+    // The shipped component disables its controls while busy, so this guards
+    // against a future caller: two interleaved runs would weave two message
+    // streams into one state machine.
+    let release: () => void = () => {}
+    asr.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve({ text: 'hello', chunks: [] })
+        }),
+    )
+
+    const audio = () => new Float32Array(16)
+    self.onmessage?.(new MessageEvent('message', { data: { type: 'transcribe', audio: audio() } }))
+    self.onmessage?.(new MessageEvent('message', { data: { type: 'transcribe', audio: audio() } }))
+    await vi.waitFor(() => expect(asr).toHaveBeenCalled())
+    release()
+    await vi.waitFor(() => expect(posted.some((m) => m.type === 'result')).toBe(true))
+
+    expect(asr).toHaveBeenCalledTimes(1)
+    expect(posted.filter((m) => m.type === 'result')).toHaveLength(1)
   })
 })

--- a/frontend/src/audio/transcribe.worker.ts
+++ b/frontend/src/audio/transcribe.worker.ts
@@ -9,6 +9,7 @@ import {
 import {
   CHUNK_LENGTH_S,
   countChunks,
+  HEARTBEAT_TOKENS,
   STRIDE_LENGTH_S,
   type WorkerRequest,
   type WorkerResponse,
@@ -81,12 +82,19 @@ if (MODEL_HOST) env.remoteHost = MODEL_HOST
 
 const post = (message: WorkerResponse) => self.postMessage(message)
 
-let transcriber: AutomaticSpeechRecognitionPipeline | null = null
-
 function onProgress(event: unknown) {
-  const p = event as { status?: string; file?: string; loaded?: number; total?: number }
-  if (p.status === 'progress' && p.total) {
-    post({ type: 'progress', loaded: p.loaded ?? 0, total: p.total, file: p.file ?? '' })
+  const p = event as { status?: string; loaded?: number; total?: number }
+  /*
+   * Only the aggregate figure. The library also emits per-file `progress`
+   * events, and forwarding those is how the bar used to sawtooth: each
+   * artefact drove it to 100 and the next reset it, and summing them by hand
+   * walks backwards as files register their sizes. `progress_total`'s
+   * denominator covers every expected file from its first event. A zero total
+   * (a mirror without content-length) is still posted: it cannot render as a
+   * percentage, but it rearms the caller's silence budget.
+   */
+  if (p.status === 'progress_total') {
+    post({ type: 'progress', loaded: p.loaded ?? 0, total: p.total ?? 0 })
   }
 }
 
@@ -152,10 +160,21 @@ async function loadWasm() {
  * `null`. Testing for the API's presence would select WebGPU on a machine it
  * cannot run on.
  */
+/**
+ * How long the adapter probe may take before WASM is chosen anyway. A hung
+ * GPU process never rejects, it just never answers, and WASM is first-class
+ * here rather than a degradation, so a slow probe simply means WASM.
+ */
+const ADAPTER_PROBE_MS = 3_000
+
 async function hasWebGpuAdapter(): Promise<boolean> {
   if (typeof navigator === 'undefined' || !('gpu' in navigator)) return false
   try {
-    return (await navigator.gpu.requestAdapter()) !== null
+    const adapter = await Promise.race([
+      navigator.gpu.requestAdapter(),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), ADAPTER_PROBE_MS)),
+    ])
+    return adapter !== null
   } catch {
     return false
   }
@@ -178,33 +197,59 @@ async function hasWebGpuAdapter(): Promise<boolean> {
  * fallback has not been exercised against real WebGPU hardware by this
  * product's own testing; only the detection-finds-nothing path has.
  */
-async function load() {
-  if (transcriber) return transcriber
+/*
+ * Single-flight: the in-flight promise is memoised, not just the result, so
+ * two near-simultaneous requests can never start two parallel multi-hundred
+ * megabyte downloads. A failed load clears the memo, so the next request
+ * starts clean rather than replaying the rejection forever.
+ */
+let loading: Promise<AutomaticSpeechRecognitionPipeline> | null = null
 
-  if (!(await hasWebGpuAdapter())) {
-    transcriber = await loadWasm()
-    return transcriber
-  }
+function load(): Promise<AutomaticSpeechRecognitionPipeline> {
+  loading ??= doLoad().catch((error: unknown) => {
+    loading = null
+    throw error
+  })
+  return loading
+}
+
+async function doLoad() {
+  if (!(await hasWebGpuAdapter())) return loadWasm()
 
   try {
-    transcriber = await pipeline('automatic-speech-recognition', MODEL, {
+    return await pipeline('automatic-speech-recognition', MODEL, {
       device: 'webgpu',
       progress_callback: onProgress,
     })
   } catch {
-    transcriber = await loadWasm()
+    return loadWasm()
   }
-  return transcriber
 }
 
+/*
+ * One run at a time. The shipped component disables its controls while busy,
+ * so this guards a future caller: two interleaved runs would weave two
+ * message streams into one state machine on the other side.
+ */
+let running = false
+
 self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
-  try {
-    if (event.data.type === 'load') {
+  if (event.data.type === 'load') {
+    try {
       await load()
       post({ type: 'ready' })
-      return
+    } catch (error) {
+      post({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Transcription failed',
+      })
     }
+    return
+  }
 
+  if (running) return
+  running = true
+  try {
     const asr = await load()
     /*
      * The model is loaded; everything after this is inference. Without this
@@ -225,22 +270,46 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
      * parameter and every kwarg here is spread into the generation config by
      * `_call_whisper`, so this rides a public API rather than a private hook.
      *
-     * `put` is required by the interface and deliberately does nothing: it
-     * fires per token, and posting at that rate would flood the main thread
-     * with messages to render a number that changes too fast to read.
+     * `put` fires per decoded token. Posting every one would flood the main
+     * thread, so it posts a throttled `alive` heartbeat instead: liveness for
+     * the caller's silence budget, never a number to render.
      */
     const total = countChunks(event.data.audio.length)
     let done = 0
+    let tokens = 0
+    let finished = false
 
     class ChunkCounter extends BaseStreamer {
-      /** Required by the interface, and deliberately empty. See above. */
-      override put() {}
+      /*
+       * Must never decode or log what it is given. `WhisperTextStreamer`
+       * without a `callback_function` prints decoded text via `console.log`,
+       * and logging transcript bodies is banned (AGENTS.md), so any streamer
+       * swap here has to keep this a `BaseStreamer` that touches nothing but
+       * a counter. The worker test asserts the console stays silent.
+       */
+      override put() {
+        tokens += 1
+        if (tokens % HEARTBEAT_TOKENS === 0) post({ type: 'alive' })
+      }
       override end() {
         done += 1
         // Clamped because the count is a prediction of the pipeline's own
         // windowing. If it is ever wrong, a progress bar that stops at 100 is a
         // much smaller lie than one that reports 14 of 13.
         post({ type: 'transcribing', done: Math.min(done, total), total })
+        /*
+         * After the last chunk the merge and decode tail blocks this thread,
+         * so no further message is possible until the result. `finishing`
+         * hands the caller that fact, so it can stop the percentage claim and
+         * stand down the silence budget. `generate()` calls `end()` exactly
+         * once per chunk in the pinned library and `countChunks` is pinned to
+         * the same loop by protocol.test.ts, so this fires on the true last
+         * chunk; the guard is insurance against a future windowing change.
+         */
+        if (done >= total && !finished) {
+          finished = true
+          post({ type: 'finishing' })
+        }
       }
     }
 
@@ -336,5 +405,7 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
       type: 'error',
       message: error instanceof Error ? error.message : 'Transcription failed',
     })
+  } finally {
+    running = false
   }
 }


### PR DESCRIPTION
## What Changed

A wedged transcription now ends: 180 s of worker silence terminates the worker and points the doctor at typing or pasting, Cancel and Try Again end the wait without reloading, and the bar stops claiming 100% while the session opens or the merge tail runs.

Closes #138
Closes #139

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] Manually exercised the affected flow

Tests: 15 new component cases in `AudioCapture.test.tsx` (stall kill, rearm, decode bounded, cancel, cancel and unmount during decode leave no worker or timer, queued-message drop, worker `onerror`, finishing coupling, stale progress reset, Try Again) and 8 new worker cases in `transcribe.worker.test.ts` (aggregate `progress_total` forwarding, zero-total pass-through, alive cadence, finishing exactly once including over-fire, console-stays-silent guard, in-flight drop). Written red first; with the two source files stashed, 17 fail.

Manual, against a black-holed `VITE_ASR_MODEL_HOST` (a local node server that accepts and never responds): the preparing state shows Cancel, Cancel returns to idle instantly, an untouched attempt alerts at 3 minutes with the paste pointer and Try Again, and Try Again reruns the retained audio. Against the real CDN: the aggregate download percentage climbs monotonically, 100% switches to the opening sentence, and a clip transcribes end to end into the draft-label flow with no false timeout.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider: egress still goes through `deid/` then `LLMClient`
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model
- [x] Citations remain ID-constrained; no free-text references accepted
- [x] No transcript bodies, note contents, or vault entries written to logs
- [x] Fixtures added are synthetic

The streamer stays a `BaseStreamer` subclass that never decodes tokens. A new worker test pins that the console stays silent during decoding, because `WhisperTextStreamer` without a `callback_function` defaults to `console.log` of decoded text.

## Notes For The Reviewer

- The two issues land together deliberately: a silence budget without the `finishing` signal would terminate a healthy worker during the token-silent merge tail on consultation-length recordings.
- `finishing` clears the budget rather than capping it: the merge blocks the worker thread so nothing can rearm, any safe cap sits minutes past what Cancel already offers, and a wrong one destroys a finished transcription.
- The abandoned `claude/transcription-timeout-loading-he5lmd` branch was assessed and not cherry-picked: it predates #134 and #136, conflicts in every hunk, and its token-only liveness had exactly the merge-tail hole above. Its validated ideas (silence budget, terminate not message, attempt guard, test harness) are re-implemented here on main.
- Follow-up filed while in the file: #140, the pre-existing microphone leak when the record tab unmounts mid-recording.
- `backend/src/routes/notifications.test.ts` showed 2 network-flake failures (fetch failed) once during a full parallel local run against the live database and passed 8 of 8 in isolation; this diff touches no backend file.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer transcription status updates, including model loading, active processing, completion, and finishing stages.
  * Added cancellation, retry without rerecording, and fallback guidance to type or paste text.
  * Added heartbeat and progress reporting to indicate ongoing activity.
  * Added protection against stalled or failed transcription runs.

* **Bug Fixes**
  * Improved cleanup after cancellation, errors, and component removal.
  * Improved model-loading fallback and prevented overlapping transcription requests.
  * Added a timeout for stalled transcription and WebGPU detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->