### PR TITLE
fix(deid): reword the seeded MRN to a detectable form so its tests stop passing vacuously

### DIFF
--- a/backend/src/deid/deid.test.ts
+++ b/backend/src/deid/deid.test.ts
@@ -307,8 +307,10 @@ describe('fixture integration — PRD §16 target: zero identifiers pass through
       expect(text, `"${value}" survived de-identification`).not.toContain(value)
     }
 
+    // All seven classes, so a fixture reword that silently breaks one
+    // detector's match cannot pass vacuously again (issue #148).
     expect(detected).toEqual(
-      expect.arrayContaining(['ADDRESS', 'EMAIL', 'NRIC', 'PATIENT', 'PHONE']),
+      expect.arrayContaining(['ADDRESS', 'DOB', 'EMAIL', 'MRN', 'NRIC', 'PATIENT', 'PHONE']),
     )
   })
 

--- a/backend/src/fixtures/corpus.ts
+++ b/backend/src/fixtures/corpus.ts
@@ -359,9 +359,11 @@ export const FIXTURES: readonly Fixture[] = [
         },
         {
           speaker: 'doctor',
+          // Cue directly before the value: the detector admits no words between
+          // them, which the previous wording broke for as long as it existed (#148).
           text:
-            "Yes, I'll note it on the invoice for PMCare. Registration number for our clinic " +
-            'file is RC-2026-00842.',
+            "Yes, I'll note it on the invoice for PMCare. Registration no. KLC-004821 for " +
+            'our clinic file.',
           offsetSeconds: 168.9,
         },
       ],

--- a/backend/src/lib/logger.leak.test.ts
+++ b/backend/src/lib/logger.leak.test.ts
@@ -198,6 +198,7 @@ describe('no clinical content reaches the log drain', () => {
       'Selangor',
       'ahmad.ismail85@example.com',
       '23 May 1985',
+      'KLC-004821',
     ]) {
       expect(logs, `identifier leaked: ${identifier}`).not.toContain(identifier)
     }


### PR DESCRIPTION
## What Changed

Fixture 4's seeded MRN is now detectable. The old line ("Registration number for our clinic file is RC-2026-00842.") broke the cue-to-value adjacency the MRN detector requires and used a two-hyphen value its pattern cannot carry, so the identifier flowed to the LLM un-tokenised while `deid.test.ts:305` and `safety.test.ts:49` asserted a literal (`KLC-004821`) that never existed in any fixture, passing vacuously. The line now reads "Registration no. KLC-004821 for our clinic file.", the exact shape `deid.test.ts:76` proves detectable, which makes both stale literals true and puts the seeded MRN inside the zero-leak guarantee end to end. Detector code is untouched, per the issue's smallest-credible-fix note.

Closes #148

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`

`phi-boundary-auditor` verified hands-on that the pipeline now produces an MRN vault entry for the fixture (tokenised, round-tripped, absent from output), that the previously vacuous assertions genuinely exercise it, and that nothing in deid, acceptance, or fixtures regressed. Its findings are applied: the `detected` assertion now requires all seven identifier classes so a future reword cannot go vacuous the same way, and the logger drain test's identifier list gains the MRN value it had always omitted.

Stated plainly: this fixes the fixture and its tests, not the detector. Non-adjacent cue phrasings and two-hyphen values remain undetected in production; that residual recall gap is filed as its own issue with a precision-test requirement.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model
- [x] Citations remain ID-constrained; no free-text references accepted
- [x] No transcript bodies, note contents, or vault entries written to logs
- [x] Fixtures added are synthetic (the reworded value is the synthetic literal the tests always named)
