### PR TITLE
fix(redflags): widen negation scope enders and raise denied ability questions as redflag-list-v5

### DIFF
--- a/backend/src/clinical-versions/index.test.ts
+++ b/backend/src/clinical-versions/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { GAP_CHECKLIST } from '../gaps/index.js'
 import { GUIDELINE_CORPUS } from '../guidelines/index.js'
-import { RED_FLAG_LIST_VERSION, REDFLAG_TRIGGERS } from '../redflags/index.js'
+import { ALL_REDFLAG_TRIGGERS, RED_FLAG_LIST_VERSION, REDFLAG_TRIGGERS } from '../redflags/index.js'
 import { ACTIVE_CLINICAL_VERSIONS, ACTIVE_PROFILE_VERSIONS } from './index.js'
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
@@ -36,7 +36,8 @@ describe('clinical content versions (issue #16)', () => {
    * that can drift once the two are edited separately.
    */
   it('stamps the same rule-list version that every trigger carries', () => {
-    for (const trigger of REDFLAG_TRIGGERS) {
+    // ALL_REDFLAG_TRIGGERS, so the UTI triggers' stamps are pinned too (#150).
+    for (const trigger of ALL_REDFLAG_TRIGGERS) {
       expect(trigger.listVersion).toBe(RED_FLAG_LIST_VERSION.id)
     }
 

--- a/backend/src/clinical-versions/no-stray-clinical-constants.test.ts
+++ b/backend/src/clinical-versions/no-stray-clinical-constants.test.ts
@@ -3,7 +3,7 @@ import { join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { GAP_CHECKLIST } from '../gaps/index.js'
-import { REDFLAG_TRIGGERS } from '../redflags/index.js'
+import { ALL_REDFLAG_TRIGGERS } from '../redflags/index.js'
 
 /**
  * Issue #16, acceptance criteria 3 and 4. Clinical content is versioned data;
@@ -44,8 +44,10 @@ const SCANNED_TREES = [
 
 const SCORING_SYSTEMS = /\b(centor|mcisaac)\b/i
 
+// ALL_REDFLAG_TRIGGERS, not REDFLAG_TRIGGERS: the UTI ids were unguarded for
+// as long as the scan read only the URTI list (issue #150, folded nit).
 const CLINICAL_IDS = [
-  ...REDFLAG_TRIGGERS.map((trigger) => trigger.id),
+  ...ALL_REDFLAG_TRIGGERS.map((trigger) => trigger.id),
   ...GAP_CHECKLIST.map((entry) => entry.id),
 ]
 
@@ -112,7 +114,7 @@ describe('clinical constants live only in the versioned data files (issue #16)',
     expect(
       violations((line) => literals.some((literal) => line.includes(literal))),
       'A clinical rule is written down outside the versioned data. Branch on data read ' +
-        'from REDFLAG_TRIGGERS or GAP_CHECKLIST, or move the behaviour into the entry itself.',
+        'from ALL_REDFLAG_TRIGGERS or GAP_CHECKLIST, or move the behaviour into the entry itself.',
     ).toEqual([])
   })
 

--- a/backend/src/fixtures/corpus.ts
+++ b/backend/src/fixtures/corpus.ts
@@ -371,7 +371,7 @@ export const FIXTURES: readonly Fixture[] = [
   // ─── urti-malay-red-flag ──────────────────────────────────────────────────
   // Identifiers: patient name (patronymic + introducer) and an unhyphenated
   // MyKad number, the spoken form the hosted ASR path produces.
-  // Exercises: the redflag-list-v4 Malay alternates end to end. Every expected
+  // Exercises: the Malay matcher alternates (#153) end to end. Every expected
   // flag fires from a Malay phrase, the idiom "Tak apa" must not read as a
   // denial (it precedes the chest-pain disclosure), and the stridor screening
   // question is genuinely denied in Malay, so it must stay silent. The denied

--- a/backend/src/redflags/question-context.test.ts
+++ b/backend/src/redflags/question-context.test.ts
@@ -2,7 +2,7 @@ import type { Transcript } from '@shared/types'
 import { describe, expect, it } from 'vitest'
 import { FIXTURE_RUBRICS, FIXTURES } from '../fixtures/index.js'
 import { evaluateRedFlags } from './evaluate.js'
-import { REDFLAG_TRIGGERS } from './triggers.js'
+import { ALL_REDFLAG_TRIGGERS, REDFLAG_TRIGGERS } from './triggers.js'
 
 /**
  * GitHub issue #70. The engine matched every turn as if it asserted what it
@@ -171,6 +171,37 @@ describe('a denial that repeats the phrase it denies', () => {
     ).toEqual(['chest-pain'])
   })
 
+  /**
+   * Issue #150. "just" introduces an affirmed symptom exactly the way "cuma"
+   * does in Malay, and treating it as still inside the denial suppressed an
+   * urgent trigger on ordinary phrasing.
+   */
+  it('fires after "just", which introduces an affirmed symptom (issue #150)', () => {
+    expect(
+      ruleIds(transcript([{ speaker: 'patient', text: 'No fever, just chest pain.' }])),
+    ).toEqual(['chest-pain'])
+  })
+
+  it('fires after "only", the same construction', () => {
+    expect(
+      ruleIds(
+        transcript([{ speaker: 'patient', text: 'No fever, only chest pain when I cough.' }]),
+      ),
+    ).toEqual(['chest-pain'])
+  })
+
+  it('fires on the minimiser reading too, because a minimised symptom is present', () => {
+    expect(
+      ruleIds(transcript([{ speaker: 'patient', text: 'No fever, just a bit of chest pain.' }])),
+    ).toEqual(['chest-pain'])
+  })
+
+  it('still suppresses when the denial itself comes after "just"', () => {
+    expect(
+      ruleIds(transcript([{ speaker: 'patient', text: 'Honestly just no chest pain at all.' }])),
+    ).toEqual([])
+  })
+
   it('fires on a plain report', () => {
     expect(ruleIds(transcript([{ speaker: 'patient', text: 'I have chest pain.' }]))).toEqual([
       'chest-pain',
@@ -189,5 +220,95 @@ describe('vocabulary that was missing a genuine escalation', () => {
     expect(
       ruleIds(transcript([{ speaker: 'patient', text: 'I cannot swallow anything now.' }])),
     ).toEqual(['swallowing-oral-intake'])
+  })
+})
+
+/**
+ * Issue #163. A positively framed ability question answered with a bare
+ * negation asserts the inability the trigger exists to catch, but no matcher
+ * span exists in either turn, so v4 raised nothing on the commonest
+ * question-answer shape in either language. The composition is deliberately
+ * narrow: adjacent doctor-question and patient-reply, an unhedged leading
+ * denial, and no re-affirmation after it.
+ */
+describe('a positively framed ability question answered with a bare negation (issue #163)', () => {
+  const allRuleIds = (t: Transcript): string[] =>
+    evaluateRedFlags(t, ALL_REDFLAG_TRIGGERS)
+      .map((f) => f.ruleId)
+      .filter((id): id is string => id !== undefined)
+      .sort()
+
+  it.each([
+    ['swallowing-oral-intake', 'Boleh telan tak?', 'Tak.'],
+    ['significant-dyspnoea', 'Boleh bernafas macam biasa tak?', 'Tak boleh doktor.'],
+    ['uti-unable-to-pass-urine', 'Kencing boleh keluar tak?', 'Tak keluar langsung.'],
+    ['swallowing-oral-intake', 'Can you swallow?', 'No.'],
+    ['swallowing-oral-intake', 'Are you able to eat or drink?', 'Cannot, doctor.'],
+    ['swallowing-oral-intake', 'Can you swallow?', "No, I can't."],
+    ['swallowing-oral-intake', 'Can you eat or drink?', 'Nothing since yesterday.'],
+    ['swallowing-oral-intake', 'Boleh telan tak?', 'Tak, tak boleh langsung.'],
+    [
+      'significant-dyspnoea',
+      'Boleh bernafas macam biasa tak?',
+      'Tak boleh doktor, sikit-sikit pun tak boleh.',
+    ],
+    ['uti-unable-to-pass-urine', 'Boleh kencing tak?', 'Belum lagi doktor.'],
+  ] as const)('raises %s for "%s" answered "%s"', (id, question, reply) => {
+    expect(
+      allRuleIds(
+        transcript([
+          { speaker: 'doctor', text: question },
+          { speaker: 'patient', text: reply },
+        ]),
+      ),
+    ).toContain(id)
+  })
+
+  it.each([
+    ['an affirmed ability', 'Boleh telan tak?', 'Boleh.'],
+    ['a hedged yes', 'Boleh telan tak?', 'Boleh, sikit-sikit je.'],
+    ['uncertainty, because unknown is never negative', 'Boleh telan tak?', 'Tak pasti doktor.'],
+    ['English uncertainty', 'Can you swallow?', 'Not sure.'],
+    [
+      'a denial followed by re-affirmed intake, the pinned canary',
+      'Boleh makan tak?',
+      'Takde, boleh makan minum macam biasa.',
+    ],
+  ] as const)('stays silent on %s', (_case, question, reply) => {
+    expect(
+      allRuleIds(
+        transcript([
+          { speaker: 'doctor', text: question },
+          { speaker: 'patient', text: reply },
+        ]),
+      ),
+    ).toEqual([])
+  })
+
+  it('stays silent on an unanswered ability question, which asserts nothing abnormal', () => {
+    expect(allRuleIds(transcript([{ speaker: 'doctor', text: 'Boleh telan tak?' }]))).toEqual([])
+  })
+
+  it('does not compose across an interleaved turn, so a denial never pairs with the wrong question', () => {
+    expect(
+      allRuleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Boleh telan tak?' },
+          { speaker: 'doctor', text: 'Take your time.' },
+          { speaker: 'patient', text: 'Tak.' },
+        ]),
+      ),
+    ).toEqual([])
+  })
+
+  it('leaves the negatively framed forms on their existing over-firing route', () => {
+    expect(
+      allRuleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Tak boleh telan ke?' },
+          { speaker: 'patient', text: 'Boleh je, takde masalah.' },
+        ]),
+      ),
+    ).toContain('swallowing-oral-intake')
   })
 })

--- a/backend/src/redflags/triggers.ts
+++ b/backend/src/redflags/triggers.ts
@@ -14,7 +14,7 @@ import type { RedFlagTrigger } from './types.js'
  * changes. Recorded with every analysis (docs/trd.md §15).
  */
 export const RED_FLAG_LIST_VERSION: ClinicalArtefactVersion = {
-  id: 'redflag-list-v4',
+  id: 'redflag-list-v5',
   effectiveDate: '2026-08-15',
 }
 
@@ -89,9 +89,17 @@ const asserts = (transcript: Transcript, index: number): boolean => {
 
 /**
  * Words that end the scope of a preceding negation: "no fever but chest pain",
- * "tiada demam, cuma sesak nafas".
+ * "no fever, just chest pain", "tiada demam, cuma sesak nafas".
+ *
+ * "just" and "only" (issue #150) are the English counterparts of "cuma": in
+ * "No fever, just chest pain" the denial scopes over fever alone and "just"
+ * introduces an affirmed symptom. Both are more polysemous than "cuma", but
+ * the minimiser reading ("just a bit of chest pain") describes a symptom that
+ * is present, so ending the denial there fires on it, which is the direction
+ * this engine must fail in; widening this list can only convert suppressions
+ * into fires, never the reverse.
  */
-const NEGATION_SCOPE_END = /\b(?:but|tapi|however|although|except|cuma|cuman)\b/i
+const NEGATION_SCOPE_END = /\b(?:but|just|only|however|although|except|tapi|cuma|cuman)\b/i
 
 /** An unambiguous negator sitting immediately before the matched span. */
 const TRAILING_NEGATOR = new RegExp(
@@ -140,6 +148,74 @@ const findSpan = (transcript: Transcript, patterns: readonly RegExp[]): string |
       if (match === null) continue
       if (SPAN_CARRIES_NEGATOR.test(match[0])) return match[0]
       if (asserts(transcript, index) && !isNegated(turn.text, match.index)) return match[0]
+    }
+  }
+  return null
+}
+
+/**
+ * A reply that denies the ability just asked about (issue #163). English
+ * "No." / "Cannot." / "Not really."; Malay through MALAY_NEGATOR, so the
+ * idiom, uncertainty, and hedge exclusions apply ("Tak pasti." and "Tak apa."
+ * never count, mirroring "Not sure."), with a negated modal or verb consumed
+ * as part of the denial ("Tak boleh", "Tak keluar langsung") so the
+ * re-affirmation check reads only what follows it.
+ */
+const ABILITY_DENIAL = new RegExp(
+  `^\\s*(?:no+|nope|none|nothing|negative|cannot|can'?t|not(?!\\s+(?:sure|certain))|(?:${MALAY_NEGATOR.source}|takda|belum)(?:\\s+(?:boleh|dapat|lalu|larat|lepas|keluar|nak))*)\\b`,
+  'i',
+)
+
+/**
+ * A reply that opens with a denial and then re-affirms the ability answers a
+ * different framing, not an inability: "Takde, boleh makan minum macam
+ * biasa." denies the vomiting it was asked about and affirms intake, and must
+ * stay silent. A modal preceded by its own negator is not a re-affirmation
+ * ("Tak, tak boleh langsung." repeats the denial), and neither is the English
+ * negative contraction ("No, I can't."), so both stay denials. The cost is
+ * accepted and pinned: a mixed reply like "Tak boleh, ada sikit je" reads as
+ * re-affirmation and does not fire through this path; partial intake sits
+ * with the doctor, not this composition.
+ */
+const REPLY_REAFFIRMS =
+  /(?<!\b(?:tak|tidak)\s)\b(?:boleh|dapat|ada|ya)\b|\b(?:yes|yeah|ok(?:ay)?)\b|\bcan(?!'?t\b|\s+not\b)\b/i
+
+/**
+ * Fires when an ability is asked about positively and denied in the reply
+ * (issue #163): "Boleh telan tak?" / "Tak boleh doktor." asserts the
+ * inability the trigger exists to catch, but no turn carries a span the
+ * matchers can anchor on, so v4 raised nothing on the commonest
+ * question-answer shape in either language. The span returned is the ability
+ * phrase from the doctor's question, the same precedent as an affirmed
+ * screening question: the question is the only place the symptom is named.
+ *
+ * Deliberately narrow, because this composition has its own over-fire budget:
+ * only a doctor turn that is a question, only the immediately following
+ * patient reply, only an unhedged leading denial, and only when nothing after
+ * the denial re-affirms. Each question pattern excludes the negatively framed
+ * form ("tak boleh telan?"), which already fires through the
+ * SPAN_CARRIES_NEGATOR route above. Two silences are accepted and pinned: an
+ * unanswered ability question fires nothing (unlike a symptom question, the
+ * question alone asserts nothing abnormal), and an interleaved reply is not
+ * composed, because pairing a denial with the wrong question would assert an
+ * inability nobody stated.
+ */
+const findDeniedAbility = (
+  transcript: Transcript,
+  questionPatterns: readonly RegExp[],
+): string | null => {
+  for (const [index, turn] of transcript.turns.entries()) {
+    if (turn.speaker !== 'doctor' || !isQuestion(turn.text)) continue
+
+    const reply = transcript.turns[index + 1]
+    if (reply === undefined || reply.speaker !== 'patient') continue
+
+    const denial = ABILITY_DENIAL.exec(reply.text)
+    if (denial === null || REPLY_REAFFIRMS.test(reply.text.slice(denial[0].length))) continue
+
+    for (const pattern of questionPatterns) {
+      const match = pattern.exec(turn.text)
+      if (match !== null) return match[0]
     }
   }
   return null
@@ -206,6 +282,10 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /na[fp]as\s+pendek/i,
         /\btercungap/i,
         /\btermengah/i,
+      ]) ??
+      findDeniedAbility(transcript, [
+        /(?<!\b(?:tak|tidak)\s)\b(?:boleh|dapat|larat)\s+(?:nak\s+)?(?:tarik\s+)?(?:ber)?na[fp]as/i,
+        /can\s+you\s+breathe/i,
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -271,6 +351,11 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /(?:tak|tidak)\s+(?:boleh|dapat|lalu)\s+(?:nak\s+)?telan/i,
         /(?:tak|tidak)\s+(?:boleh|dapat|lalu)\s+(?:nak\s+)?(?:makan|minum)/i,
         /(?:telan|makan|minum)\s+(?:pun\s+)?tak\s+(?:boleh|lalu)/i,
+      ]) ??
+      findDeniedAbility(transcript, [
+        /(?<!\b(?:tak|tidak)\s)\b(?:boleh|dapat|lalu)\s+(?:nak\s+)?(?:telan|makan|minum)/i,
+        /can\s+you\s+(?:swallow|eat|drink)/i,
+        /(?<!\bnot\s)\bable\s+to\s+(?:swallow|eat|drink)/i,
       ]),
     clinicalSource: DELPHI_AIRWAY_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -417,6 +502,11 @@ export const UTI_REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /(?:tak|tidak)\s+(?:boleh|dapat)\s+(?:nak\s+)?(?:kencing|buang\s+air\s+kecil)/i,
         /(?:air\s+)?kencing\s+tak\s+keluar/i,
         /kencing\s+(?:pun\s+)?tak\s+(?:boleh|lepas)/i,
+      ]) ??
+      findDeniedAbility(transcript, [
+        /(?<!\b(?:tak|tidak)\s)\b(?:boleh|dapat)\s+(?:nak\s+)?(?:kencing|buang\s+air\s+kecil)/i,
+        /\bkencing\b[^.!?]{0,16}?(?<!\b(?:tak|tidak)\s)\b(?:boleh|dapat)\s+keluar/i,
+        /can\s+you\s+(?:pass\s+urine|pee|urinate)/i,
       ]),
     clinicalSource: UTI_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,


### PR DESCRIPTION
## What Changed

Two critical red-flag false negatives are fixed as `redflag-list-v5`, both in the mixed Malay/English speech the hosted-ASR path now transcribes. First, `just` and `only` end a denial's scope the way `cuma` already does, so "No fever, just chest pain." raises the urgent chest-pain flag instead of being suppressed. Second, a new tightly scoped composition raises a flag when a positively framed ability question is answered with an unhedged denial ("Boleh telan tak?" / "Tak boleh doktor.", "Can you swallow?" / "No, I can't."), wired into significant-dyspnoea, swallowing-oral-intake, and uti-unable-to-pass-urine; previously the commonest question-answer shape in either language raised nothing. The folded nits from #150: the clinical-constants guard and the version-stamp test now read `ALL_REDFLAG_TRIGGERS`, so the six UTI trigger ids are guarded and stamped-pinned too, and the fixture comment that named `redflag-list-v4` becomes version-neutral so it stops drifting on every bump.

Closes #150
Closes #163

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`

`clinical-safety-reviewer` audited the diff: suppression invariant untouched, and the scope-ender widening verified monotonic (a differential over 313 transcripts found 0 lost flags, 72 new fires). Its three should-fix findings, all gaps in the new path rather than regressions, are fixed and pinned by new tests: `can't` no longer reads as a re-affirming "can"; a repeated denial ("Tak, tak boleh langsung.") no longer reads as re-affirmation; and the denial vocabulary gained `takda`, `belum`, `none`, `nothing` for parity with `LEADING_DENIAL`. New pins also cover the accepted silences: unanswered ability questions, non-adjacent replies, hedged or uncertain replies, and the denial-then-reaffirmation canary.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model (`mergeRedFlags` and `evaluate.ts` untouched; the change is additive matching only)
- [x] Citations remain ID-constrained; no free-text references accepted
- [x] No transcript bodies, note contents, or vault entries written to logs
- [x] Fixtures added are synthetic (none added)

## Notes For The Reviewer

- Named over-fire cost, accepted per the fail-open doctrine and worth knowing at review: "Boleh makan ubat ni tak?" / "Tak boleh, saya alah." raises urgent swallowing-oral-intake, and the exam instruction "Boleh tarik nafas dalam-dalam?" / "Tak boleh, sakit." raises emergency significant-dyspnoea. A spurious flag costs one dismissal; the suppressed alternative costs what the engine exists to prevent.
- The version bump to v5 is in the same diff as the matcher changes; every `listVersion` reads the constant, and audit stamping flows through `getActiveClinicalVersions` by reference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved red-flag detection when symptoms are qualified by “just” or “only,” while preserving valid symptom denials.
  - Added support for detecting concerning inability or denial responses following clinician questions.
  - Expanded coverage for breathlessness, swallowing or intake difficulties, and urinary retention.
  - Improved handling of English and Malay phrasing, including positively framed questions and nearby patient negations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->