### PR TITLE
fix(ui): release the microphone when the record tab unmounts

### DIFF
--- a/frontend/src/audio/AudioCapture.test.tsx
+++ b/frontend/src/audio/AudioCapture.test.tsx
@@ -57,14 +57,22 @@ class FakeMediaRecorder {
   mimeType = 'audio/webm'
   ondataavailable: ((event: { data: Blob }) => void) | null = null
   onstop: (() => void) | null = null
-  start = vi.fn()
+  /** Modelled because the teardown path reads it before stopping (issue #140). */
+  state: 'inactive' | 'recording' = 'inactive'
+  /** Real recorders expose the stream they were built on; teardown needs it. */
+  readonly stream: { getTracks: () => { stop: () => void }[] }
+  start = vi.fn(() => {
+    this.state = 'recording'
+  })
 
-  constructor(_stream: unknown) {
+  constructor(stream: { getTracks: () => { stop: () => void }[] }) {
+    this.stream = stream
     recorders.push(this)
   }
 
   /** The browser fires these after stop() returns, never inside it. */
   stop() {
+    this.state = 'inactive'
     queueMicrotask(() => {
       this.ondataavailable?.({ data: new Blob(['pcm']) })
       this.onstop?.()
@@ -543,6 +551,38 @@ describe('prewarming the speech model', () => {
 
     expect(spawned().terminate).toHaveBeenCalled()
     expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('releases every microphone track when unmounted mid-recording', async () => {
+    // Issue #140. Tracks were stopped only inside `onstop`, which only the Stop
+    // button reaches, so switching intake tabs left the browser's recording
+    // indicator on. In a consulting room that reads as "still listening".
+    tracks = [{ stop: vi.fn() }, { stop: vi.fn() }]
+    const { unmount } = renderCapture()
+    await startRecording()
+
+    unmount()
+
+    // Every track, not just the first: a stream carrying two would otherwise
+    // half-release and keep the indicator lit.
+    for (const track of tracks) expect(track.stop).toHaveBeenCalled()
+  })
+
+  it('starts no transcription for a recording it tore down', async () => {
+    // Unlike the test above, this one does NOT fail before the fix, because
+    // nothing stopped the recorder and so `onstop` never fired at all. It
+    // guards the fix instead: stopping the recorder to free the device must
+    // not also queue a decode, which would build a fresh worker moments after
+    // teardown killed the last one, on a component that is already gone.
+    const { unmount, onTranscript } = renderCapture()
+    await startRecording()
+    const built = workers.length
+
+    unmount()
+    await settle()
+
+    expect(workers).toHaveLength(built)
+    expect(onTranscript).not.toHaveBeenCalled()
   })
 
   it('builds no worker when microphone access is refused', async () => {

--- a/frontend/src/audio/AudioCapture.tsx
+++ b/frontend/src/audio/AudioCapture.tsx
@@ -307,6 +307,21 @@ export function AudioCapture({
       if (stall.current !== null) window.clearTimeout(stall.current)
       worker.current?.terminate()
       worker.current = null
+      // A recording still running owns the microphone, and nothing above
+      // releases it: `onstop` does that, and only the Stop button reaches
+      // `onstop`. Leaving it live keeps the browser's recording indicator on
+      // after the doctor has moved to another tab (issue #140).
+      //
+      // Detached before stopping, because a stop the doctor did not ask for
+      // must free the device without also queueing a transcription: that
+      // handler would build a fresh worker moments after the terminate above,
+      // for a component that is already gone.
+      const media = recorder.current
+      recorder.current = null
+      if (media === null) return
+      media.onstop = null
+      if (media.state !== 'inactive') media.stop()
+      for (const track of media.stream.getTracks()) track.stop()
     },
     [],
   )


### PR DESCRIPTION
## What Changed

Unmounting the record tab during a recording now stops the recorder and releases every track of its stream, so the browser's recording indicator goes out instead of staying lit until reload.

Closes #140

## Why

Tracks were only ever stopped inside `media.onstop`, and only the Stop and Transcribe button reaches that handler. The unmount cleanup was extended in #139 for timers and workers, and the recorder was deliberately left out of that diff. Switching intake tabs or navigating away therefore left the microphone live. The component's own comment already names why that matters: in a consulting room it reads as "still listening".

`onstop` is detached before the teardown stop. Freeing the device must not also queue a transcription, which would build a fresh worker moments after the cleanup terminated the last one, for a component that is already gone.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`

Two tests added to `AudioCapture.test.tsx`, and both were checked against a reverted fix rather than assumed to have teeth:

- `releases every microphone track when unmounted mid-recording` fails before the fix (`expected "spy" to be called at least once`) and passes after. Uses a two-track stream, so a partial release is caught.
- `starts no transcription for a recording it tore down` does **not** fail before the fix, and its comment says so rather than implying otherwise. It guards the fix instead: removing the `media.onstop = null` line makes it fail.

`FakeMediaRecorder` gained `state` and `stream`, which real `MediaRecorder` exposes and the teardown path reads.

## Notes For The Reviewer

Source change is 15 added lines in one existing cleanup effect, no deletions. `state !== 'inactive'` is checked before stopping so a recorder that already stopped is not stopped twice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone cleanup when leaving the audio capture screen.
  * Prevented unwanted transcription and background processing from starting during shutdown.
  * Ensured active recordings and microphone tracks are stopped reliably when capture ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->