### PR TITLE
feat(ui): prewarm the speech model when recording starts

### DIFF
--- a/frontend/src/audio/AudioCapture.test.tsx
+++ b/frontend/src/audio/AudioCapture.test.tsx
@@ -50,6 +50,32 @@ function spawned(index = 0): FakeWorker {
   return instance
 }
 
+/** Every recorder the component builds, so tests can drive its stop. */
+const recorders: FakeMediaRecorder[] = []
+
+class FakeMediaRecorder {
+  mimeType = 'audio/webm'
+  ondataavailable: ((event: { data: Blob }) => void) | null = null
+  onstop: (() => void) | null = null
+  start = vi.fn()
+
+  constructor(_stream: unknown) {
+    recorders.push(this)
+  }
+
+  /** The browser fires these after stop() returns, never inside it. */
+  stop() {
+    queueMicrotask(() => {
+      this.ondataavailable?.({ data: new Blob(['pcm']) })
+      this.onstop?.()
+    })
+  }
+}
+
+/** Swappable per test, so microphone access can be made to fail. */
+let getUserMedia: () => Promise<{ getTracks: () => { stop: () => void }[] }>
+let tracks: { stop: ReturnType<typeof vi.fn> }[]
+
 /** Swappable per test, so a decode can be made to hang or settle late. */
 let decodeAudioData: () => Promise<unknown>
 
@@ -73,10 +99,19 @@ class FakeOfflineAudioContext {
 beforeEach(() => {
   vi.useFakeTimers()
   workers.length = 0
+  recorders.length = 0
   decodeAudioData = async () => ({ duration: 1 })
+  tracks = [{ stop: vi.fn() }]
+  getUserMedia = async () => ({ getTracks: () => tracks })
   vi.stubGlobal('Worker', FakeWorker)
   vi.stubGlobal('AudioContext', FakeAudioContext)
   vi.stubGlobal('OfflineAudioContext', FakeOfflineAudioContext)
+  vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
+  // jsdom has no mediaDevices at all, so this defines rather than spies.
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia: () => getUserMedia() },
+    configurable: true,
+  })
   // jsdom reports few cores and no memory, and the hardware floor would hide
   // the whole control cluster, so pin the machine capable.
   Object.defineProperty(navigator, 'hardwareConcurrency', { value: 8, configurable: true })
@@ -119,6 +154,18 @@ function pickFile() {
 
 const startButton = () =>
   screen.getByRole('button', { name: /start recording/i }) as HTMLButtonElement
+
+const stopButton = () => screen.getByRole('button', { name: /stop and transcribe/i })
+
+async function startRecording() {
+  fireEvent.click(startButton())
+  await settle()
+}
+
+async function stopRecording() {
+  fireEvent.click(stopButton())
+  await settle()
+}
 
 describe('the silence budget', () => {
   it('terminates a worker that stays silent and points at typing or pasting', async () => {
@@ -363,5 +410,151 @@ describe('try again', () => {
 
     expect(workers).toHaveLength(2)
     expect(spawned(1).postMessage).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('prewarming the speech model', () => {
+  it('posts a load request to a fresh worker when recording starts', async () => {
+    renderCapture()
+    await startRecording()
+
+    expect(workers).toHaveLength(1)
+    expect(spawned().postMessage).toHaveBeenCalledTimes(1)
+    expect(spawned().postMessage).toHaveBeenCalledWith({ type: 'load' })
+    stopButton()
+  })
+
+  it('keeps the recording UI untouched by prewarm progress and ready', async () => {
+    renderCapture()
+    await startRecording()
+
+    spawned().reply({ type: 'progress', loaded: 100, total: 500 })
+    spawned().reply({ type: 'ready' })
+
+    expect(screen.queryByRole('progressbar')).toBeNull()
+    expect(screen.queryByText(/downloading|preparing|opening/i)).toBeNull()
+    expect(document.querySelector('.busy-spinner')).toBeNull()
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    screen.getByRole('button', { name: /0:01/ })
+  })
+
+  it('never arms the silence budget from prewarm alone', async () => {
+    renderCapture()
+    await startRecording()
+    spawned().reply({ type: 'progress', loaded: 1, total: 10 })
+
+    act(() => {
+      vi.advanceTimersByTime(STALL_TIMEOUT_MS + 1000)
+    })
+
+    expect(spawned().terminate).not.toHaveBeenCalled()
+    expect(screen.queryByRole('alert')).toBeNull()
+    stopButton()
+  })
+
+  it('reuses the prewarmed worker and load when the recording stops', async () => {
+    const { onTranscript } = renderCapture()
+    await startRecording()
+    spawned().reply({ type: 'ready' })
+    await stopRecording()
+
+    expect(workers).toHaveLength(1)
+    expect(spawned().postMessage).toHaveBeenCalledTimes(2)
+    expect(spawned().postMessage.mock.calls[0]?.[0]).toEqual({ type: 'load' })
+    expect(spawned().postMessage.mock.calls[1]?.[0]).toMatchObject({ type: 'transcribe' })
+    expect(tracks[0]?.stop).toHaveBeenCalled()
+
+    // The load's own answer can land beside the transcribe's; a repeated
+    // ready must read as the same state, not a restart.
+    spawned().reply({ type: 'ready' })
+    spawned().reply({ type: 'ready' })
+    screen.getAllByText(/transcribing on this device/i)
+    spawned().reply({ type: 'result', text: 'hello', segments: [] })
+    expect(onTranscript).toHaveBeenCalledWith({ text: 'hello', segments: [] })
+  })
+
+  it('stays silent when the prewarm fails, and still transcribes on stop', async () => {
+    const { onTranscript } = renderCapture()
+    await startRecording()
+    spawned().reply({ type: 'error', message: 'network gave out' })
+
+    expect(screen.queryByRole('alert')).toBeNull()
+    stopButton()
+
+    await stopRecording()
+    expect(workers).toHaveLength(1)
+    expect(spawned().postMessage.mock.calls[1]?.[0]).toMatchObject({ type: 'transcribe' })
+    spawned().reply({ type: 'progress', loaded: 1, total: 10 })
+    spawned().reply({ type: 'ready' })
+    spawned().reply({ type: 'result', text: 'recovered', segments: [] })
+    expect(onTranscript).toHaveBeenCalledWith({ text: 'recovered', segments: [] })
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('quietly replaces a worker that dies during the prewarm', async () => {
+    const { onTranscript } = renderCapture()
+    await startRecording()
+
+    spawned().die()
+
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(spawned().terminate).toHaveBeenCalled()
+    stopButton()
+
+    await stopRecording()
+    expect(workers).toHaveLength(2)
+    expect(spawned(1).postMessage).toHaveBeenCalledTimes(1)
+    expect(spawned(1).postMessage.mock.calls[0]?.[0]).toMatchObject({ type: 'transcribe' })
+    spawned(1).reply({ type: 'ready' })
+    spawned(1).reply({ type: 'result', text: 'second worker', segments: [] })
+    expect(onTranscript).toHaveBeenCalledWith({ text: 'second worker', segments: [] })
+  })
+
+  it('swallows a prewarm error that lands during the decode after stop', async () => {
+    let releaseDecode: () => void = () => {}
+    const { onTranscript } = renderCapture()
+    await startRecording()
+
+    decodeAudioData = () =>
+      new Promise((resolve) => {
+        releaseDecode = () => resolve({ duration: 1 })
+      })
+    fireEvent.click(stopButton())
+    await settle()
+    spawned().reply({ type: 'error', message: 'load failed late' })
+    expect(screen.queryByRole('alert')).toBeNull()
+
+    releaseDecode()
+    await settle()
+    expect(spawned().postMessage.mock.calls[1]?.[0]).toMatchObject({ type: 'transcribe' })
+    spawned().reply({ type: 'ready' })
+    spawned().reply({ type: 'result', text: 'late recovery', segments: [] })
+    expect(onTranscript).toHaveBeenCalledWith({ text: 'late recovery', segments: [] })
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('unmounting mid-recording terminates the prewarmed worker and leaves no timer', async () => {
+    const { unmount } = renderCapture()
+    await startRecording()
+
+    unmount()
+
+    expect(spawned().terminate).toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('builds no worker when microphone access is refused', async () => {
+    renderCapture()
+    getUserMedia = async () => {
+      throw new Error('denied')
+    }
+    fireEvent.click(startButton())
+    await settle()
+
+    expect(workers).toHaveLength(0)
+    expect(screen.getByRole('alert').textContent).toMatch(/microphone/i)
+    expect(screen.queryByRole('button', { name: /try again/i })).toBeNull()
   })
 })

--- a/frontend/src/audio/AudioCapture.tsx
+++ b/frontend/src/audio/AudioCapture.tsx
@@ -145,6 +145,14 @@ export function AudioCapture({
   const recorder = useRef<MediaRecorder | null>(null)
   const chunks = useRef<Blob[]>([])
 
+  /**
+   * True from the prewarm `load` posted at record start until the real
+   * transcribe request is posted, or the run is torn down. While set, every
+   * worker message is background chatter: nothing it says may change phase,
+   * render progress, surface an error, or arm the silence budget (issue #145).
+   */
+  const prewarming = useRef(false)
+
   /*
    * Always the latest prop, never the closure the worker was created with.
    * The worker is created once and its onmessage assigned once, so a plain
@@ -176,6 +184,7 @@ export function AudioCapture({
     (message: string | null) => {
       attempt.current += 1
       clearStall()
+      prewarming.current = false
       worker.current?.terminate()
       worker.current = null
       setPhase('idle')
@@ -203,6 +212,10 @@ export function AudioCapture({
       // A terminated worker's already-queued message must not resurrect
       // state: a result racing a cancel loses to the cancel.
       if (attempt.current !== id) return
+      // Prewarm chatter: the doctor is still recording, and nothing the load
+      // says may disturb that. The transcribe path clears the flag at its
+      // post, so a load reply landing later reads as that run's own.
+      if (prewarming.current) return
       const message = event.data
       switch (message.type) {
         case 'progress':
@@ -260,12 +273,27 @@ export function AudioCapture({
     // The only channels a dying worker has: a failed module fetch, a CSP
     // block or an out-of-memory kill fires no `message`, only these. Without
     // them a death is indistinguishable from a slow load.
-    instance.onerror = () => {
-      if (attempt.current === id) abort(WORKER_DIED_ERROR)
+    const died = () => {
+      if (attempt.current !== id) return
+      if (prewarming.current && recorder.current !== null) {
+        // The warm-up died while the doctor is still recording. Say nothing:
+        // the recording is what matters, and the stop path rebuilds a fresh
+        // worker and reloads from scratch. The bump drops any message this
+        // worker already queued, which would otherwise land once the flag
+        // clears. Not `abort`, which would reset the phase and drop the
+        // recording UI. The `recorder` gate keeps the post-stop decode window
+        // on the loud path: bumping there would strand the in-flight decode.
+        attempt.current += 1
+        clearStall()
+        instance.terminate()
+        worker.current = null
+        prewarming.current = false
+        return
+      }
+      abort(WORKER_DIED_ERROR)
     }
-    instance.onmessageerror = () => {
-      if (attempt.current === id) abort(WORKER_DIED_ERROR)
-    }
+    instance.onerror = died
+    instance.onmessageerror = died
     worker.current = instance
     return instance
   }, [abort, clearStall, watchForStall])
@@ -307,6 +335,10 @@ export function AudioCapture({
       try {
         const audio = await toMono16k(blob)
         if (attempt.current !== id) return
+        // Cleared here rather than at the top: a prewarm `error` delivered
+        // during the decode must stay swallowed, or its banner would outlive
+        // a successful run, which never calls `setError(null)` itself.
+        prewarming.current = false
         const request: WorkerRequest = { type: 'transcribe', audio }
         ensureWorker().postMessage(request, [audio.buffer as ArrayBuffer])
       } catch (cause) {
@@ -340,10 +372,17 @@ export function AudioCapture({
       recorder.current = media
       setSeconds(0)
       setPhase('recording')
+      // Prewarm: the model downloads and opens while the doctor is still
+      // speaking, so the stop is answered by a warm session instead of a cold
+      // load (issue #145). Last in the block, so a throwing recorder setup
+      // never leaves a prewarm behind on a run that failed to start.
+      prewarming.current = true
+      const request: WorkerRequest = { type: 'load' }
+      ensureWorker().postMessage(request)
     } catch {
       setError('Microphone access was refused, or no microphone is available.')
     }
-  }, [transcribe])
+  }, [ensureWorker, transcribe])
 
   const stop = useCallback(() => {
     recorder.current?.stop()

--- a/frontend/src/audio/protocol.ts
+++ b/frontend/src/audio/protocol.ts
@@ -72,6 +72,12 @@ export const HEARTBEAT_TOKENS = 8
  * moment a request arrives until it answers, and the caller arms a silence
  * budget against these messages, so a new phase that stays quiet for minutes
  * is a regression even when it ends well.
+ *
+ * A caller may also post a bare `load` to prewarm; its reply stream is
+ * `progress* -> ready | error`, and a `transcribe` posted while that load is
+ * in flight answers with a second `ready` once its own wait on the shared
+ * load resolves, so a repeated `ready` must read as the same state, never a
+ * restart.
  */
 export type WorkerResponse =
   /**


### PR DESCRIPTION
## What Changed

The record button now posts the worker's existing `{ type: 'load' }` request the moment `getUserMedia` succeeds, so the model downloads and opens while the doctor is still speaking. A `prewarming` ref swallows every worker message until the real transcribe request is posted, so prewarm progress, `ready`, or `error` can never change the phase, render transcription progress, arm the silence budget, or surface an error over a recording in progress.

Closes #145

## Why

Nothing in the app ever sent `load`, so every recording paid the cold model load only after the doctor pressed stop. Measured on real hardware during verification: the stop-to-transcript wait fell from a cold load (download plus a 26 s session open) to a warm handoff, with the result 27.6 s after stop on a 50 s recording.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (frontend 93/93; pre-existing backend timeout flake on the dev machine reproduced with this diff stashed, unrelated)
- [x] Manually exercised the affected flow

Nine new tests in `AudioCapture.test.tsx` behind new `MediaRecorder`/`getUserMedia` fakes: load posted on record start; recording UI untouched by prewarm progress and ready; silence budget never armed by prewarm alone (advanced past `STALL_TIMEOUT_MS` mid-recording); stop reuses the prewarmed worker and load, repeated `ready` idempotent; prewarm `error` silent with the stop path still transcribing; a worker dying mid-recording replaced silently on stop; unmount mid-recording terminates the prewarmed worker with no timer left; no worker at all when the microphone is refused; and a prewarm `error` landing during the post-stop decode window still swallowed. All 15 pre-existing tests from PR #141 pass unchanged. Live browser check with a synthetic microphone stream: one worker, posts exactly `load` then `transcribe`, phase stayed `recording` through a real WebGPU model load, warm handoff on stop.

## Notes For The Reviewer

- The worker answers a prewarm `load` with `ready`, and the transcribe request answers with a second `ready` once its own wait on the shared load resolves. The repeated `ready` is idempotent by design and now documented in `protocol.ts`.
- Worker death while recording is absorbed silently (terminate, bump the attempt, let stop rebuild a fresh worker) rather than `abort`, which would have reset the phase and destroyed the recording UI mid-consultation. The `recorder.current` gate keeps the post-stop decode window on the loud path.
- The prewarm flag clears at the transcribe post rather than at the top of `transcribe()`: a prewarm `error` delivered during the audio decode would otherwise paint a stale error banner that survives a successful result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recording now prepares the transcription model in advance, helping transcription begin more smoothly after recording stops.
  * Active recordings recover automatically if the background processing service stops, avoiding unnecessary interruption.
  * Transcription continues to handle delayed model loading and microphone access errors gracefully.

* **Documentation**
  * Clarified the processing status messages used during model preparation and transcription.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->