### PR TITLE
feat(deid): teach the detectors Malay identifier forms and stopwords

### DIFF
--- a/backend/src/deid/deid.test.ts
+++ b/backend/src/deid/deid.test.ts
@@ -13,6 +13,47 @@ describe('detector inventory (docs/trd.md §9)', () => {
     expect(labelsIn('My IC number is 850523-14-5677.')).toContain('NRIC')
   })
 
+  it('detects an unhyphenated MyKad number beside a Malay identity cue', () => {
+    expect(labelsIn('Nombor kad pengenalan saya 900412086543.')).toContain('NRIC')
+  })
+
+  it('detects a structurally valid unhyphenated MyKad with no cue at all', () => {
+    // Recall-first: transcription drops hyphens and puts the digits far from
+    // the "IC" that introduced them, so validity alone must gate.
+    expect(labelsIn('The number 900412086543 was on the form.')).toContain('NRIC')
+  })
+
+  it('still detects an invalid unhyphenated number when the context says it is an IC', () => {
+    expect(labelsIn('His IC is 850523175677 lah.')).toContain('NRIC')
+    expect(labelsIn('No. K/P 850523175677 tertera di kad.')).toContain('NRIC')
+  })
+
+  it('detects a date of birth behind a Malay birth cue', () => {
+    expect(labelsIn('Tarikh lahir 23 Mac 1985, betul?')).toContain('DOB')
+    expect(labelsIn('Dia dilahirkan pada 3 Ogos 1990.')).toContain('DOB')
+  })
+
+  it('detects a clinic record number behind a Malay record cue', () => {
+    expect(labelsIn('Nombor pendaftaran KLC-004821 untuk fail.')).toContain('MRN')
+    expect(labelsIn('No. fail KLC-004821 ya.')).toContain('MRN')
+  })
+
+  it('still mints a name introduced by saya after the Malay stopword additions', () => {
+    expect(labelsIn('Nama saya Aisyah binti Osman.')).toContain('PATIENT')
+    expect(labelsIn('Nanti cari saya Khairul di kaunter.')).toContain('PATIENT')
+  })
+
+  it('still detects weekday-named patients, whole span included', () => {
+    // Khamis and Jumaat are attested Malay given names outside the gazetteer,
+    // which is why they are not weekday stopwords: trimNameSpan would strip
+    // them off the front of a patronymic span and leak them in cleartext.
+    expect(labelsIn('Nama saya Khamis.')).toContain('PATIENT')
+    const values = detect('Khamis bin Sulaiman datang tadi.')
+      .filter((m) => m.label === 'PATIENT')
+      .map((m) => m.value)
+    expect(values).toContain('Khamis bin Sulaiman')
+  })
+
   it('detects a Malaysian mobile number', () => {
     expect(labelsIn('You can call me at 012-3456789.')).toContain('PHONE')
   })
@@ -67,6 +108,36 @@ describe('precision — clinical content must survive', () => {
     expect(text).toContain('Paracetamol')
     expect(text).toContain('Monday')
   })
+
+  it('does not tokenise an arbitrary twelve-digit reference number', () => {
+    // Pins the 0.3 base for a structurally invalid bare run: no birth date, no
+    // context, no token. The sentence avoids words like "invoice" and
+    // "clinic", whose substrings satisfy the 'ic' context cue: hasContext
+    // matches substrings, a pre-existing behaviour this test must not rely on
+    // either way.
+    const { text } = deidentify('Reference 123456789012 is printed on the receipt.')
+    expect(text).toContain('123456789012')
+  })
+
+  it('does not tokenise a Malay-month follow-up date that carries no birth cue', () => {
+    const { text } = deidentify('Jumpa lagi 20 Ogos 2026 untuk susulan.')
+    expect(text).toContain('20 Ogos 2026')
+  })
+
+  it('does not read an English word starting with a Malay month prefix as a date', () => {
+    const { text } = deidentify('Date of birth noted; discharge 12 2024 planned.')
+    expect(text).toContain('discharge 12 2024')
+  })
+
+  it('does not mint a name from saya followed by a Malay everyday word', () => {
+    const { text } = deidentify('Boleh tulis surat untuk saya Doktor?')
+    expect(text).toContain('Doktor')
+  })
+
+  it('keeps a Malay weekday in clinical content', () => {
+    const { text } = deidentify('Datang balik jumpa saya Isnin depan.')
+    expect(text).toContain('Isnin')
+  })
 })
 
 describe('NRIC structural validation', () => {
@@ -80,6 +151,19 @@ describe('NRIC structural validation', () => {
 
   it('rejects an unassigned place-of-birth code', () => {
     expect(isStructurallyValidNric('850523-17-5677')).toBe(false)
+  })
+
+  it('accepts the unhyphenated form of a valid number', () => {
+    expect(isStructurallyValidNric('900412086543')).toBe(true)
+  })
+
+  it('rejects an unhyphenated number with an impossible birth month', () => {
+    expect(isStructurallyValidNric('901345086543')).toBe(false)
+  })
+
+  it('rejects a half-hyphenated hybrid neither detector can produce', () => {
+    expect(isStructurallyValidNric('850523-145677')).toBe(false)
+    expect(isStructurallyValidNric('85052314-5677')).toBe(false)
   })
 
   it('still detects a structurally invalid NRIC when the context says it is one', () => {
@@ -115,6 +199,13 @@ describe('tokenisation and the request-scoped vault', () => {
     const original = 'Encik Ahmad bin Ismail, IC 850523-14-5677, phone 012-3456789.'
     const { text, vault } = deidentify(original)
     expect(text).not.toContain('850523-14-5677')
+    expect(vault.rehydrate(text)).toBe(original)
+  })
+
+  it('round-trips an unhyphenated MyKad', () => {
+    const original = 'IC saya 900412086543, doktor.'
+    const { text, vault } = deidentify(original)
+    expect(text).not.toContain('900412086543')
     expect(vault.rehydrate(text)).toBe(original)
   })
 

--- a/backend/src/deid/detectors.ts
+++ b/backend/src/deid/detectors.ts
@@ -5,7 +5,7 @@ import {
   NAME_STOPWORDS,
   PATRONYMICS,
 } from './gazetteer.js'
-import { isStructurallyValidNric, NRIC_PATTERN } from './nric.js'
+import { isStructurallyValidNric, NRIC_PATTERN, NRIC_UNHYPHENATED_PATTERN } from './nric.js'
 
 /**
  * Detector inventory for the Malaysian context (docs/trd.md §9).
@@ -59,7 +59,7 @@ function scoreWith(
 
 // ─── NRIC ────────────────────────────────────────────────────────────────────
 
-const NRIC_CONTEXT = ['ic', 'i/c', 'nric', 'mykad', 'kad pengenalan', 'identity', 'pesakit']
+const NRIC_CONTEXT = ['ic', 'i/c', 'k/p', 'nric', 'mykad', 'kad pengenalan', 'identity', 'pesakit']
 
 function detectNric(text: string): Match[] {
   const out: Match[] = []
@@ -69,6 +69,24 @@ function detectNric(text: string): Match[] {
     // Structural validity is precision, not recall: an implausible NRIC still
     // scores high enough to be tokenised when the context says it is one.
     const base = isStructurallyValidNric(value) ? 0.85 : 0.4
+    out.push({
+      label: 'NRIC',
+      start,
+      end: start + value.length,
+      value,
+      score: scoreWith(text, start, start + value.length, base, NRIC_CONTEXT),
+    })
+  }
+  // Hyphens do not survive speech or casual typing. A structurally valid bare
+  // twelve-digit run gates with no context at all (recall-first: transcription
+  // puts digits far from the "IC" that introduced them), and validity bounds
+  // the false positives: a random twelve-digit reference number rarely carries
+  // a real birth date plus an assigned place-of-birth code. An invalid one
+  // needs the context boost, mirroring the mistyped-IC philosophy above.
+  for (const m of text.matchAll(NRIC_UNHYPHENATED_PATTERN)) {
+    const value = m[0]
+    const start = m.index
+    const base = isStructurallyValidNric(value) ? 0.55 : 0.3
     out.push({
       label: 'NRIC',
       start,
@@ -156,9 +174,19 @@ function detectAddress(text: string): Match[] {
  * tokenising them would destroy the clinical content the note depends on.
  * The DOB cue is therefore mandatory, not a score boost.
  */
-const DOB_CUE = /(?:born(?:\s+on)?|date\s+of\s+birth|d\.?o\.?b\.?|birthday|lahir)\b/gi
-const DATE_NEAR_CUE =
-  /\b(?:\d{1,2}[/\-.]\d{1,2}[/\-.]\d{2,4}|\d{1,2}(?:st|nd|rd|th)?\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?,?\s+\d{4}|(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+\d{4})\b/gi
+const DOB_CUE =
+  /(?:born(?:\s+on)?|date\s+of\s+birth|d\.?o\.?b\.?|birthday|(?:di|ke)?lahir(?:an|kan)?)\b/gi
+// Malay months whose first three letters differ from the English abbreviation:
+// Mac, Mei, Ogos, Okt(ober), Dis(ember). The rest already match via the
+// English prefix plus `[a-z]*` (Januari, Februari, April, Jun, Julai, ...).
+// The Malay alternates sit outside that `[a-z]*` so `Dis` cannot ride it into
+// "discharge" or `Mac` into "macam".
+const MONTH =
+  /(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*|Mac|Mei|Ogos|Okt(?:ober)?|Dis(?:ember)?/
+const DATE_NEAR_CUE = new RegExp(
+  `\\b(?:\\d{1,2}[/\\-.]\\d{1,2}[/\\-.]\\d{2,4}|\\d{1,2}(?:st|nd|rd|th)?\\s+(?:${MONTH.source})\\.?,?\\s+\\d{4}|(?:${MONTH.source})\\.?\\s+\\d{1,2},?\\s+\\d{4})\\b`,
+  'gi',
+)
 
 function detectDob(text: string): Match[] {
   const out: Match[] = []
@@ -183,7 +211,7 @@ function detectDob(text: string): Match[] {
 // ─── Medical / clinic record number ──────────────────────────────────────────
 
 const MRN_CUE =
-  /\b(?:MRN|RN|record\s+(?:no|number)|registration\s+(?:no|number)|clinic\s+(?:no|number)|patient\s+(?:id|no|number)|file\s+(?:no|number))\b[:\s.#-]*([A-Z]{0,4}[-/]?\d{3,10}[A-Z]?)\b/gi
+  /\b(?:MRN|RN|record\s+(?:no|number)|registration\s+(?:no|number)|clinic\s+(?:no|number)|patient\s+(?:id|no|number)|file\s+(?:no|number)|(?:no\.?|nombor)\s+(?:pendaftaran|fail|klinik|pesakit))\b[:\s.#-]*([A-Z]{0,4}[-/]?\d{3,10}[A-Z]?)\b/gi
 
 function detectMrn(text: string): Match[] {
   const out: Match[] = []

--- a/backend/src/deid/gazetteer.ts
+++ b/backend/src/deid/gazetteer.ts
@@ -274,6 +274,35 @@ export const NAME_STOPWORDS = new Set(
     'have',
     'has',
     'had',
+    // Malay everyday words. Load-bearing against the bare 'saya' introducer:
+    // without these, "...untuk saya Doktor" mints a false PATIENT token, and a
+    // false token corrupts the note on rehydration. Deliberately absent
+    // although they are months or weekdays: 'mei' (a given name in
+    // GIVEN_NAMES) and 'khamis', 'jumaat', 'sabtu', 'ahad' (attested Malay
+    // given names outside the gazetteer, where trimNameSpan's stopword loop
+    // would strip them off a patronymic span and leak them in cleartext).
+    // A recall loss on the PHI boundary outranks the precision gain.
+    'doktor',
+    'klinik',
+    'jururawat',
+    'ubat',
+    'sakit',
+    'demam',
+    'batuk',
+    'selsema',
+    'pesakit',
+    'farmasi',
+    'isnin',
+    'selasa',
+    'rabu',
+    'januari',
+    'februari',
+    'mac',
+    'jun',
+    'julai',
+    'ogos',
+    'oktober',
+    'disember',
     'malaysia',
     'selangor',
     'johor',

--- a/backend/src/deid/nric.ts
+++ b/backend/src/deid/nric.ts
@@ -32,6 +32,13 @@ const UNASSIGNED_PB = new Set([
 
 export const NRIC_PATTERN = /\b(\d{6})-(\d{2})-(\d{4})\b/g
 
+/**
+ * The same number as spoken or casually typed: twelve digits, no hyphens. The
+ * exactly-twelve bound is load-bearing: `\b` on both sides means a longer digit
+ * run (an invoice or account number) does not partially match.
+ */
+export const NRIC_UNHYPHENATED_PATTERN = /\b(\d{6})(\d{2})(\d{4})\b/g
+
 function isValidBirthDate(yymmdd: string): boolean {
   const month = Number(yymmdd.slice(2, 4))
   const day = Number(yymmdd.slice(4, 6))
@@ -46,7 +53,10 @@ function isValidBirthDate(yymmdd: string): boolean {
 }
 
 export function isStructurallyValidNric(candidate: string): boolean {
-  const match = /^(\d{6})-(\d{2})-(\d{4})$/.exec(candidate)
+  // Fully hyphenated or fully bare, never a half-hyphenated hybrid neither
+  // detector pattern can produce.
+  const match =
+    /^(\d{6})-(\d{2})-(\d{4})$/.exec(candidate) ?? /^(\d{6})(\d{2})(\d{4})$/.exec(candidate)
   if (!match) return false
 
   const [, yymmdd, pb] = match


### PR DESCRIPTION
## What Changed

The de-identification gate now catches the Malaysian identifier forms it previously missed: unhyphenated 12-digit MyKad numbers (structurally validated, recall-first scoring), Malay-month birth dates behind widened Malay birth cues (lahir, dilahirkan, kelahiran), and Malay record-number cues (nombor pendaftaran, no. fail, ...). Malay everyday words, weekdays, and months join the name stopwords so the bare "saya" introducer cannot mint a false PATIENT token from "...untuk saya Doktor".

Closes #152

## Why

Transcripts containing Malay already enter the system (fixtures, paste), and the hosted Malaysian ASR path (#154, gated shipped by #151) will send more. An unhyphenated MyKad previously leaked past both the gate and the egress guard, which shares the same detectors.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (415 backend tests including 17 new cases; all four workspaces green)
- [x] phi-boundary-auditor review: one blocker and three nits found, all resolved in this diff (below)

New pinned cases in `backend/src/deid/deid.test.ts`: unhyphenated MyKad with a Malay cue, structurally valid bare number with no cue (pins the 0.55 base), invalid bare number near an IC or K/P cue (pins 0.3 + 0.35 boost), vault round-trip of a bare number, both validator forms, Malay DOB (23 Mac 1985, dilahirkan pada 3 Ogos 1990), Malay MRN cues, and precision: an arbitrary invalid 12-digit reference survives, a cueless Malay-month follow-up date survives, "untuk saya Doktor" mints nothing, "Isnin" survives, while "Nama saya Aisyah binti Osman" and "saya Khairul" still mint.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider: egress still goes through `deid/` then `LLMClient`
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model (untouched)
- [x] Citations remain ID-constrained; no free-text references accepted (untouched)
- [x] No transcript bodies, note contents, or vault entries written to logs (no logging changes)
- [x] Fixtures added are synthetic (no fixture changes here; the Malay fixture seeding a bare MyKad lands with #153, after this merges)

## Notes For The Reviewer

- **Deliberate deviation from the issue's stopword list, hardened by the audit: five month/weekday words are excluded.** `mei` is a given name in `GIVEN_NAMES`; the auditor then showed `khamis`, `jumaat`, `sabtu`, and `ahad` are attested Malay given names outside the gazetteer, where `trimNameSpan`'s leading-stopword loop would strip them off a patronymic span and leak them in cleartext ("Khamis bin Sulaiman" minting only on "bin Sulaiman"). All five exclusions are commented at the site and pinned by tests ("Nama saya Khamis." mints; the patronymic span survives whole). The honest cost: "jumpa saya Khamis depan" is re-admitted as a false positive, which rehydration restores; the alternative was a real name leaving the API.
- **Audit nits fixed in this diff:** the Malay month alternates now sit outside the shared `[a-z]*` so `Dis` cannot ride into "discharge" (pinned); the structural validator accepts fully-hyphenated or fully-bare forms only, never a half-hyphenated hybrid (pinned).
- **Pre-existing behaviour surfaced while testing, filed as #159 rather than fixed inline:** `hasContext` matches substrings, so the `ic` cue inside "invoice"/"clinic" can boost an invalid bare 12-digit number to acceptance. Over-redaction only; a word-boundary rewrite needs every context list audited first (ADDRESS relies on `live` inside "lives"). Two further `trimNameSpan` observations went to #149 as comments.
- `assertNoIdentifiers`, `markDeidentified`, `deidentify`, and the vault are untouched; the egress guard inherits the new recall by construction.

Generated with [Claude Code](https://claude.com/claude-code)
