### PR TITLE
feat(evals): run the hosted ASR measurement gate and record the verdict

### DIFF
--- a/docs/trd.md
+++ b/docs/trd.md
@@ -1628,6 +1628,51 @@ Recorded so the option is scoped, not attempted, in this window.
 - PriMock57 (57 acted mock GP consultations, audio plus utterance-level speaker ground truth, downloaded locally and never committed) is the candidate corpus for the EER gate above.
 - A resident warm worker between recordings was considered for load time and rejected: a warm session holds the full weights in memory while the doctor works elsewhere, which is the OOM kill this section's memory failure mode warns about. Prewarm-per-recording through the existing but unsent `load` request is the open alternative, with one hazard: the worker answers it with `ready`, which the component currently reads as the start of transcription.
 
+### 20.3 Measured Finding: Hosted `ilmu-asr-v4.2` Against The Shipped Local Path
+
+Measured **15/08/26**, gating issue #151 (the hosted-ASR build, issues #154 and #155, does not start unless this section records a ship decision). Harness: `evals/asr-ab.ts`, three default runs per sample plus one `language='ms'` probe, response-shape probes, and a report per run under the gitignored `evals/reports/`.
+
+**Samples, provenance stated per the 20.1 convention.** Two samples, neither committed:
+
+1. The 20.2 reference recording: 83.4 s synthetic two-voice consultation, Windows SAPI voices, anglicised Malay pronunciation.
+2. A new 99.2 s scripted rojak consultation: single human reader voicing both roles, phone recording (AAC 48 kHz stereo, decoded to 16 kHz mono), Malay-dominant with mid-sentence English switches, scripted ground truth. Synthetic content; no patient data of any kind was sent to any provider.
+
+**Local arm:** `@huggingface/transformers` 4.2.0, the exact production dependency, Node CPU, `dtype: 'q8'`, `graphOptimizationLevel: 'disabled'`, production generation options, run per the 20.1 method with the same caveat (browser WASM is slower than these Node figures).
+
+#### Token Table, Rojak Sample
+
+| Token (Ground Truth)                    | `ilmu-asr-v4.2`                         | `whisper-small` `language:'en'` (shipped)                         | `whisper-small` `language:'ms'`                  |
+| --------------------------------------- | --------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------ |
+| "batuk sudah empat hari lah"            | "patut sudah empat hari lah"            | **"it's been four days"** (translated)                            | "patuk sudah empah hari lah"                     |
+| "Ada demam tak?"                        | "ada teman tak"                         | **"Do you have a fever?"** (translated)                           | "Ada teman tak?"                                 |
+| "tiga puluh lapan point dua"            | correct ("poin"/"point" varies by run)  | "38.2" (translated to digits)                                     | "38.2"                                           |
+| "Any phlegm when you cough? Kahak ada?" | "any 你 fling when you cough kahak ada" | "Any flanks when you cough, or cough, or white"                   | "Any fling when your cough kakak ada"            |
+| "dada rasa sakit sikit"                 | **correct**                             | **"your feet are strong, you will feel a little pain"**           | "dah dah rasa sakit sikit"                       |
+| "Tekak merah sikit, tonsil tak bengkak" | "kekak merah sikit tongso tak pengkat"  | "Tekak Merah sikit Tongsil, Dap penkak" (after an English detour) | "Tekak. Merah sikit. Tongsel. Tak penkak."       |
+| "denggi", both mentions                 | "tenggi"                                | "tanggi"                                                          | "tanggi"                                         |
+| "Boleh dapat MC tak"                    | "boleh tapak MC tak" (MC survives)      | **"Can I get a doctor's leave?"** (translated, MC gone)           | "boleh tapak emci tak"                           |
+| "semput"                                | "sempuk"                                | "if you feel sick" (gone)                                         | "sempuk"                                         |
+| Duplicated or invented content          | one stutter ("air air")                 | repeated blocks plus invented clauses                             | repeated blocks plus one fabricated Malay clause |
+| Punctuation and casing                  | **none**: flat lowercase stream         | yes                                                               | partial                                          |
+| Wall clock (99.2 s audio)               | 2.3 to 2.5 s (**RTF 0.024**)            | 66.2 s (RTF 0.67, Node CPU floor)                                 | 157.5 s (**RTF 1.59**, slower than real time)    |
+
+#### Findings, In Order Of Consequence
+
+1. **The shipped local configuration fails dangerously, not gracefully, on Malay-dominant audio.** `language: 'en'` on this recording produced fluent English translation-fabrication: "bila batuk kuat, dada rasa sakit sikit" became "when your feet are strong, you will feel a little pain", erasing the exact phrase the chest-pain red flag matches on. This is 20.1 finding 2 and the section 21 threat table reproduced on the production settings, and it is the measured justification for the consent-gated hosted path: the on-device default has no safe answer for a Malay consultation today.
+2. **`auto` is not detection.** With `language` unset, transformers.js logs "No language specified - defaulting to English" per chunk; output was byte-identical to `'en'`. 20.1 finding 3 withdrew the silent-translation claim from secondary research; this run supplies the mechanism: there is no detection to mistrust, only a default.
+3. **A doctor-declared `'ms'` toggle would not be a fix.** It transcribes rather than translates, but with stride-duplication blocks, one fabricated clause, "emci" for MC, and RTF 1.59 on a 16-core machine, which clinic hardware multiplies. The on-device toggle idea stays rejected; the section 20 language row stands unchanged.
+4. **`ilmu-asr-v4.2` wins the rojak arm decisively on structure and speed.** Correct matrix language, mid-sentence code-switching preserved, clinical content largely intact (including "dada rasa sakit sikit" and "kahak"), roughly 40x faster than the local WASM path, at about RM 0.012 per consultation-minute. Its error family on this recording is consonant devoicing ("patut" for "batuk", "teman" for "demam", "tenggi" for "denggi", "pengkat" for "bengkak"), shared with `whisper-small` `'ms'` at the same spots, which points at the phone-mic audio profile as a contributor; plus one Chinese-character intrusion on "phlegm" and no punctuation.
+5. **The early-access API diverges from its documentation, in ways the relay must absorb.** `verbose_json` is not honoured (the response is `{text, usage: {type: "duration", seconds}}` with `timestamp_granularities[]` a no-op), `srt` returns a single cue spanning the whole file, the `prompt` biasing field is a no-op (identical output with punctuation-style and jargon prompts), and `temperature=0` is not byte-deterministic on the rojak sample (three runs differed in minor tokens; the TTS sample was deterministic). Consequences: no per-turn offsets exist, draft speaker labels cannot engage (the flat unpunctuated prose also defeats sentence splitting), and the relay's audited `durationSeconds` comes from `usage.seconds`, the one duration the API actually returns.
+6. **Reference-recording arm, for continuity with 20.2:** rough parity with the local WASM baseline on anglicised TTS (both garble the TTS-Malay tokens; ILMU uniquely recovered "Okay can", uniquely stuttered once, and spells numerals out), deterministic there, 2.0 to 2.4 s. The TTS register cannot carry the Malay verdict, which is why the human-read sample exists.
+
+#### Decision, Applying The Rule Written In #151 Before Measurement
+
+Tokens: ILMU beats local. Segments: fail (none delivered). **Ship the hosted path, with the prose-fallback caveat recorded:** hosted transcripts enter the app as paste-grade prose (unpunctuated, unsegmented, no draft speaker labels, no per-turn offsets), and the consent UI must not promise labelling on the hosted path. The devoicing family and the "phlegm" intrusion belong in the consent tooltip's accuracy framing (#155) rather than in a marketing sentence.
+
+**Limits, stated plainly.** n=1 reader, one phone microphone, a non-clinical room; one sample per register; token comparison rather than WER, per the 20.1 convention; the local arm ran in Node CPU rather than browser WASM. The devoicing overlap between both models suggests re-measurement with a clinic-grade microphone before treating it as a provider property. If the provider ships working `verbose_json` segments or punctuation later, the draft-labels verdict in finding 5 is the one to re-measure.
+
+**Cost of the whole gate:** about RM 0.20 of the RM 20 early-access credit.
+
 ---
 
 ## 21. LLM Guardrail Architecture

--- a/evals/asr-ab.ts
+++ b/evals/asr-ab.ts
@@ -1,0 +1,353 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { basename, extname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * A/B harness for hosted ASR (issue #151): posts a local audio file to ILMU's
+ * `/audio/transcriptions` endpoint and reports what came back, so the token
+ * table and segment-integrity verdict in `docs/trd.md` section 20.3 are
+ * measured rather than assumed.
+ *
+ * **This is not a test and must never become one.** Every run spends a real,
+ * billed API call, and its output moves with the provider. `bun run test`
+ * stays deterministic and free precisely because this lives outside it.
+ *
+ * Nothing this touches is committed: audio samples stay wherever they already
+ * live on disk, and reports land in `evals/reports/` (gitignored). Never point
+ * it at a recording of a real consultation; the provenance rules of trd.md
+ * sections 20.1 and 20.2 (synthetic or scripted audio only) apply here.
+ *
+ * Usage, from the repo root (the key is read from `.env` or the environment):
+ *
+ *   bunx tsx evals/asr-ab.ts <audio-file> [--runs 3] [--probe-ms]
+ *     [--label name] [--ground-truth turns.json]
+ */
+
+try {
+  process.loadEnvFile(fileURLToPath(new URL('../.env', import.meta.url)))
+} catch {
+  // No .env at the repo root; rely on the ambient environment.
+}
+
+const API_KEY = process.env.ILMU_API_KEY
+const BASE_URL = process.env.ILMU_BASE_URL ?? 'https://api.ilmu.ai/v1'
+const MODEL = process.env.ILMU_ASR_MODEL ?? 'ilmu-asr-v4.2'
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  '.flac': 'audio/flac',
+  '.m4a': 'audio/mp4',
+  '.mp3': 'audio/mpeg',
+  '.mp4': 'audio/mp4',
+  '.ogg': 'audio/ogg',
+  '.wav': 'audio/wav',
+  '.webm': 'audio/webm',
+}
+
+interface Segment {
+  start: number
+  end: number | null
+  text: string
+}
+
+interface RunResult {
+  ms: number
+  text: string
+  language: string | null
+  duration: number | null
+  /** Billed seconds from the `usage` object, the one duration ILMU reliably returns. */
+  usageSeconds: number | null
+  segments: Segment[]
+}
+
+function usage(): never {
+  console.error(
+    'usage: bunx tsx evals/asr-ab.ts <audio-file> [--runs 3] [--probe-ms] [--label name] [--ground-truth turns.json]',
+  )
+  process.exit(2)
+}
+
+interface Args {
+  audioPath: string
+  runs: number
+  probeMs: boolean
+  label: string
+  groundTruthPath: string | null
+}
+
+function parseArgs(argv: string[]): Args {
+  let audioPath: string | null = null
+  let runs = 3
+  let probeMs = false
+  let label: string | null = null
+  let groundTruthPath: string | null = null
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === undefined) break
+    if (arg === '--runs') {
+      runs = Number(argv[++i])
+      if (!Number.isInteger(runs) || runs < 1) usage()
+    } else if (arg === '--probe-ms') {
+      probeMs = true
+    } else if (arg === '--label') {
+      const value = argv[++i]
+      if (value === undefined) usage()
+      label = value
+    } else if (arg === '--ground-truth') {
+      const value = argv[++i]
+      if (value === undefined) usage()
+      groundTruthPath = value
+    } else if (arg.startsWith('--')) {
+      usage()
+    } else if (audioPath === null) {
+      audioPath = arg
+    } else {
+      usage()
+    }
+  }
+
+  if (audioPath === null) usage()
+  return {
+    audioPath,
+    runs,
+    probeMs,
+    label: label ?? basename(audioPath, extname(audioPath)),
+    groundTruthPath,
+  }
+}
+
+/**
+ * Parsed rather than trusted, by hand: the shared Zod contract for this wire
+ * shape arrives with the relay route (#154), and importing zod here would add
+ * an undeclared dependency to the evals workspace for one shape.
+ */
+function parseResponse(body: unknown): Omit<RunResult, 'ms'> {
+  if (typeof body !== 'object' || body === null) throw new Error('response body is not an object')
+  const record = body as Record<string, unknown>
+  if (typeof record.text !== 'string') throw new Error('response has no string `text`')
+  const segmentsRaw = Array.isArray(record.segments) ? record.segments : []
+  const segments: Segment[] = segmentsRaw.map((raw, index) => {
+    if (typeof raw !== 'object' || raw === null)
+      throw new Error(`segment ${index} is not an object`)
+    const s = raw as Record<string, unknown>
+    if (typeof s.start !== 'number' || typeof s.text !== 'string') {
+      throw new Error(`segment ${index} lacks a numeric start or string text`)
+    }
+    return { start: s.start, end: typeof s.end === 'number' ? s.end : null, text: s.text }
+  })
+  let usageSeconds: number | null = null
+  if (typeof record.usage === 'object' && record.usage !== null) {
+    const u = record.usage as Record<string, unknown>
+    if (typeof u.seconds === 'number') usageSeconds = u.seconds
+  }
+  return {
+    text: record.text,
+    language: typeof record.language === 'string' ? record.language : null,
+    duration: typeof record.duration === 'number' ? record.duration : null,
+    usageSeconds,
+    segments,
+  }
+}
+
+async function transcribeOnce(
+  audio: Buffer,
+  filename: string,
+  mime: string,
+  language: string | null,
+): Promise<RunResult> {
+  const form = new FormData()
+  form.append('file', new Blob([new Uint8Array(audio)], { type: mime }), filename)
+  form.append('model', MODEL)
+  form.append('response_format', 'verbose_json')
+  form.append('temperature', '0')
+  if (language !== null) form.append('language', language)
+
+  const startedAt = Date.now()
+  const response = await fetch(`${BASE_URL}/audio/transcriptions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    body: form,
+    signal: AbortSignal.timeout(180_000),
+  })
+  const ms = Date.now() - startedAt
+  if (!response.ok) {
+    throw new Error(`ILMU returned ${response.status}: ${(await response.text()).slice(0, 500)}`)
+  }
+  return { ms, ...parseResponse(await response.json()) }
+}
+
+/** Mirrors `usable()` in frontend/src/audio/draft-turns.ts, the gate that decides
+ * whether draft speaker labels engage or the transcript falls back to prose. */
+const normalise = (text: string): string => text.replace(/\s+/g, ' ').trim()
+
+interface Integrity {
+  usable: boolean
+  failures: string[]
+  contiguousBoundaries: number
+  boundaries: number
+  finalEnd: number | null
+}
+
+function checkIntegrity(segments: Segment[], fullText: string): Integrity {
+  const failures: string[] = []
+  if (segments.length === 0) failures.push('no segments')
+  let previousStart = Number.NEGATIVE_INFINITY
+  for (const [index, segment] of segments.entries()) {
+    if (!Number.isFinite(segment.start) || segment.start < previousStart) {
+      failures.push(`segment ${index} start is non-finite or decreasing`)
+    }
+    if (segment.end !== null && !Number.isFinite(segment.end)) {
+      failures.push(`segment ${index} end is non-finite`)
+    }
+    previousStart = segment.start
+  }
+  if (normalise(segments.map((s) => s.text).join(' ')) !== normalise(fullText)) {
+    failures.push('concatenated segment text does not reproduce the transcript')
+  }
+
+  let contiguousBoundaries = 0
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    const current = segments[i]
+    const next = segments[i + 1]
+    if (!current || !next) continue
+    if (current.end !== null && Math.abs(current.end - next.start) < 1e-6) contiguousBoundaries += 1
+  }
+  const last = segments.at(-1)
+  return {
+    usable: failures.length === 0,
+    failures,
+    contiguousBoundaries,
+    boundaries: Math.max(0, segments.length - 1),
+    finalEnd: last ? (last.end ?? last.start) : null,
+  }
+}
+
+interface GroundTruthFile {
+  durationSeconds?: number
+  turns?: { text?: string }[]
+}
+
+async function readGroundTruth(path: string): Promise<string> {
+  const parsed = JSON.parse(await readFile(path, 'utf8')) as GroundTruthFile
+  const texts = (parsed.turns ?? []).map((t) => t.text).filter((t): t is string => Boolean(t))
+  if (texts.length === 0) throw new Error(`no turn texts found in ${path}`)
+  return texts.join(' ')
+}
+
+function renderSegments(segments: Segment[]): string[] {
+  return [
+    '| # | Start | End | Text |',
+    '| --- | --- | --- | --- |',
+    ...segments.map(
+      (s, i) =>
+        `| ${i} | ${s.start.toFixed(2)} | ${s.end === null ? 'null' : s.end.toFixed(2)} | ${s.text.replaceAll('|', '\\|')} |`,
+    ),
+  ]
+}
+
+async function main() {
+  if (!API_KEY) {
+    console.error('ILMU_API_KEY is not set (root .env or environment); nothing was sent.')
+    process.exit(2)
+  }
+  const args = parseArgs(process.argv.slice(2))
+
+  const mime = MIME_BY_EXTENSION[extname(args.audioPath).toLowerCase()]
+  if (!mime) {
+    console.error(`unsupported audio extension on ${args.audioPath}; nothing was sent.`)
+    process.exit(2)
+  }
+  const audio = await readFile(args.audioPath)
+  const filename = basename(args.audioPath)
+  console.log(`${args.label}: ${filename} (${(audio.byteLength / 1024 / 1024).toFixed(1)} MB)`)
+  console.log(
+    `model ${MODEL} at ${BASE_URL}, ${args.runs} run(s)${args.probeMs ? ' + ms probe' : ''}`,
+  )
+
+  const runs: RunResult[] = []
+  for (let i = 0; i < args.runs; i += 1) {
+    const run = await transcribeOnce(audio, filename, mime, null)
+    runs.push(run)
+    console.log(
+      `  run ${i + 1}: ${(run.ms / 1000).toFixed(1)}s, ${run.segments.length} segments, language=${run.language ?? '?'}, duration=${run.duration ?? run.usageSeconds ?? '?'}`,
+    )
+  }
+  const probe = args.probeMs ? await transcribeOnce(audio, filename, mime, 'ms') : null
+  if (probe) {
+    console.log(`  ms probe: ${(probe.ms / 1000).toFixed(1)}s, ${probe.segments.length} segments`)
+  }
+
+  const first = runs[0]
+  if (!first) throw new Error('no runs completed')
+  const texts = new Set(runs.map((r) => r.text))
+  const segmentSets = new Set(runs.map((r) => JSON.stringify(r.segments)))
+  const deterministic = texts.size === 1 && segmentSets.size === 1
+  const integrity = checkIntegrity(first.segments, first.text)
+  const groundTruth = args.groundTruthPath ? await readGroundTruth(args.groundTruthPath) : null
+
+  const verboseHonoured =
+    first.segments.length > 0 || first.duration !== null || first.language !== null
+  console.log(`  deterministic across ${args.runs} run(s): ${deterministic ? 'yes' : 'NO'}`)
+  console.log(`  verbose_json honoured: ${verboseHonoured ? 'yes' : 'no'}`)
+  console.log(
+    `  usable() verdict: ${integrity.usable ? 'pass' : `FAIL (${integrity.failures.join('; ')})`}`,
+  )
+
+  const startedAt = new Date().toISOString()
+  const lines = [
+    `# ASR A/B: ${args.label}`,
+    '',
+    `- **When:** ${startedAt}`,
+    `- **Model:** \`${MODEL}\` at ${BASE_URL}`,
+    `- **File:** ${filename} (${audio.byteLength} bytes)`,
+    `- **Runs:** ${args.runs}${args.probeMs ? ' plus one language=ms probe' : ''}`,
+    '',
+    '## Runs',
+    '',
+    '| Run | Latency | Segments | Detected Language | Reported Duration | Billed Seconds |',
+    '| --- | --- | --- | --- | --- | --- |',
+    ...runs.map(
+      (r, i) =>
+        `| ${i + 1} | ${(r.ms / 1000).toFixed(1)}s | ${r.segments.length} | ${r.language ?? '?'} | ${r.duration ?? '?'} | ${r.usageSeconds ?? '?'} |`,
+    ),
+    ...(probe
+      ? [
+          `| ms probe | ${(probe.ms / 1000).toFixed(1)}s | ${probe.segments.length} | ${probe.language ?? '?'} | ${probe.duration ?? '?'} | ${probe.usageSeconds ?? '?'} |`,
+        ]
+      : []),
+    '',
+    '## Verdicts',
+    '',
+    `- **Deterministic:** ${deterministic ? 'yes, byte-identical text and segments' : 'NO'}`,
+    `- **verbose_json honoured:** ${verboseHonoured ? 'yes' : 'no (segments, language, and duration absent; only `usage.seconds` returned)'}`,
+    `- **Segment integrity (\`usable()\` contract):** ${integrity.usable ? 'pass' : `FAIL: ${integrity.failures.join('; ')}`}`,
+    ...(first.segments.length === 0
+      ? [
+          '- **Consequence:** no per-segment timestamps on this path; draft speaker labels would run in single-segment content mode (sentence scoring still works, per-turn offsets are lost)',
+        ]
+      : []),
+    `- **Contiguous boundaries:** ${integrity.contiguousBoundaries} of ${integrity.boundaries}`,
+    `- **Final segment end:** ${integrity.finalEnd ?? 'n/a'}`,
+    '',
+    '## Transcript (Run 1)',
+    '',
+    first.text.trim(),
+    '',
+    ...(probe ? ['## Transcript (language=ms Probe)', '', probe.text.trim(), ''] : []),
+    ...(groundTruth ? ['## Ground Truth', '', groundTruth, ''] : []),
+    '## Segments (Run 1)',
+    '',
+    ...renderSegments(first.segments),
+    '',
+  ]
+
+  await mkdir(new URL('reports/', import.meta.url), { recursive: true })
+  const reportPath = new URL(
+    `reports/asr-ab-${args.label}-${startedAt.replace(/[:.]/g, '-')}.md`,
+    import.meta.url,
+  )
+  await writeFile(reportPath, lines.join('\n'), 'utf8')
+  console.log(`\nReport: ${fileURLToPath(reportPath)}`)
+}
+
+await main()


### PR DESCRIPTION
## What Changed

The hosted-ASR measurement gate is run and recorded: a committed A/B harness (`evals/asr-ab.ts`) plus `docs/trd.md` section 20.3 with the token table, the API-reality findings, and the pre-written decision rule applied. Verdict: ship the hosted path, with the prose-fallback caveat.

Closes #151

## Why

Issues #154 (ILMU relay) and #155 (consent UI) were gated on measuring `ilmu-asr-v4.2` against the shipped local `whisper-small` before any hosted UI work. The decisive finding: on a human-read Malay-dominant rojak sample, the shipped `language: 'en'` pin translates and fabricates (the chest-pain phrase became "your feet are strong, you will feel a little pain"), while ILMU preserves the language, the code-switching, and the red-flag phrase at roughly 40x the speed, with no timestamps and no punctuation (the recorded caveat).

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] Manually exercised the affected flow

Harness run against both samples through the real ILMU endpoint (3 runs each, determinism checked, plus `language='ms'`, response-shape, and prompt-biasing probes); local arm run with the exact production dependency and options in Node (`en`, `ms`, and unset). Reports land in the gitignored `evals/reports/`; no audio, transcript output, or key is committed. No tests added: the harness is explicitly not a test (it spends billed API calls) and nothing under `bun run test` changed.

## Notes For The Reviewer

- The Clinical-Safety Checklist section is deleted per its own rule: the diff touches only `evals/` and `docs/`, none of the listed paths. Both measurement samples are synthetic or scripted; no patient data of any kind was sent to any provider.
- Spend for the whole gate: about RM 0.20 of the RM 20 early-access credit.
- Follow-on design consequences are already commented on #154 (audit duration from `usage.seconds`; documented fields currently absent) and #155 (hosted output is paste-grade prose; tooltip carries the measured accuracy framing).

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hosted speech transcription, available behind the existing consent flow.
  * Hosted transcription provides faster results and better preservation of clinical content in tested Malay and English samples.
  * Added evaluation tooling for comparing transcription quality, response consistency, and language performance.

* **Documentation**
  * Documented accuracy findings and limitations, including prose-only output, missing timestamps, occasional recognition errors, and nondeterministic results.
  * Added guidance to disclose these limitations in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->