### PR TITLE
perf(ui): cut the WebGPU model download with a per-module dtype

### DIFF
--- a/docs/trd.md
+++ b/docs/trd.md
@@ -1407,6 +1407,47 @@ The failure is inside an ONNX Runtime **optimisation pass** that rewrites quanti
 
 That distinction matters for anyone reviewing it later: this disables a graph rewrite, not a correctness check, and it does not alter the model or its output. It is a workaround for a runtime bug, not a quality trade.
 
+#### Per-Module Dtype On WebGPU (Issue #144)
+
+The WebGPU branch originally set no `dtype`, so the library default applied and everything came down at fp32. It now pins a full-precision encoder with a `q4` decoder, the pairing the official transformers.js WebGPU Whisper demos ship for models of this size. Two nearby options were rejected on evidence, not preference:
+
+- **Scalar `q8`** is pathologically slow on WebGPU (transformers.js issue #894 measures 27 s against 5.2 s WASM on the same file), and the q8 decoder independently fails to open on this runtime (the qdq diagnosis above).
+- **An fp16 encoder** would save a further 176 MB, but the demos reserve fp16 encoders for `large-v3-turbo`, and the pinning row above records an open v4 + WebGPU + fp16 timestamp issue. Timestamps carry §20.2, so full precision won.
+
+##### Download Size, Measured 15/08/26
+
+In-browser `progress_total` on the production worker, Intel gen-9 adapter; per-artifact sizes are CDN `content-length`:
+
+| Path                          | Total Measured | Weight Artifacts                                              |
+| ----------------------------- | -------------- | ------------------------------------------------------------- |
+| WASM `q8` (unchanged)         | ~250 MB        | encoder_quantized 92.3 MB + decoder_merged_quantized 156.8 MB |
+| WebGPU, fp32 default (before) | 970.9 MB       | encoder 352.8 MB + decoder_merged 615.3 MB                    |
+| WebGPU, fp32 + q4 (after)     | 588.7 MB       | encoder 352.8 MB + decoder_merged_q4 233.1 MB                 |
+
+A 39% cut, not the issue's hoped-for half: the q4 decoder is 233 MB, not the ~170 MB the estimate assumed. Weights cache per artifact, so an existing WebGPU user re-downloads the decoder once; the fp32 encoder stays cached.
+
+##### Session And Speed, Same Machine And Recording
+
+The session opens with the q4 decoder, no qdq failure, no WASM fallback. On the §20.2 83.4 s reference recording, stamped: session open 26.2 s and transcription 74.6 s (RTF 0.89) under fp32 + q4, against 41.5 s and 153.8 s (RTF 1.84) under an fp32 decoder, and 178.5 s (RTF 2.14) for the 14/08/26 WASM q8 baseline. The q4 decoder halves decode time on top of halving its download.
+
+##### Token A/B, Stated With The Honesty §20.1 Demands
+
+The §20.1 sample was no longer present on the measurement machine, so the A/B ran on the §20.2 synthetic consultation instead: ground truth known, but TTS voices with anglicised Malay pronunciation, which §20.2 already records as a register caveat. n=1, not a benchmark. Two q4 runs were byte-identical, so the differences below are deterministic, not noise.
+
+| Token (Ground Truth)         | WASM q8 (14/08 Baseline) | WebGPU fp32 + q4      | WebGPU fp32 Decoder          |
+| ---------------------------- | ------------------------ | --------------------- | ---------------------------- |
+| "Any phlegm when you cough?" | phlegm                   | **flam**              | phlegm                       |
+| "Batuk sudah 3 hari lah"     | Batuxidha 3 Harry Law    | Batuxedot 3 harry law | Batuxidothri harila (no "3") |
+| "MC", both mentions          | MC                       | MC                    | mc                           |
+| "sakit"                      | socket                   | socket                | socket                       |
+| Everything else              | Identical                | Identical             | Identical                    |
+
+No dtype dominated. Against the fp32 default it replaces, q4 keeps the numeral in "3 hari" and the MC capitalisation and loses "phlegm" to a phonetic "flam"; the TTS voice's rendering of exactly that word is the kind of token one synthetic sample cannot settle. A real-speech A/B is the open follow-up, not a blocker recorded as solved.
+
+##### Timestamp Integrity On The Reference Recording
+
+18 segments, monotonic and contiguous (`end[i] == start[i+1]` throughout), final end 83.5 s against 83.38 s true duration, and the concatenated segment text reconstructs the transcript after whitespace normalisation. Neither known failure shape from §20.2 appeared.
+
 ### Threat: ASR Is A Second Fabrication Surface
 
 This is a genuine architectural gap, stated as one. Every control in this system — the de-identification gate (§9), the rules engine (§10), ID-constrained citations (§11), and evidence-bound assertion (§21.4) — sits **downstream of the transcript** and cannot detect a transcript that is already wrong.

--- a/frontend/src/audio/AudioCapture.tsx
+++ b/frontend/src/audio/AudioCapture.tsx
@@ -417,9 +417,9 @@ export function AudioCapture({
           <AlertTriangle aria-hidden className="mt-0.5 size-4 shrink-0 text-urgent" />
           <div className="min-w-0 flex-1">
             <p className="text-sm text-ink">
-              This device may not have the memory to run the speech model, which needs roughly
-              250&nbsp;MB of weights and holds them in memory. On a constrained machine the browser
-              tab can be killed mid-consultation.
+              This device may not have the memory to run the speech model, which needs roughly 250
+              to 590&nbsp;MB of weights depending on how it runs, and holds them in memory. On a
+              constrained machine the browser tab can be killed mid-consultation.
             </p>
             <Button size="sm" variant="ghost" className="mt-2" onClick={() => setOverridden(true)}>
               Enable Recording Anyway

--- a/frontend/src/audio/transcribe.worker.ts
+++ b/frontend/src/audio/transcribe.worker.ts
@@ -29,7 +29,7 @@ import {
  * during a consultation is worse than a slow one.
  *
  * **The model is fetched from the HuggingFace CDN on first use and cached by
- * the browser thereafter, never bundled into the build.** Roughly 250 MB of
+ * the browser thereafter, never bundled into the build.** Hundreds of MB of
  * weights in a Vercel deployment would be absurd, and the CDN fetch is the one
  * runtime call to a third party in this product; `docs/` discloses it, because
  * a reviewer who finds it unannounced in a network trace has every reason to
@@ -107,24 +107,11 @@ async function loadWasm() {
   return pipeline('automatic-speech-recognition', MODEL, {
     device: 'wasm',
     /*
-     * Split by module, and both halves are forced rather than tuned.
-     *
-     * **The `q8` decoder does not load at all**, on either published repo, and
-     * that was measured rather than assumed: the same failure appears with
-     * `Xenova/whisper-small` and `onnx-community/whisper-small`, so it is a
-     * property of how the quantised decoder is converted against the ONNX
-     * Runtime bundled here, not of one mirror.
-     *
-     *   Can't create a session. qdq_actions.cc:137 TransposeDQWeightsForMatMulNBits
-     *   Missing required scale: model.decoder.embed_tokens.weight_merged_0_scale
-     *
-     * It surfaces only after the full weight download and is reported as a
-     * generic session failure, which is why it is written down here.
-     *
-     * So the decoder stays unquantised and the encoder carries the saving. That
-     * is also the better half to quantise on the merits: the encoder runs once
-     * over the audio, while the decoder runs per token and is where a
-     * quantisation artefact turns into a wrong word.
+     * A scalar, so every module is quantised: encoder and decoder both run
+     * q8, which is the library's own WASM default made explicit and pinned.
+     * The quantised decoder refuses to open under default session options,
+     * and the fix for that is the disabled optimisation pass below, not a
+     * different dtype (docs/trd.md section 20 records the diagnosis).
      */
     dtype: 'q8',
     /*
@@ -187,9 +174,13 @@ async function hasWebGpuAdapter(): Promise<boolean> {
  * graph-optimisation pass in `loadWasm` are measured fixes for a bug in the
  * WASM execution provider specifically, never checked against WebGPU's, so
  * carrying them across backends would be a guess wearing the shape of a fix.
- * `dtype` is left unset for WebGPU instead: this library's own default for it
- * is `fp32`, `q8` is a WASM-only default, and the q8 decoder is independently
- * known not to load at all on this runtime (see `loadWasm`).
+ * WebGPU instead pins the pairing the library's own Whisper demos ship for
+ * models this size: a full-precision encoder with a `q4` decoder (issue
+ * #144). Left at the device default everything comes down at `fp32`, roughly
+ * 968 MB against this pairing's roughly 586 MB, and scalar `q8` is not the
+ * answer either: transformers.js issue #894 measures it pathologically slow
+ * on WebGPU, and the q8 decoder is independently known not to open on this
+ * runtime (see `loadWasm`).
  *
  * A WebGPU adapter existing is not proof every operator this model needs is
  * implemented in it, so a failure here still falls back to the WASM path
@@ -219,6 +210,7 @@ async function doLoad() {
   try {
     return await pipeline('automatic-speech-recognition', MODEL, {
       device: 'webgpu',
+      dtype: { encoder_model: 'fp32', decoder_model_merged: 'q4' },
       progress_callback: onProgress,
     })
   } catch {


### PR DESCRIPTION
## What Changed

The WebGPU branch of `doLoad()` now pins `dtype: { encoder_model: 'fp32', decoder_model_merged: 'q4' }`, the pairing the official transformers.js WebGPU Whisper demos ship for whisper-small-class models. Measured in-browser on the production worker: 970.9 MB at the previous fp32 default down to 588.7 MB, and stamped decode time halved (74.6 s against 153.8 s for the 83.4 s reference recording). The comment that falsely claimed the WASM scalar `q8` was split per module with an unquantised decoder is corrected, and the below-floor hardware banner now states the honest 250 to 590 MB range instead of the WASM-only figure. Full measurements, the token A/B, and the timestamp-integrity check are recorded in `docs/trd.md` section 20.

Closes #144

## Why

The WebGPU path silently inherited the library's fp32 default and downloaded nearly a gigabyte where the WASM path downloads 250 MB, while the recorder's own copy promised the smaller number. Scalar `q8` was not an option: transformers.js issue #894 measures it pathologically slow on WebGPU, and the q8 decoder independently fails to open on this runtime (the qdq diagnosis in the TRD).

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (frontend 84/84 on this branch; pre-existing backend timeout flake on the dev machine reproduced with the diff stashed, unrelated)
- [x] Manually exercised the affected flow

Exercised end to end on real WebGPU hardware (Intel gen-9 adapter, dev build): the session opens with the q4 decoder, no qdq failure and no WASM fallback; two runs were byte-identical; 18 segments, monotonic and contiguous, final end 83.5 s against 83.38 s true duration, segment text reconstructing the transcript. `loadWasm` is byte-identical apart from the corrected comment.

## Notes For The Reviewer

- **Cache invalidation:** weights cache per artifact, so an existing WebGPU user re-downloads the 233 MB q4 decoder once; the fp32 encoder stays cached. WASM users are unaffected.
- **The A/B verdict, stated honestly:** the original section 20.1 sample no longer exists on the measurement machine, so the token A/B ran on the section 20.2 synthetic reference (ground truth known, TTS register caveat recorded). No dtype dominated: against the fp32 default this replaces, q4 keeps the numeral in "3 hari" and the MC capitalisation, loses "phlegm" to a phonetic "flam", and halves download and decode. A real-speech A/B is the recorded follow-up.
- **fp16 encoder rejected** for now: a further 176 MB saving, but the demos reserve fp16 encoders for large-v3-turbo and the TRD pinning row records an open v4 + WebGPU + fp16 timestamp issue, and timestamps carry the speaker-label feature.
- The banner copy change in `AudioCapture.tsx` was pulled into scope by the frontend reviewer's finding that the old "roughly 250 MB" understated the WebGPU path for exactly the constrained machines the banner exists to warn.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider — egress still goes through `deid/` then `LLMClient`
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model
- [x] Citations remain ID-constrained; no free-text references accepted
- [x] No transcript bodies, note contents, or vault entries written to logs
- [x] Fixtures added are synthetic

🤖 Generated with [Claude Code](https://claude.com/claude-code)