### PR TITLE
fix(ui): opaque tints for chrome, and dropover panels aligned to the cluster

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -130,6 +130,13 @@ The reasoning is not aesthetic. A translucent surface has a contrast ratio that 
 
 **A selected row is still content.** Selection is expressed as a tint layered _over_ the opaque surface, never by replacing it. Setting an `--color-accent` alpha as the row's `background-color` removes the surface instead of tinting it, and the row goes translucent over the page's dot grid. That shipped once and read as muddy rather than selected.
 
+**Tints are opaque tokens, not alpha utilities** (settled 15/08/26). Every selected, active and open state uses `--color-accent-soft`, with `--color-accent-soft-hover` for its hover step and `--color-sunken-soft` for hovering an unselected control. None of them carry an alpha channel.
+
+- **Why.** `bg-accent/8`, `/12` and `/16` are translucent fills rather than colours. On a card that reads correctly, because the card beneath is opaque. On the sidebar, the dock, the chrome cluster, the approve bar and the step bar it does not: those are glass, so the tint composited against whatever happened to be scrolling behind and read as a wash. That is the same objection this section already makes to translucent content, arriving one layer down.
+- **Why not teal glass.** `backdrop-filter` establishes a backdrop root and a descendant may only sample inside it, so glass nested in glass is flat by construction. Every host listed above is itself glass, which leaves opaque as the only option that is actually a colour.
+- **Measured.** 12% of accent over the surface is `#E3EDEA` light and `#1E2E28` dark, within 8/255 of what the translucent version happened to render over glass. Accent text on it measures 5.45:1 light and 6.05:1 dark.
+- **One value replaced three.** The `/16` step existed only to survive the glass beneath it. Opaque removes that reason.
+
 | Layer                            | Treatment                                                                                                |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | Content                          | Opaque `--color-surface`, radius 16px, shadow rather than a border at rest                               |
@@ -209,10 +216,12 @@ motion; animating the blur is. The earlier rule removed the blur entirely, which
 suppressed an effect the preference was never asking about. The sidebar still
 expands, still dims, still frosts, still works.
 
-**The active nav item is tinted at `bg-accent/16`** where every other active state
-in the app is `/12`. It is the only one painted on glass with the scrim behind it,
-and at the current glass alpha the `/12` tint measured 4.05:1 with the island
-expanded, which is under AA.
+**The active nav item is tinted with `--color-accent-soft`**, the same token as
+every other active state. It used to be the exception at `bg-accent/16` where the
+rest of the app was `/12`, because it was painted on glass with the scrim behind
+it and at that glass alpha the `/12` tint measured 4.05:1 with the island
+expanded, under AA. An opaque token composites against nothing, so the exception
+and the measurement it rested on both retire (settled 15/08/26).
 
 ## Layout
 

--- a/frontend/src/audio/SpeakerAssign.tsx
+++ b/frontend/src/audio/SpeakerAssign.tsx
@@ -63,7 +63,7 @@ export function SpeakerAssign({
               className={cn(
                 'inline-flex h-8 w-18 shrink-0 items-center justify-center rounded-control border text-xs font-semibold transition-colors',
                 line.speaker === 'doctor'
-                  ? 'border-accent/40 bg-accent/8 text-accent hover:bg-accent/16'
+                  ? 'border-accent/40 bg-accent-soft text-accent hover:bg-accent-soft-hover'
                   : 'border-line bg-sunken text-ink-muted hover:bg-line/60',
               )}
             >

--- a/frontend/src/demo/DemoStepBar.tsx
+++ b/frontend/src/demo/DemoStepBar.tsx
@@ -72,7 +72,7 @@ export function DemoStepBar() {
                   aria-current={isCurrent ? 'step' : undefined}
                   className={cn(
                     'flex items-center gap-1.5 rounded-control px-2 py-1 text-xs whitespace-nowrap transition-colors duration-150',
-                    isCurrent && 'bg-accent/16 font-medium text-accent',
+                    isCurrent && 'bg-accent-soft font-medium text-accent',
                     isDone && 'text-ink-muted',
                     !isCurrent && !isDone && 'text-ink-muted/60',
                   )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,6 +41,46 @@
   --color-accent: oklch(0.47 0.089 168);
   --color-accent-hover: oklch(0.405 0.082 168);
   --color-accent-ink: oklch(1 0 0);
+  /*
+   * The one accent tint, and it is opaque on purpose.
+   *
+   * Every selected, active and open state used to be `bg-accent/8`, `/12` or
+   * `/16`, which is a translucent fill rather than a colour. On a card that
+   * happens to look right, because the card underneath is opaque. On the
+   * sidebar, the dock, the chrome cluster, the approve bar and the step bar it
+   * does not: those are `.glass`, so the tint composited against whatever was
+   * scrolling behind them and read as a wash rather than a selection. The rule
+   * this breaks is already written down, in the sentence explaining why chrome
+   * is glass and content is not: a translucent surface has a contrast ratio
+   * that depends on what is behind it, so it cannot be verified once.
+   *
+   * A teal *glass* treatment is not the alternative. `backdrop-filter`
+   * establishes a backdrop root and a descendant may only sample inside it, so
+   * glass nested in glass is flat by construction. Every one of those hosts is
+   * itself glass, which leaves opaque as the only option that is actually a
+   * colour.
+   *
+   * Mixed rather than hardcoded so it tracks both themes from one line: the
+   * dark block redefines `--color-accent` and `--color-surface`, and custom
+   * properties resolve at use, so this follows without a second declaration.
+   * Measured at 12% over the surface: `#E3EDEA` light, `#1E2E28` dark, which is
+   * within 8/255 of what the old translucent version happened to render over
+   * glass, so this is the same colour made deterministic rather than a new one.
+   *
+   * One value replaces three. The `/16` step existed only because the sidebar
+   * sat on glass and needed the extra weight to survive it; opaque removes that
+   * reason, and three tints nobody can tell apart were never a system.
+   */
+  --color-accent-soft: color-mix(in oklab, var(--color-accent) 12%, var(--color-surface));
+  /* Paired with the above the way `--color-accent-hover` is paired with
+   * `--color-accent`, so a hover step on a tinted control stays a state rather
+   * than becoming a fourth tint. */
+  --color-accent-soft-hover: color-mix(in oklab, var(--color-accent) 18%, var(--color-surface));
+  /* The neutral counterpart, for hovering an *unselected* control in the
+   * chrome. `bg-sunken/60` had the same defect as the accent tints and in the
+   * same three places, all of them glass: the sidebar, the dock's cluster and
+   * the dropover triggers. */
+  --color-sunken-soft: color-mix(in oklab, var(--color-sunken) 60%, var(--color-surface));
 
   /* The two stops of the coachmark ring's gradient. Same hue as the accent so
    * the tour reads as part of the product, separated on lightness and chroma

--- a/frontend/src/review/ApproveBar.tsx
+++ b/frontend/src/review/ApproveBar.tsx
@@ -73,7 +73,7 @@ export function ApproveBar({
 
   if (approved) {
     return (
-      <div className="mt-6 flex items-center gap-2 rounded-card border border-accent/30 bg-accent/8 px-4 py-3">
+      <div className="mt-6 flex items-center gap-2 rounded-card border border-accent/30 bg-accent-soft px-4 py-3">
         <CheckCircle2 aria-hidden className="size-5 shrink-0 text-accent" />
         {/* The attribution is the point of the approval, not decoration on it,
             so it prints. Issue #26: an exported clinical document that cannot

--- a/frontend/src/review/NoteEditor.tsx
+++ b/frontend/src/review/NoteEditor.tsx
@@ -58,7 +58,7 @@ export function NoteEditor({
                   data-provenance={edited ? 'edited' : 'ai'}
                   className={cn(
                     'rounded-full px-2 py-0.5 text-2xs font-medium',
-                    edited ? 'bg-accent/12 text-accent' : 'bg-sunken text-ink-muted',
+                    edited ? 'bg-accent-soft text-accent' : 'bg-sunken text-ink-muted',
                   )}
                 >
                   {edited ? 'You Edited This' : 'AI Generated'}

--- a/frontend/src/routes/ConsultationNew.tsx
+++ b/frontend/src/routes/ConsultationNew.tsx
@@ -114,7 +114,7 @@ export function ConsultationNew() {
             onClick={() => setTab(id)}
             className={cn(
               'inline-flex min-h-10 items-center gap-2 rounded-control px-3 text-sm font-medium transition-colors',
-              tab === id ? 'bg-accent/12 text-accent' : 'text-ink-muted hover:bg-sunken',
+              tab === id ? 'bg-accent-soft text-accent' : 'text-ink-muted hover:bg-sunken',
             )}
           >
             <Icon aria-hidden className="size-4" />

--- a/frontend/src/shell/ChromeCluster.tsx
+++ b/frontend/src/shell/ChromeCluster.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Bell, LogOut, Moon, Settings as SettingsIcon, Sun, UserRound } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { api } from '../lib/api.js'
 import { useTheme } from '../lib/theme.js'
@@ -29,6 +29,9 @@ import { NotificationPanel } from './NotificationPanel.js'
 export function ChromeCluster() {
   const { resolved, setPreference } = useTheme()
   const [seenAt, setSeenAt] = useState<number | null>(null)
+  // Both panels hang off the cluster rather than off the button that opened
+  // them, so they share one right edge and one gap below the bar.
+  const cluster = useRef<HTMLDivElement>(null)
 
   const notifications = useQuery({
     queryKey: ['notifications'],
@@ -46,6 +49,7 @@ export function ChromeCluster() {
 
   return (
     <div
+      ref={cluster}
       data-print="hide"
       style={{ zIndex: 'var(--z-sidebar)', top: 'calc(0.75rem + var(--live-banner-inset, 0px))' }}
       className="glass fixed right-4 flex items-center gap-1 rounded-float p-1.5 md:right-6"
@@ -55,7 +59,7 @@ export function ChromeCluster() {
         onClick={() => setPreference(resolved === 'dark' ? 'light' : 'dark')}
         aria-label={resolved === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
         title={resolved === 'dark' ? 'Light Theme' : 'Dark Theme'}
-        className="flex size-9 items-center justify-center rounded-control text-ink-muted transition-colors duration-150 hover:bg-sunken/60 hover:text-ink"
+        className="flex size-9 items-center justify-center rounded-control text-ink-muted transition-colors duration-150 hover:bg-sunken-soft hover:text-ink"
       >
         {resolved === 'dark' ? (
           <Sun aria-hidden className="size-4.5" />
@@ -68,11 +72,16 @@ export function ChromeCluster() {
         label={unread > 0 ? `Notifications, ${unread} new` : 'Notifications'}
         icon={<Bell aria-hidden className="size-4.5" />}
         badge={unread}
+        anchor={cluster}
       >
         {(close) => <NotificationPanel onSeen={markSeen} close={close} />}
       </Dropover>
 
-      <Dropover label="Account" icon={<UserRound aria-hidden className="size-4.5" />}>
+      <Dropover
+        label="Account"
+        icon={<UserRound aria-hidden className="size-4.5" />}
+        anchor={cluster}
+      >
         {(close) => <AccountPanel close={close} />}
       </Dropover>
     </div>

--- a/frontend/src/shell/Dropover.tsx
+++ b/frontend/src/shell/Dropover.tsx
@@ -1,5 +1,6 @@
 import {
   type ReactNode,
+  type RefObject,
   useCallback,
   useEffect,
   useId,
@@ -29,6 +30,7 @@ export function Dropover({
   icon,
   badge,
   align = 'right',
+  anchor,
   children,
 }: {
   label: string
@@ -36,6 +38,11 @@ export function Dropover({
   /** Rendered as a count on the trigger. Omitted entirely when zero. */
   badge?: number
   align?: 'left' | 'right'
+  /**
+   * The surface to align and offset against, when the trigger sits inside one.
+   * Defaults to the trigger itself, which is right for a button standing alone.
+   */
+  anchor?: RefObject<HTMLElement | null>
   children: (close: () => void) => ReactNode
 }) {
   const [open, setOpen] = useState(false)
@@ -56,17 +63,29 @@ export function Dropover({
   const [position, setPosition] = useState<{ top: number; left?: number; right?: number }>()
 
   const place = useCallback(() => {
-    const rect = trigger.current?.getBoundingClientRect()
+    /*
+     * Measured from the surface the trigger sits in, not from the trigger.
+     *
+     * The button is one of three inside a padded floating cluster, so its own
+     * box is the wrong thing to hang a panel off. Measured on the deployed
+     * build at 1280px: the panel's right edge landed 47px inside the cluster's,
+     * because the bell is the middle button, and its top landed 1px below the
+     * cluster's bottom, because the 8px offset was taken from a trigger sitting
+     * 7px above that edge. Two panels opening at two different x positions read
+     * as drift, and 1px reads as the panel welded to the bar.
+     *
+     * Against the cluster both fall out for free: edges line up whichever
+     * button was pressed, and the gap is a real gap.
+     */
+    const rect = (anchor?.current ?? trigger.current)?.getBoundingClientRect()
     if (!rect) return
     setPosition({
-      // 8px below the trigger, which is what `top-11` against a `size-9`
-      // button used to produce.
       top: rect.bottom + 8,
       ...(align === 'right'
         ? { right: Math.max(16, window.innerWidth - rect.right) }
         : { left: Math.max(16, rect.left) }),
     })
-  }, [align])
+  }, [align, anchor])
 
   // Layout effect so the panel never paints at a stale position for a frame.
   useLayoutEffect(() => {
@@ -123,7 +142,9 @@ export function Dropover({
         onClick={() => setOpen((value) => !value)}
         className={cn(
           'relative flex size-9 items-center justify-center rounded-control transition-colors duration-150',
-          open ? 'bg-accent/12 text-accent' : 'text-ink-muted hover:bg-sunken/60 hover:text-ink',
+          open
+            ? 'bg-accent-soft text-accent'
+            : 'text-ink-muted hover:bg-sunken-soft hover:text-ink',
         )}
       >
         {icon}

--- a/frontend/src/shell/MobileDock.tsx
+++ b/frontend/src/shell/MobileDock.tsx
@@ -35,7 +35,7 @@ export function MobileDock() {
             cn(
               'flex min-h-12 flex-1 flex-col items-center justify-center gap-0.5 rounded-control px-2 py-1.5',
               'text-2xs font-medium transition-colors duration-150',
-              isActive ? 'bg-accent/12 text-accent' : 'text-ink-muted',
+              isActive ? 'bg-accent-soft text-accent' : 'text-ink-muted',
             )
           }
         >

--- a/frontend/src/shell/SidebarIsland.tsx
+++ b/frontend/src/shell/SidebarIsland.tsx
@@ -93,7 +93,7 @@ export function SidebarIsland({
       <Link
         to="/"
         aria-label="CatatMD home"
-        className="flex items-center gap-2 rounded-control px-2 py-3 transition-colors duration-150 hover:bg-sunken/60"
+        className="flex items-center gap-2 rounded-control px-2 py-3 transition-colors duration-150 hover:bg-sunken-soft"
       >
         <Mark className="size-6 text-accent" />
         <Wordmark
@@ -121,8 +121,8 @@ export function SidebarIsland({
                   'flex h-11 items-center gap-3 rounded-control px-3',
                   'text-sm font-medium transition-colors duration-150',
                   isActive
-                    ? 'bg-accent/16 text-accent'
-                    : 'text-ink-muted hover:bg-sunken/60 hover:text-ink',
+                    ? 'bg-accent-soft text-accent'
+                    : 'text-ink-muted hover:bg-sunken-soft hover:text-ink',
                 )
               }
             >
@@ -147,8 +147,8 @@ export function SidebarIsland({
             cn(
               'flex h-11 items-center gap-3 rounded-control px-3 text-sm font-medium transition-colors duration-150',
               isActive
-                ? 'bg-accent/16 text-accent'
-                : 'text-ink-muted hover:bg-sunken/60 hover:text-ink',
+                ? 'bg-accent-soft text-accent'
+                : 'text-ink-muted hover:bg-sunken-soft hover:text-ink',
             )
           }
         >
@@ -170,7 +170,7 @@ export function SidebarIsland({
           onClick={() => setPinned((value) => !value)}
           aria-pressed={pinned}
           aria-label={pinned ? 'Unpin sidebar' : 'Pin sidebar open'}
-          className="flex h-11 items-center gap-3 rounded-control px-3 text-sm font-medium text-ink-muted transition-colors duration-150 hover:bg-sunken/60 hover:text-ink"
+          className="flex h-11 items-center gap-3 rounded-control px-3 text-sm font-medium text-ink-muted transition-colors duration-150 hover:bg-sunken-soft hover:text-ink"
         >
           <PanelLeft aria-hidden className={cn('size-5 shrink-0', pinned && 'text-accent')} />
           <span

--- a/frontend/src/ui/AssertionState.tsx
+++ b/frontend/src/ui/AssertionState.tsx
@@ -23,7 +23,7 @@ const LABELS: Record<AssertionState, string> = {
 }
 
 const STYLES: Record<AssertionState, string> = {
-  PRESENT: 'bg-accent/12 text-accent border-accent/25',
+  PRESENT: 'bg-accent-soft text-accent border-accent/25',
   DENIED: 'bg-sunken text-ink border-line',
   CLINICIAN_OBSERVED: 'bg-advisory/12 text-advisory border-advisory/25',
   // Deliberately legible rather than faint. A doctor scanning for what was

--- a/frontend/src/ui/Select.tsx
+++ b/frontend/src/ui/Select.tsx
@@ -174,7 +174,9 @@ export function Select({
                 className={cn(
                   'flex cursor-pointer items-center justify-between gap-3 rounded-control',
                   'px-3 py-2 text-sm whitespace-nowrap transition-colors duration-150',
-                  isSelected ? 'bg-accent/16 font-medium text-accent' : 'text-ink hover:bg-sunken',
+                  isSelected
+                    ? 'bg-accent-soft font-medium text-accent'
+                    : 'text-ink hover:bg-sunken',
                 )}
               >
                 {option.label}


### PR DESCRIPTION
## What Changed

The notification and account panels now align to the chrome cluster instead of the button that opened them, and every accent or chrome tint is an opaque token rather than an alpha utility.

## Why

**Both observations checked out, measured on the deployed build.**

Panel placement, at 1280px:

| | Before | After |
| --- | --- | --- |
| Right edge vs cluster | 47px inside | 0px |
| Gap below cluster | 1px | 8px |

The panel hung off its trigger, which is one of three buttons inside a padded cluster. The bell is the middle one, hence 47px. The 8px offset was taken from a trigger sitting 7px above the cluster's bottom edge, hence a 1px gap.

**The tints were genuinely translucent, and in the places where it matters.** `bg-accent/8`, `/12`, `/16` and `bg-sunken/60` are fills, not colours. On a card that reads correctly because the card beneath is opaque. On the sidebar, dock, chrome cluster, approve bar, step bar and dropover triggers it does not: all six are `.glass`, so the tint composited against whatever was scrolling behind.

`docs/DESIGN.md` already carried the objection one layer up, in the sentence explaining why chrome is glass and content is not: *a translucent surface has a contrast ratio that depends on whatever scrolls behind it, so it cannot be verified once.*

**Teal glassmorphism was not available.** `backdrop-filter` establishes a backdrop root and a descendant may only sample inside it, so glass nested in glass is flat by construction. That is already why the dropover panel is portalled to `body`. Every host here is itself glass, which leaves opaque as the only option that is actually a colour.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (564 tests)
- [x] `bun run build`
- [x] `npx impeccable detect` clean
- [x] Manually exercised the affected flow

Measured, not asserted:

| | Light | Dark |
| --- | --- | --- |
| 12% accent over surface | `#E3EDEA` | `#1E2E28` |
| Drift from the old glass rendering | 8/255 | 3.5/255 |
| Accent text on the tint | 5.45:1 | 6.05:1 |

So this is the same colour made deterministic, not a new one. The token resolves per theme and renders fully opaque in both, confirmed in a browser against the built CSS: `oklab(0.936 …)` light, `oklab(0.276 …)` dark. Tailwind's own static fallback for the light value came out as `#e3edea`, matching the computation independently.

Panel placement was verified by simulating the new anchor on the deployed build: 0px misalignment, 8px gap, for both panels.

## Notes For The Reviewer

**One value replaced three.** The `/16` step existed only to survive the glass beneath it. Opaque removes that reason, so the sidebar's documented exception and the 4.05:1 measurement it rested on both retire. `docs/DESIGN.md` is updated rather than left contradicting the code.

**Severity tints are deliberately untouched.** `bg-emergency/8`, `/10`, `/12`, `bg-urgent/8` and `bg-ink/8` all sit on opaque surfaces, where a tint and a solid colour render identically. There is nothing to fix, and changing severity presentation on a clinical safety surface is not something to do for tidiness.

**Translucent borders are also untouched**, for the same reason plus scope: `border-accent/30`, `/25` and `/40` are hairlines, and the reported defect is about fills.

**`color-mix` support** is Chrome 111+, Safari 16.2+, Firefox 113+. Tailwind emits a static hex fallback for older engines, but that fallback is the light value only, so a browser without `color-mix` would show a light tint in dark mode. Judged acceptable at current coverage; worth knowing it is the one degradation path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated selected, active, hover, and open states with consistent accent and neutral highlights.
  - Improved visual consistency across navigation, tabs, speaker labels, approval banners, badges, menus, and dropdowns.
  - Refined theme button and sidebar hover states for clearer appearance.

- **Bug Fixes**
  - Improved dropdown positioning when menus are anchored within shared interface areas.
  - Enhanced contrast and readability for highlighted interface states across light themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->