### PR TITLE
feat(redflags): teach the engine Malay and fix negation idioms as redflag-list-v4

### DIFF
--- a/backend/src/acceptance/safety.test.ts
+++ b/backend/src/acceptance/safety.test.ts
@@ -47,6 +47,8 @@ describe('GUARANTEE — no direct identifier crosses the privacy gateway', () =>
     'ahmad.ismail85@example.com',
     'Jalan Meranti',
     'KLC-004821',
+    'Faizal bin Osman',
+    '900412086543',
   ]
 
   it('leaks zero identifiers across every fixture (PRD §16 target: 0)', () => {

--- a/backend/src/analysis/prompt.ts
+++ b/backend/src/analysis/prompt.ts
@@ -21,7 +21,10 @@ const sharedPreamble = (
 ) => `You are extracting structured clinical information from a de-identified GP
 consultation transcript for ${profile.scope}. You do not diagnose and you do not
 replace clinical judgement: every output you produce is reviewed and edited
-by the treating doctor before it is used.`
+by the treating doctor before it is used. The transcript may be in English,
+Bahasa Malaysia, or code-switched Malaysian speech; write every output field
+in English, except verbatim evidence spans, which always stay in the
+transcript's own words whatever the language.`
 
 /**
  * Operation 1a. Carries the evidence rules, because it is the only half that
@@ -47,9 +50,11 @@ Produce two things from the transcript:
      **one speaker turn only**: never join a question and its answer into a
      single span, and never include the "Doctor:" or "Patient:" label.
      Never abbreviate with "..." or any ellipsis. Never tidy up wording,
-     spelling, or grammar: copy it exactly as written, Manglish and all.
-     A shorter span that matches beats a longer one that does not, so quote
-     the few words that carry the finding, not the whole turn.
+     spelling, or grammar: copy it exactly as written, Manglish, Malay and
+     all. Never translate or normalise an evidence span; quote it verbatim
+     in its original language. A shorter span that matches beats a longer
+     one that does not, so quote the few words that carry the finding, not
+     the whole turn.
    - Where a field genuinely has no supporting text, leave "evidence" as an
      empty string and use NOT_ASSESSED. An empty string is expected and
      costs you nothing.

--- a/backend/src/fixtures/corpus.ts
+++ b/backend/src/fixtures/corpus.ts
@@ -367,6 +367,62 @@ export const FIXTURES: readonly Fixture[] = [
       ],
     },
   },
+
+  // ─── urti-malay-red-flag ──────────────────────────────────────────────────
+  // Identifiers: patient name (patronymic + introducer) and an unhyphenated
+  // MyKad number, the spoken form the hosted ASR path produces.
+  // Exercises: the redflag-list-v4 Malay alternates end to end. Every expected
+  // flag fires from a Malay phrase, the idiom "Tak apa" must not read as a
+  // denial (it precedes the chest-pain disclosure), and the stridor screening
+  // question is genuinely denied in Malay, so it must stay silent. The denied
+  // question deliberately carries a negator-free span (nafas berbunyi):
+  // negator-carrying spans like "tak boleh telan" fire even when denied, the
+  // documented fail-open trade in triggers.ts.
+  {
+    id: 'urti-malay-red-flag',
+    label: 'Malay-language URTI with red flags (rojak register)',
+    transcript: {
+      source: 'fixture',
+      turns: [
+        { speaker: 'doctor', text: 'Selamat pagi, apa masalah hari ini?', offsetSeconds: 0.0 },
+        {
+          speaker: 'patient',
+          text: 'Nama saya Faizal bin Osman. Nombor kad pengenalan saya 900412086543.',
+          offsetSeconds: 3.2,
+        },
+        {
+          speaker: 'patient',
+          text: 'Doktor, batuk teruk dah seminggu. Semalam batuk sampai keluar darah sikit.',
+          offsetSeconds: 10.8,
+        },
+        { speaker: 'doctor', text: 'Ada sesak nafas?', offsetSeconds: 18.9 },
+        {
+          speaker: 'patient',
+          text: 'Ada, bila baring rasa semput, susah nak bernafas.',
+          offsetSeconds: 21.0,
+        },
+        { speaker: 'doctor', text: 'Sakit dada tak?', offsetSeconds: 27.6 },
+        {
+          speaker: 'patient',
+          text: 'Tak apa doktor, dada sakit sikit je bila batuk kuat.',
+          offsetSeconds: 29.4,
+        },
+        { speaker: 'doctor', text: 'Bila tidur, nafas berbunyi tak?', offsetSeconds: 36.2 },
+        {
+          speaker: 'patient',
+          text: 'Takde, tidur okay je.',
+          offsetSeconds: 39.0,
+        },
+        { speaker: 'doctor', text: 'Demam macam mana?', offsetSeconds: 43.5 },
+        { speaker: 'patient', text: 'Demam pun tak kebah, doktor.', offsetSeconds: 45.6 },
+        {
+          speaker: 'doctor',
+          text: 'Baik, saya nak periksa dulu. Lepas tu kita bincang.',
+          offsetSeconds: 49.8,
+        },
+      ],
+    },
+  },
 ]
 
 for (const fixture of FIXTURES) {

--- a/backend/src/fixtures/rubrics.ts
+++ b/backend/src/fixtures/rubrics.ts
@@ -109,4 +109,26 @@ export const FIXTURE_RUBRICS: readonly FixtureRubric[] = [
     // The negative control. The patient explicitly denies every symptom screened for.
     expectedRedFlagIds: [],
   },
+  {
+    fixtureId: 'urti-malay-red-flag',
+    gradedAgainst: ['CAP-3', 'PRD §12 (input-language limitation)', 'TRD §9 detector inventory'],
+    expectedBehaviour:
+      'Every expected rule flag fires from a Malay phrase: haemoptysis from "batuk sampai ' +
+      'keluar darah", dyspnoea from the "sesak nafas" screening exchange (the affirmed question ' +
+      'carries the span), chest pain from "dada sakit" despite the leading idiom "Tak apa" ' +
+      '(never mind, not a denial), and the vital-sign concern from "Demam pun tak kebah". The ' +
+      'Malay stridor screening question is genuinely denied ("Takde, tidur okay je") and stays ' +
+      'silent. The patient name and the unhyphenated MyKad number are both tokenised.',
+    failsQaIf:
+      'Any of the four expected rule flags is missing (a Malay symptom phrase silently missed ' +
+      'the deterministic engine), or stridor-airway-compromise fires from the denied screening ' +
+      'question, or either seeded identifier reaches the LLM egress un-tokenised.',
+    identifierClasses: ['PATIENT', 'NRIC'],
+    expectedRedFlagIds: [
+      'chest-pain',
+      'haemoptysis',
+      'significant-dyspnoea',
+      'vital-signs-concern',
+    ],
+  },
 ]

--- a/backend/src/redflags/malay-triggers.test.ts
+++ b/backend/src/redflags/malay-triggers.test.ts
@@ -1,0 +1,253 @@
+import type { Transcript } from '@shared/types'
+import { describe, expect, it } from 'vitest'
+import { evaluateRedFlags } from './evaluate.js'
+import { ALL_REDFLAG_TRIGGERS } from './triggers.js'
+
+/**
+ * GitHub issue #153. The matchers were English-only, so a Malay consultation
+ * silently missed emergency-severity triggers, and the Malay negators shipped
+ * in the machinery could suppress an English hit but never produce one:
+ * "Tak apa, chest pain sikit je" muted the urgent chest-pain flag because
+ * "tak apa" (never mind) sat in the trailing-negator window.
+ *
+ * Two things are pinned here. A completeness ratchet: every trigger id must
+ * carry at least one Malay-only firing case, so a future trigger cannot ship
+ * English-only. And the negation case table: idioms, uncertainty, and the
+ * question particle must fail open, while genuine Malay denials still
+ * suppress. Zero tolerance for false negatives outranks precision throughout.
+ */
+
+const transcript = (turns: { speaker: 'doctor' | 'patient'; text: string }[]): Transcript => ({
+  source: 'fixture',
+  turns,
+})
+
+const ruleIds = (t: Transcript): string[] =>
+  evaluateRedFlags(t, ALL_REDFLAG_TRIGGERS)
+    .map((f) => f.ruleId)
+    .filter((id): id is string => id !== undefined)
+    .sort()
+
+const patient = (text: string): Transcript => transcript([{ speaker: 'patient', text }])
+
+/** One Malay-only firing case per trigger id, keyed by the id it must raise. */
+const MALAY_TRIGGER_FIXTURES: Record<string, string> = {
+  haemoptysis: 'Batuk berdarah sejak pagi tadi.',
+  'significant-dyspnoea': 'Sesak nafas bila naik tangga.',
+  'chest-pain': 'Sakit dada bila batuk kuat.',
+  'stridor-airway-compromise': 'Nafas berbunyi bila tidur malam.',
+  'swallowing-oral-intake': 'Tak boleh telan langsung sejak semalam.',
+  'vital-signs-concern': 'Demam tak turun-turun dah tiga hari.',
+  'uti-systemic-features': 'Demam dan menggigil sejak semalam.',
+  'uti-flank-or-back-pain': 'Sakit pinggang sebelah kanan.',
+  'uti-systemic-deterioration': 'Saya rasa nak pengsan tadi pagi.',
+  'uti-pregnancy-mentioned': 'Saya mengandung empat bulan.',
+  'uti-unable-to-pass-urine': 'Dah dua hari kencing tak keluar.',
+  'uti-potentially-complicating-context': 'Saya ada kencing manis.',
+}
+
+describe('every trigger has Malay coverage (issue #153)', () => {
+  it('the Malay case table covers exactly the trigger list, so a new trigger cannot ship English-only', () => {
+    expect(Object.keys(MALAY_TRIGGER_FIXTURES).sort()).toEqual(
+      ALL_REDFLAG_TRIGGERS.map((t) => t.id).sort(),
+    )
+  })
+
+  it.each(Object.entries(MALAY_TRIGGER_FIXTURES))('%s fires on a Malay-only turn', (id, text) => {
+    expect(ruleIds(patient(text))).toContain(id)
+  })
+
+  it.each([
+    ['haemoptysis', 'Batuk sampai berdarah semalam.'],
+    ['haemoptysis', 'Ludah berdarah pagi tadi.'],
+    ['chest-pain', 'Sakit dekat dada bila tarik nafas dalam.'],
+    ['chest-pain', 'Dada terasa sakit sikit.'],
+    ['significant-dyspnoea', 'Rasa sesak bila baring malam.'],
+    ['swallowing-oral-intake', 'Makan pun tak boleh dah dua hari.'],
+    ['vital-signs-concern', 'Nadi laju sangat tadi.'],
+    ['vital-signs-concern', 'Suhu badan tinggi sangat malam tadi.'],
+    ['uti-potentially-complicating-context', 'Pesakit laki-laki, umur empat puluh.'],
+  ])('%s also fires on the everyday variant "%s"', (id, text) => {
+    expect(ruleIds(patient(text))).toContain(id)
+  })
+})
+
+describe('Malay idioms, uncertainty, and question particles fail open', () => {
+  it('fires through the idiom "tak apa", the reported false negative', () => {
+    expect(ruleIds(patient('Tak apa, chest pain sikit je.'))).toContain('chest-pain')
+    expect(ruleIds(patient('Tak apa doktor, dada sakit sikit je.'))).toContain('chest-pain')
+  })
+
+  it('fires through the single-word idiom "takpe"', () => {
+    expect(ruleIds(patient('Takpe, sakit dada sikit je.'))).toContain('chest-pain')
+  })
+
+  it('fires through uncertainty, because unknown is never negative (docs/prd.md §10)', () => {
+    expect(ruleIds(patient('Tak tahu lah, kadang-kadang sakit dada.'))).toContain('chest-pain')
+    expect(ruleIds(patient('Tak pasti, tapi dada rasa ketat.'))).toContain('chest-pain')
+  })
+
+  it('fires through a minimizer that precedes the disclosure', () => {
+    expect(ruleIds(patient('Takde apa-apa, sakit dada sikit je.'))).toContain('chest-pain')
+  })
+
+  it('fires after "tapi" and "cuma", which end a denial\'s scope', () => {
+    expect(ruleIds(patient('Tak ada demam, tapi batuk berdarah.'))).toContain('haemoptysis')
+    expect(ruleIds(patient('Tiada demam, cuma sesak nafas sikit.'))).toContain(
+      'significant-dyspnoea',
+    )
+  })
+
+  it('does not read the question particle as a denial', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Ada tak sakit dada?' },
+          { speaker: 'patient', text: 'Ada, sejak pagi.' },
+        ]),
+      ),
+    ).toContain('chest-pain')
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Sakit dada ke tak?' },
+          { speaker: 'patient', text: 'Ya doktor.' },
+        ]),
+      ),
+    ).toContain('chest-pain')
+  })
+
+  it('does not read an idiomatic or uncertain Malay reply as a leading denial', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Any chest pain?' },
+          { speaker: 'patient', text: 'Tak apa doktor.' },
+        ]),
+      ),
+    ).toContain('chest-pain')
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Any chest pain?' },
+          { speaker: 'patient', text: 'Tak tahu doktor.' },
+        ]),
+      ),
+    ).toContain('chest-pain')
+  })
+
+  it('does not read the intensifier "bukan main" as a denial', () => {
+    expect(ruleIds(patient('Bukan main sakit dada saya semalam.'))).toContain('chest-pain')
+  })
+
+  it('does not read a hedge as a denial, because "not very" confirms presence', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Ada sesak nafas?' },
+          { speaker: 'patient', text: 'Tak berapa teruk, tapi ada la sikit.' },
+        ]),
+      ),
+    ).toContain('significant-dyspnoea')
+  })
+
+  it('does not read the minimizer "tak ada apa-apa" or "takde apa-apa" as a denial', () => {
+    expect(ruleIds(patient('Tak ada apa-apa, sakit dada sikit je.'))).toContain('chest-pain')
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Ada sesak nafas?' },
+          { speaker: 'patient', text: 'Takde apa-apa yang teruk, tapi ada sikit.' },
+        ]),
+      ),
+    ).toContain('significant-dyspnoea')
+  })
+
+  it('fires through a leading "Tak," when the span carries its own negator', () => {
+    // Malay screening questions are normally negatively framed ("Boleh telan
+    // tak?"), so a leading "Tak" is the standard affirmation of the finding.
+    // A double negation is never a denial.
+    expect(ruleIds(patient('Tak, kencing tak keluar dah dua hari.'))).toContain(
+      'uti-unable-to-pass-urine',
+    )
+    expect(ruleIds(patient('Tak, tak boleh telan.'))).toContain('swallowing-oral-intake')
+    expect(ruleIds(patient('Tak, saya tak boleh bernafas langsung.'))).toContain(
+      'significant-dyspnoea',
+    )
+    expect(ruleIds(patient('Tak, demam tak kebah lagi.'))).toContain('vital-signs-concern')
+  })
+
+  it('fires on the "tarik nafas" collocation, the commonest Malay dyspnoea phrasing', () => {
+    expect(ruleIds(patient('Susah nak tarik nafas, doktor.'))).toContain('significant-dyspnoea')
+    expect(ruleIds(patient('Tak boleh tarik nafas langsung.'))).toContain('significant-dyspnoea')
+  })
+
+  it('fires when a negatively framed question is affirmed with a leading "Tak"', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Kencing tak keluar ke?' },
+          { speaker: 'patient', text: 'Tak, memang tak keluar.' },
+        ]),
+      ),
+    ).toContain('uti-unable-to-pass-urine')
+  })
+
+  it('over-fires on a genuinely denied negative question, the other documented accepted asymmetry', () => {
+    // "Boleh je" denies the inability, but the span in the question carries
+    // its own negator, so both context checks are skipped. A spurious flag
+    // costs the doctor one dismissal; the suppressed alternative costs the
+    // thing this engine exists to prevent.
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Tak boleh telan ke?' },
+          { speaker: 'patient', text: 'Boleh je, takde masalah.' },
+        ]),
+      ),
+    ).toContain('swallowing-oral-intake')
+  })
+
+  it('exercises the "ke" half of the question-particle lookbehind', () => {
+    expect(ruleIds(patient('Betul ke tak sakit dada ni, doktor?'))).toContain('chest-pain')
+  })
+
+  it('over-fires on post-posed standalone negation, the documented accepted asymmetry', () => {
+    // Negation is only looked for before the match, so "Sakit dada pun takde."
+    // raises the flag. Failing open is the direction this engine must fail in;
+    // this test documents the trade rather than discovering it later.
+    expect(ruleIds(patient('Sakit dada pun takde.'))).toContain('chest-pain')
+  })
+})
+
+describe('genuine Malay denials still suppress', () => {
+  it('does not fire on a plain Malay denial', () => {
+    expect(ruleIds(patient('Tiada sakit dada.'))).not.toContain('chest-pain')
+    expect(ruleIds(patient('Tak ada sakit dada, batuk je.'))).not.toContain('chest-pain')
+    expect(ruleIds(patient('Takde sesak nafas.'))).not.toContain('significant-dyspnoea')
+    expect(ruleIds(patient('Tidak ada batuk berdarah.'))).not.toContain('haemoptysis')
+  })
+
+  it('does not fire when a Malay screening question is denied in Malay', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Ada sesak nafas?' },
+          { speaker: 'patient', text: 'Takde.' },
+        ]),
+      ),
+    ).not.toContain('significant-dyspnoea')
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Batuk ada darah tak?' },
+          { speaker: 'patient', text: 'Tak ada, doktor.' },
+        ]),
+      ),
+    ).not.toContain('haemoptysis')
+  })
+
+  it('does not fire on chained genuine denials', () => {
+    expect(ruleIds(patient('Tak ada demam, tak ada menggigil.'))).toEqual([])
+  })
+})

--- a/backend/src/redflags/triggers.ts
+++ b/backend/src/redflags/triggers.ts
@@ -14,8 +14,8 @@ import type { RedFlagTrigger } from './types.js'
  * changes. Recorded with every analysis (docs/trd.md §15).
  */
 export const RED_FLAG_LIST_VERSION: ClinicalArtefactVersion = {
-  id: 'redflag-list-v3',
-  effectiveDate: '2026-08-14',
+  id: 'redflag-list-v4',
+  effectiveDate: '2026-08-15',
 }
 
 const URTI_PROFILES: readonly ProfileId[] = ['adult-acute-urti']
@@ -26,13 +26,36 @@ const URTI_AND_UTI_PROFILES: readonly ProfileId[] = [
 const UTI_PROFILES: readonly ProfileId[] = ['adult-acute-uncomplicated-uti']
 
 /**
+ * Malay negators, minus constructions that mention rather than deny.
+ * "tak apa"/"takpe" is the idiom "never mind"; "tak tahu"/"tak pasti" is
+ * uncertainty, and unknown is never negative (docs/prd.md §10); "tak berapa"/
+ * "tak banyak" is a hedge ("not very"), which confirms presence; "tak ada
+ * apa-apa" is the minimizer that precedes a disclosure; a "tak" right after
+ * "ada" or "ke" is the question particle ("ada tak sakit dada?"), not a
+ * denial. "bukan" is deliberately absent: "bukan main sakit dada" is an
+ * intensifier, and a negator that can read it as a denial is a false negative.
+ * One accepted asymmetry: post-posed standalone negation ("Sakit dada pun
+ * takde.") over-fires, because negation is only looked for before the match,
+ * and failing open is the direction this engine must fail in.
+ * The fragment carries no flag of its own; both hosts below add `i`.
+ */
+const MALAY_NEGATOR =
+  /(?<!\b(?:ada|ke)\s)(?:tak(?!\s+(?:apa|pe|tahu|pasti|berapa|banyak|seberapa|ada\s+apa)\b)|tidak(?!\s+(?:apa|mengapa|tahu|pasti|berapa|banyak|seberapa|ada\s+apa)\b)|takde(?!\s+apa\b)|tiada(?!\s+apa\b))/
+
+/**
  * A reply that opens by denying the thing just asked about. Deliberately narrow
  * (GitHub issue #70): it matches only an unambiguous leading negation, in
  * English and the Malay a Malaysian consultation actually uses, and anything it
- * is unsure of is not a denial.
+ * is unsure of is not a denial. The Malay side comes solely from
+ * MALAY_NEGATOR, so its idiom, uncertainty, hedge, and minimizer exclusions
+ * apply here too: "Tak apa doktor.", "Tak tahu doktor.", "Tak berapa teruk,
+ * tapi ada sikit.", and "Takde apa-apa yang teruk, tapi ada sikit." all fail
+ * open, while "Takde.", "Tak ada.", and "Tiada." stay genuine denials.
  */
-const LEADING_DENIAL =
-  /^\s*(?:no+|nope|none|nothing|negative|tak|tidak|takde|tak\s+ada|takda|belum)\b/i
+const LEADING_DENIAL = new RegExp(
+  `^\\s*(?:no+|nope|none|nothing|negative|${MALAY_NEGATOR.source}|takda|belum)\\b`,
+  'i',
+)
 
 /**
  * Whether a doctor turn asks rather than states. A screening question names the
@@ -64,12 +87,17 @@ const asserts = (transcript: Transcript, index: number): boolean => {
   return !LEADING_DENIAL.test(reply.text)
 }
 
-/** Words that end the scope of a preceding negation: "no fever but chest pain". */
-const NEGATION_SCOPE_END = /\b(?:but|tapi|however|although|except)\b/i
+/**
+ * Words that end the scope of a preceding negation: "no fever but chest pain",
+ * "tiada demam, cuma sesak nafas".
+ */
+const NEGATION_SCOPE_END = /\b(?:but|tapi|however|although|except|cuma|cuman)\b/i
 
 /** An unambiguous negator sitting immediately before the matched span. */
-const TRAILING_NEGATOR =
-  /\b(?:no|not|none|never|denies|denied|without|tak|tidak|takde|tiada)\b[^.!?;]{0,24}$/i
+const TRAILING_NEGATOR = new RegExp(
+  `\\b(?:no|not|none|never|denies|denied|without|${MALAY_NEGATOR.source})\\b[^.!?;]{0,24}$`,
+  'i',
+)
 
 /**
  * Is this match negated by the words immediately before it? Scoped tightly on
@@ -86,13 +114,32 @@ const isNegated = (text: string, matchIndex: number): boolean => {
   return TRAILING_NEGATOR.test(inScope)
 }
 
+/**
+ * A span that carries its own negator asserts the inability it names:
+ * "cannot swallow", "tak boleh telan", "kencing tak keluar". Around such a
+ * span, negation words flip meaning rather than deny it. A negator before it
+ * ("Tak, kencing tak keluar dah dua hari") is Malay's affirmative reply to a
+ * negatively framed screening question, and a "Tak." reply to a question that
+ * names the span ("Kencing tak keluar ke?") affirms the finding rather than
+ * denying it, because Malay screening questions are normally negatively
+ * framed. A double negation is never a denial in either language, so these
+ * spans skip both the reply-denial check and the trailing-negator check. The
+ * bypass is deliberately broader than Malay inability: English
+ * negator-carrying spans ("not coming down", "not able to eat") and
+ * absence-of-event spans ("period tak datang") take the same route, because
+ * the polarity argument holds for all of them. The cost is accepted and
+ * pinned by test: a genuinely denied negative question over-fires.
+ * Over-firing is the direction this engine fails in.
+ */
+const SPAN_CARRIES_NEGATOR = /\b(?:no|not|cannot|tak|tidak|takde|tiada)\b|can'?t|won'?t/i
+
 const findSpan = (transcript: Transcript, patterns: readonly RegExp[]): string | null => {
   for (const [index, turn] of transcript.turns.entries()) {
-    if (!asserts(transcript, index)) continue
-
     for (const pattern of patterns) {
       const match = pattern.exec(turn.text)
-      if (match && !isNegated(turn.text, match.index)) return match[0]
+      if (match === null) continue
+      if (SPAN_CARRIES_NEGATOR.test(match[0])) return match[0]
+      if (asserts(transcript, index) && !isNegated(turn.text, match.index)) return match[0]
     }
   }
   return null
@@ -120,6 +167,11 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /blood[- ]tinge?d?\s+(?:sputum|phlegm|mucus)/i,
         /blood\s+in\s+(?:the\s+|my\s+|his\s+|her\s+)?(?:sputum|phlegm|mucus|cough)/i,
         /\bha?emoptysis\b/i,
+        /batuk(?:-batuk)?\s+(?:sampai\s+)?(?:ber)?darah/i,
+        /batuk(?:-batuk)?\s+(?:sampai\s+)?(?:keluar|ada)\s+darah/i,
+        /kahak\s+(?:ada\s+)?(?:ber)?darah/i,
+        /darah\s+dalam\s+kahak/i,
+        /ludah\s+(?:ber)?darah/i,
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -138,6 +190,22 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /\bbreathless(?:ness)?\b/i,
         /struggling\s+to\s+breathe/i,
         /gasping\s+for\s+(?:air|breath)/i,
+        // na[fp]as covers both the Malaysian (nafas) and Indonesian (napas)
+        // spellings, which both occur in Malaysian speech-to-text output.
+        // Bare "sesak" is deliberately excluded ("hidung sesak" is an ordinary
+        // blocked nose in URTI); "rasa sesak" and an intensified "sesak" are
+        // unambiguous and included.
+        /sesak\s+na[fp]as/i,
+        /rasa\s+sesak\b/i,
+        /sesak\s+(?:sangat|teruk)\b/i,
+        /\bsemput\b/i,
+        /(?:susah|payah|sukar)\s+(?:nak\s+|untuk\s+)?(?:tarik\s+)?(?:ber)?na[fp]as/i,
+        // The negator is part of the phrase, as in /can'?t\s+breathe/ above,
+        // so isNegated cannot read it as a denial of itself.
+        /(?:tak|tidak)\s+(?:boleh|dapat|larat)\s+(?:nak\s+)?(?:tarik\s+)?(?:ber)?na[fp]as/i,
+        /na[fp]as\s+pendek/i,
+        /\btercungap/i,
+        /\btermengah/i,
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -152,6 +220,11 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /chest\s+pain/i,
         /pain\s+in\s+(?:my|the|his|her)\s+chest/i,
         /tight(?:ness)?\s+in\s+(?:my|the|his|her)\s+chest/i,
+        /sakit\s+(?:kat\s+|di\s+|dekat\s+)?dada/i,
+        /dada\s+(?:saya\s+|pun\s+)?(?:(?:te)?rasa\s+)?sakit/i,
+        /dada\s+(?:(?:te)?rasa\s+)?(?:ketat|berat|sesak)/i,
+        /sesak\s+dada/i,
+        /nyeri\s+dada/i,
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -163,12 +236,18 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
     severity: 'emergency',
     matcher: (transcript) =>
       findSpan(transcript, [
+        // stridor and trismus stay English: they are clinical terms a
+        // Malaysian doctor states in English.
         /\bstridor\b/i,
         /noisy\s+breathing/i,
         /\bdrooling\b/i,
         /\btrismus\b/i,
         /muffled\s+voice/i,
         /voice\s+sounds?\s+muffled/i,
+        /na[fp]as\s+berbunyi/i,
+        /berbunyi\s+(?:bila|masa|waktu|ketika)\s+(?:tarik\s+)?na[fp]as/i,
+        /air\s+liur\s+(?:asyik\s+)?meleleh/i,
+        /meleleh\s+air\s+liur/i,
       ]),
     clinicalSource: DELPHI_AIRWAY_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -186,6 +265,12 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /not\s+(?:been\s+)?able\s+to\s+(?:eat|drink)/i,
         /refusing\s+to\s+(?:eat|drink)/i,
         /no\s+oral\s+intake/i,
+        // "susah nak telan" is deliberately excluded: difficulty swallowing is
+        // expected URTI odynophagia, and adding it would widen this trigger
+        // from inability to difficulty, a clinical-scope change.
+        /(?:tak|tidak)\s+(?:boleh|dapat|lalu)\s+(?:nak\s+)?telan/i,
+        /(?:tak|tidak)\s+(?:boleh|dapat|lalu)\s+(?:nak\s+)?(?:makan|minum)/i,
+        /(?:telan|makan|minum)\s+(?:pun\s+)?tak\s+(?:boleh|lalu)/i,
       ]),
     clinicalSource: DELPHI_AIRWAY_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -209,6 +294,16 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /(?:temperature|fever)\D{0,20}(?:very\s+high|extremely\s+high|not\s+coming\s+down|won'?t\s+come\s+down)/i,
         /(?:heart\s+rate|pulse)\D{0,20}(?:very\s+fast|racing|dangerously\s+(?:high|fast))/i,
         /blood\s+pressure\D{0,20}(?:very\s+low|dropping|dangerously\s+low)/i,
+        // Bare "berdebar" (palpitation) and bare "darah rendah" (a chronic
+        // descriptor) are excluded: neither states the critical severity this
+        // trigger exists to match.
+        /demam\D{0,20}(?:tak|tidak)\s+(?:turun(?:-turun)?|kebah)/i,
+        /demam\s+(?:sangat|terlalu)\s+(?:tinggi|teruk)/i,
+        /demam\s+(?:tinggi|teruk)\s+sangat/i,
+        /suhu(?:\s+badan)?\D{0,20}(?:sangat\s+tinggi|tinggi\s+sangat|terlalu\s+tinggi)/i,
+        /oksigen\D{0,20}rendah/i,
+        /(?:jantung|nadi)\D{0,20}(?:sangat\s+laju|laju\s+sangat)/i,
+        /tekanan\s+darah\D{0,20}(?:sangat\s+rendah|rendah\s+sangat|jatuh)/i,
       ]),
     clinicalSource:
       'No Malaysian-sourced numeric vital-sign threshold found in the docs/trd.md §11 corpus ' +
@@ -233,10 +328,14 @@ export const UTI_REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
     severity: 'urgent',
     matcher: (transcript) =>
       findSpan(transcript, [
+        // Bare /\bdemam\b/ mirrors the deliberate breadth of bare /\bfever\b/.
         /\bfever(?:ish)?\b/i,
         /\bchills?\b/i,
         /\brigors?\b/i,
         /\bshiver(?:ing)?\b/i,
+        /\bdemam\b/i,
+        /\bmenggigil\b/i,
+        /seram\s+sejuk/i,
       ]),
     clinicalSource: UTI_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -252,6 +351,10 @@ export const UTI_REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /\bloin\b/i,
         /\bkidney\s+pain\b/i,
         /(?:pain|ache)\s+(?:in\s+)?(?:my\s+)?(?:lower\s+)?back\b/i,
+        /sakit\s+(?:kat\s+|di\s+|dekat\s+)?pinggang/i,
+        /pinggang\s+(?:(?:te)?rasa\s+)?sakit/i,
+        /sakit\s+(?:kat\s+|di\s+|dekat\s+)?belakang/i,
+        /belakang\s+(?:(?:te)?rasa\s+)?sakit/i,
       ]),
     clinicalSource: UTI_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -268,6 +371,14 @@ export const UTI_REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /\bvery\s+drowsy\b/i,
         /\bextremely\s+weak\b/i,
         /\bfeeling\s+very\s+unwell\b/i,
+        // Bare "tak larat" is excluded as too broad (everyday tiredness); the
+        // \b on "keliru" keeps "mengelirukan" (confusing) out.
+        /\bpengsan\b/i,
+        /\bpitam\b/i,
+        /\bkeliru\b/i,
+        /lemah\s+(?:sangat|teruk)/i,
+        /sangat\s+lemah/i,
+        /tak\s+larat\s+(?:nak\s+)?bangun/i,
       ]),
     clinicalSource: UTI_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -282,6 +393,11 @@ export const UTI_REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /\bpregnan(?:t|cy)\b/i,
         /\bmissed\s+(?:my\s+)?period\b/i,
         /\btrying\s+for\s+(?:a\s+)?baby\b/i,
+        // The \b on "mengandung" keeps "mengandungi" (contains) out.
+        /\bmengandung\b/i,
+        /\bhamil\b/i,
+        /(?:period|haid)\s+(?:tak\s+datang|lambat|lewat)/i,
+        /(?:tak\s+datang|lambat|lewat)\s+(?:period|haid)/i,
       ]),
     clinicalSource: UTI_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -296,6 +412,11 @@ export const UTI_REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /(?:can'?t|cannot|unable\s+to)\s+(?:pass|pee|urinate)/i,
         /\bnot\s+passing\s+(?:any\s+)?urine\b/i,
         /\bno\s+urine\s+(?:is\s+)?coming\s+out\b/i,
+        // "susah nak kencing" is deliberately excluded: dysuria is an expected
+        // uncomplicated-UTI symptom, not retention.
+        /(?:tak|tidak)\s+(?:boleh|dapat)\s+(?:nak\s+)?(?:kencing|buang\s+air\s+kecil)/i,
+        /(?:air\s+)?kencing\s+tak\s+keluar/i,
+        /kencing\s+(?:pun\s+)?tak\s+(?:boleh|lepas)/i,
       ]),
     clinicalSource: UTI_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -313,6 +434,15 @@ export const UTI_REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /\bimmunosuppress(?:ed|ion)\b/i,
         /\bdiabetes?\b/i,
         /\bmale\b/i,
+        // "sakit buah pinggang" is ambiguous between kidney disease and kidney
+        // pain; firing this trigger either way is the safe direction. Bare
+        // "buah pinggang" is excluded, and /\blelaki\b/ mirrors the deliberate
+        // breadth of /\bmale\b/ exactly.
+        /kencing\s+manis/i,
+        /\bkateter\b/i,
+        /(?:masalah|penyakit|sakit)\s+buah\s+pinggang/i,
+        /buah\s+pinggang\s+(?:rosak|gagal|bermasalah)/i,
+        /\b(?:lelaki|laki-laki)\b/i,
       ]),
     clinicalSource: UTI_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,

--- a/backend/src/suggestions/prompt.ts
+++ b/backend/src/suggestions/prompt.ts
@@ -20,7 +20,10 @@ export function buildSuggestionsSystemPrompt(profile: ClinicalProfile): string {
   return `You are assisting a Malaysian GP who is reviewing a de-identified consultation
 transcript for ${profile.scope}. Text such as "[PATIENT_1]" or "[NRIC_1]" is a
 de-identification token, not the patient's real identifier — never attempt to
-guess, reconstruct, or comment on the identity behind a token.
+guess, reconstruct, or comment on the identity behind a token. The transcript
+may be in English, Bahasa Malaysia, or code-switched Malaysian speech. Write
+suggestions and red-flag candidates in English, and quote any transcript
+evidence verbatim in its original language, never translated.
 
 Task 1 — guideline-cited suggestions:
 Using ONLY the guideline corpus listed below, propose clinical suggestions that


### PR DESCRIPTION
## What Changed

Every deterministic red-flag trigger now fires on the Malay phrasing a Malaysian consultation actually uses (versioned as `redflag-list-v4`), and Malay idioms can no longer mute a hit: "Tak apa, chest pain sikit je." now raises the urgent chest-pain flag instead of being read as a denial. The analysis and suggestions prompts state the transcript may be Malay or code-switched, that output stays English, and that evidence spans are quoted verbatim, never translated. A Malay-register fixture with a graded rubric pins the behaviour end to end.

Closes #153

## Why

The matchers were English-only, so Malay symptom phrases (batuk berdarah, sesak nafas, sakit dada, demam tak kebah) silently missed emergency-severity triggers, while the Malay negators already shipped in the machinery could suppress an English hit but never produce one. Malay transcripts already enter the system today (fixtures, paste) and the gated hosted ASR path (#151/#154) will send more. The prompt lines exist because `analysis/evidence.ts` does exact substring matching: a translated Malay span silently downgrades the assertion to NOT_ASSESSED and inflates false gaps.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (599 tests across all four workspaces; 457 backend including 42 new cases)
- [x] clinical-safety-reviewer on the diff: 2 blockers and 5 majors found, all fixed and re-verified (below)

New `backend/src/redflags/malay-triggers.test.ts`: a completeness ratchet asserting the per-id Malay case map keys equal `ALL_REDFLAG_TRIGGERS` ids (a future trigger cannot ship English-only), one Malay-only firing case per trigger id, and the full negation table: idiom, uncertainty, minimizer, question-particle, scope-ender (tapi/cuma), and intensifier cases all fail open; plain, chained, and screening-reply Malay denials still suppress; the post-posed-negation over-fire is pinned as the documented accepted asymmetry. The new fixture `urti-malay-red-flag` auto-grades through the existing rubric test to exactly its four expected ids with the denied Malay screening question as a must-stay-silent canary. Acceptance zero-leak sweep now also covers "Faizal bin Osman" and the unhyphenated MyKad `900412086543` (both synthetic).

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider: egress still goes through `deid/` then `LLMClient`
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model (`mergeRedFlags` untouched; the engine stays a pure function library, evaluated on the raw transcript before any LLM call)
- [x] Citations remain ID-constrained; no free-text references accepted (untouched)
- [x] No transcript bodies, note contents, or vault entries written to logs (no logging changes)
- [x] Fixtures added are synthetic

## Notes For The Reviewer

- **Matcher alternates are translation-level, same id, same severity.** Deliberate exclusions are commented at the site: "susah nak telan" (difficulty vs inability is a clinical-scope change), "susah nak kencing" (dysuria vs retention), bare "berdebar", "darah rendah", "tak larat", "buah pinggang". Breadth-parity choices mirror existing English breadth exactly: bare `demam` next to bare `fever`, `lelaki` next to `male`.
- **The negation fix is asymmetric on purpose.** Idioms ("tak apa"/"takpe"), uncertainty ("tak tahu"/"tak pasti", PRD section 10: unknown is never negative), hedges ("tak berapa"/"tak banyak", which confirm presence), minimizers ("tak ada apa-apa"/"takde apa-apa"), and the question particle ("ada tak", "ke tak") fail open; genuine denials (tiada, tak ada, takde, tidak ada) still suppress; "bukan" is not a negator ("bukan main sakit dada" is an intensifier). English alternations are byte-identical, so no existing English behaviour moves.
- **Review round, fixed and re-verified.** The clinical-safety-reviewer probe-verified two blockers: the missing "tarik nafas" collocation on the emergency dyspnoea trigger, and a leading "Tak," suppressing spans that carry their own negator, which in Malay is the standard affirmative reply to a negatively framed screening question ("Tak, kencing tak keluar dah dua hari" raised nothing). The fix: negator-carrying spans ("tak boleh telan", "cannot swallow", "kencing tak keluar") now bypass both the reply-denial and trailing-negator checks, since a double negation is never a denial in either language. Five majors also fixed: redundant leading-denial alternatives that defeated the minimizer guard, hedge exclusions, everyday-variant coverage gaps (sampai berdarah, ludah berdarah, dekat dada, terasa sakit, nadi, suhu badan, makan pun tak boleh, laki-laki), the undocumented bare-"sesak" exclusion (now documented, with "rasa sesak" included), and a preamble-versus-evidence-span language conflict in the analysis prompt.
- **Two accepted over-fire asymmetries, both documented in place and pinned by tests:** post-posed standalone negation ("Sakit dada pun takde.") fires, and a genuinely denied negative question whose span carries a negator ("Tak boleh telan ke?" / "Boleh je.") fires. A spurious flag costs the doctor one dismissal; the suppressed alternative costs the thing the engine exists to prevent. The fixture's denied-screening canary was accordingly reframed onto a negator-free span (the stridor question).
- The English cousin of the scope-ender gap ("No fever, just chest pain") remains tracked in #150 and is deliberately not folded in here.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Malay-language detection for key red-flag symptoms, including breathing difficulty, chest pain, bleeding, fever, swallowing issues, and urinary symptoms.
  * Improved handling of Malay negations, uncertainty, idioms, and question phrasing to reduce false alerts.
  * Added support for mixed English, Bahasa Malaysia, and code-switched transcripts.

* **Improvements**
  * Suggestions and alerts are now provided in English while preserving quoted clinical evidence exactly as written.
  * Added coverage for Malay-language consultations and identifier recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->