### PR TITLE
feat(ui): teach CatatAI in the guided tour without breaking its no-mocking claim

### DIFF
--- a/frontend/src/copilot/CatatAI.test.tsx
+++ b/frontend/src/copilot/CatatAI.test.tsx
@@ -1,0 +1,129 @@
+import type { ConsultationDetail } from '@shared/types'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CatatAI } from './CatatAI.js'
+
+/**
+ * The copilot's demo mode, as the guided tour meets it (issue #179).
+ *
+ * The tour's consultation is never stored (#80), so the copilot route would
+ * 404 on every message. The tour still has to teach that CatatAI exists, and
+ * `HelpButton` promises the user that nothing is mocked or replayed. Demo mode
+ * is the resolution: the real panel, genuinely inactive, saying so.
+ *
+ * These tests are therefore about what the panel must NOT do. The route is
+ * reached by `fetch`, so a stub that fails the test on any call is the pin
+ * that matters most.
+ */
+
+afterEach(cleanup)
+
+/** CatatAI reads only `id`; the rest of the detail is irrelevant to it. */
+const CONSULTATION = { id: 'demo-ephemeral' } as unknown as ConsultationDetail
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn(() => {
+    throw new Error('the demo panel must never reach the copilot route')
+  })
+  vi.stubGlobal('fetch', fetchSpy)
+  // jsdom ships HTMLDialogElement without its methods, and the expanded state
+  // is a real <dialog>. These define rather than spy.
+  HTMLDialogElement.prototype.close = vi.fn()
+  HTMLDialogElement.prototype.showModal = vi.fn()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function renderPanel(demo: boolean) {
+  const onApply = vi.fn(async () => {})
+  render(<CatatAI consultation={CONSULTATION} onApply={onApply} demo={demo} />)
+  return { onApply }
+}
+
+const openPanel = () => fireEvent.click(screen.getByRole('button', { name: /open catatai/i }))
+
+describe('the tour anchor', () => {
+  it('renders in demo mode, so the coachmark has something to point at', () => {
+    renderPanel(true)
+    // A coachmark aimed at an element that does not exist is the failure the
+    // tour's own subject scoring exists to prevent.
+    expect(document.querySelector('[data-tour="catatai"]')).not.toBeNull()
+  })
+})
+
+describe('the demo panel', () => {
+  it('offers no composer, so there is nothing that can send a message', () => {
+    renderPanel(true)
+    openPanel()
+
+    expect(screen.queryByRole('textbox')).toBeNull()
+    expect(screen.queryByRole('button', { name: /^send$/i })).toBeNull()
+  })
+
+  it('offers no suggestion chips, which would also post to the route', () => {
+    renderPanel(true)
+    openPanel()
+
+    expect(screen.getByText(/available on a saved consultation/i)).toBeTruthy()
+  })
+
+  it('never calls the copilot route while open', () => {
+    renderPanel(true)
+    openPanel()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('labels itself inactive inside the panel, not only in the coachmark', () => {
+    renderPanel(true)
+    openPanel()
+
+    // Someone who opens this without the tour text in view still learns why
+    // it is not answering.
+    expect(screen.getByText(/inactive during the tour/i)).toBeTruthy()
+    expect(screen.getByText(/scripted conversation/i)).toBeTruthy()
+  })
+
+  it('still teaches the three claims the tour step makes', () => {
+    renderPanel(true)
+    openPanel()
+
+    expect(screen.getByText(/reads the consultation as it stands/i)).toBeTruthy()
+    expect(screen.getByText(/proposes changes/i)).toBeTruthy()
+    expect(screen.getByText(/cannot approve a note/i)).toBeTruthy()
+  })
+
+  it('cannot be expanded into a modal that hides the tour behind a backdrop', () => {
+    renderPanel(true)
+    openPanel()
+
+    expect(screen.queryByRole('button', { name: /expand the panel/i })).toBeNull()
+  })
+
+  it('still closes, so the tour is never left with a panel it cannot dismiss', () => {
+    renderPanel(true)
+    openPanel()
+    fireEvent.click(screen.getByRole('button', { name: /close catatai/i }))
+
+    expect(screen.getByRole('button', { name: /open catatai/i })).toBeTruthy()
+  })
+})
+
+/*
+ * The contrast case. Without it these tests would still pass if `demo` were
+ * ignored and the composer had simply been deleted for everyone.
+ */
+describe('the real panel', () => {
+  it('keeps its composer and its expand control', () => {
+    renderPanel(false)
+    openPanel()
+
+    expect(screen.getByRole('textbox')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /expand the panel/i })).toBeTruthy()
+    expect(screen.queryByText(/inactive during the tour/i)).toBeNull()
+  })
+})

--- a/frontend/src/copilot/CatatAI.tsx
+++ b/frontend/src/copilot/CatatAI.tsx
@@ -37,10 +37,23 @@ import { type CopilotMessage, useCopilot } from './use-copilot.js'
 export function CatatAI({
   consultation,
   onApply,
+  demo = false,
 }: {
   consultation: ConsultationDetail
   /** Applies an approved proposal through the ordinary consultation PATCH. */
   onApply: (proposal: CopilotProposal, reason?: string) => Promise<void>
+  /**
+   * Renders the real panel, inactive, for the guided tour (issue #179).
+   *
+   * **Nothing is scripted in this mode, and that is the point.** The tour's
+   * consultation is never stored (#80), and the copilot route resolves its
+   * record through `assertOwnedConsultation`, so a message would 404. The
+   * obvious fix, a canned exchange, would make `HelpButton`'s "Nothing is
+   * mocked or replayed" false on the very screen that promises it. So the
+   * panel shows its own genuine empty state, says why it is inactive, and
+   * offers no way to send: no composer, no chips, and `submit` refuses.
+   */
+  demo?: boolean
 }) {
   const [open, setOpen] = useState(false)
   const [expanded, setExpanded] = useState(false)
@@ -85,7 +98,9 @@ export function CatatAI({
   }, [messages])
 
   const submit = (text: string) => {
-    if (streaming) return
+    // The demo guard is here as well as in the markup, so the one function that
+    // can reach the route refuses regardless of how it was called.
+    if (streaming || demo) return
     setDraft('')
     void send(text)
   }
@@ -112,19 +127,26 @@ export function CatatAI({
           <p className="font-medium text-ink text-sm leading-tight">CatatAI</p>
           <p className="truncate text-ink-muted text-xs">Reviews with you. Never signs off.</p>
         </div>
-        <button
-          type="button"
-          onClick={() => setExpanded((value) => !value)}
-          aria-label={expanded ? 'Dock the panel' : 'Expand the panel'}
-          title={expanded ? 'Dock' : 'Expand'}
-          className="inline-flex size-8 items-center justify-center rounded-control text-ink-muted transition-colors hover:bg-sunken hover:text-ink"
-        >
-          {expanded ? (
-            <Minimize2 aria-hidden className="size-4" />
-          ) : (
-            <Maximize2 aria-hidden className="size-4" />
-          )}
-        </button>
+        {/* No expand during the tour. The expanded state is a modal `<dialog>`,
+            which takes the top layer and makes the tour's own step bar inert
+            behind its backdrop. Escape would get out, but a control that
+            hides the tour is not worth offering for a panel holding four
+            lines of static text (issue #179). */}
+        {!demo && (
+          <button
+            type="button"
+            onClick={() => setExpanded((value) => !value)}
+            aria-label={expanded ? 'Dock the panel' : 'Expand the panel'}
+            title={expanded ? 'Dock' : 'Expand'}
+            className="inline-flex size-8 items-center justify-center rounded-control text-ink-muted transition-colors hover:bg-sunken hover:text-ink"
+          >
+            {expanded ? (
+              <Minimize2 aria-hidden className="size-4" />
+            ) : (
+              <Maximize2 aria-hidden className="size-4" />
+            )}
+          </button>
+        )}
         <button
           type="button"
           onClick={close}
@@ -136,7 +158,28 @@ export function CatatAI({
       </header>
 
       <div ref={scroller} className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4">
-        {messages.length === 0 && (
+        {demo && (
+          /*
+           * Labelled inside the panel, not only in the coachmark, so the state
+           * is self-explaining to someone who opened this without the tour's
+           * text in view. It describes the copilot rather than performing it.
+           */
+          <div className="space-y-3">
+            <p className="rounded-card border border-line bg-sunken px-3 py-2 text-ink-muted text-xs">
+              Inactive during the tour. The tour&apos;s consultation is never saved, and CatatAI
+              reads a stored record, so there is nothing here for it to open. Nothing on this screen
+              is a scripted conversation.
+            </p>
+            <p className="text-ink-muted text-sm">On a real consultation CatatAI:</p>
+            <ul className="space-y-1.5 text-ink-muted text-sm">
+              <li>reads the consultation as it stands, including your own edits</li>
+              <li>proposes changes that you choose to apply</li>
+              <li className="text-ink">cannot approve a note, and cannot retract a red flag</li>
+            </ul>
+          </div>
+        )}
+
+        {!demo && messages.length === 0 && (
           <div className="space-y-3">
             <p className="text-ink-muted text-sm">
               I can see this consultation as it stands now, including your edits. Ask me about the
@@ -159,8 +202,15 @@ export function CatatAI({
         )}
       </div>
 
+      {/* No composer and no chips in demo mode: the surest way to guarantee the
+          tour cannot reach the copilot route is to render nothing that calls
+          it (issue #179). */}
       <div className="space-y-2 border-line/60 border-t px-4 py-3">
-        {(messages.length === 0 || showFollowUps) && (
+        {demo && (
+          <p className="text-center text-ink-muted text-xs">Available on a saved consultation.</p>
+        )}
+
+        {!demo && (messages.length === 0 || showFollowUps) && (
           <div className="flex flex-wrap gap-1.5">
             {(messages.length === 0 ? opening : followUps).map((question) => (
               <button
@@ -178,41 +228,43 @@ export function CatatAI({
           </div>
         )}
 
-        <form
-          onSubmit={(event) => {
-            event.preventDefault()
-            submit(draft)
-          }}
-          className="flex items-end gap-2"
-        >
-          <label className="sr-only" htmlFor="catatai-input">
-            Ask CatatAI about this consultation
-          </label>
-          <textarea
-            id="catatai-input"
-            value={draft}
-            onChange={(event) => setDraft(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
-                event.preventDefault()
-                submit(draft)
-              }
+        {!demo && (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault()
+              submit(draft)
             }}
-            rows={1}
-            placeholder="Ask about this consultation"
-            className="max-h-28 min-h-10 flex-1 resize-none rounded-control border border-line bg-surface px-3 py-2.5 text-ink text-sm placeholder:text-ink-muted focus:border-accent focus:outline-none"
-          />
-          <Button
-            type="submit"
-            size="md"
-            variant="primary"
-            disabled={streaming || draft.trim().length === 0}
-            aria-label="Send"
-            className="size-10 shrink-0 px-0"
+            className="flex items-end gap-2"
           >
-            <ArrowUp aria-hidden className="size-4" />
-          </Button>
-        </form>
+            <label className="sr-only" htmlFor="catatai-input">
+              Ask CatatAI about this consultation
+            </label>
+            <textarea
+              id="catatai-input"
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !event.shiftKey) {
+                  event.preventDefault()
+                  submit(draft)
+                }
+              }}
+              rows={1}
+              placeholder="Ask about this consultation"
+              className="max-h-28 min-h-10 flex-1 resize-none rounded-control border border-line bg-surface px-3 py-2.5 text-ink text-sm placeholder:text-ink-muted focus:border-accent focus:outline-none"
+            />
+            <Button
+              type="submit"
+              size="md"
+              variant="primary"
+              disabled={streaming || draft.trim().length === 0}
+              aria-label="Send"
+              className="size-10 shrink-0 px-0"
+            >
+              <ArrowUp aria-hidden className="size-4" />
+            </Button>
+          </form>
+        )}
       </div>
     </>
   )

--- a/frontend/src/demo/DemoTour.test.tsx
+++ b/frontend/src/demo/DemoTour.test.tsx
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { TOUR_STEP_COUNT, TOUR_STEPS } from './DemoTour.js'
+
+/**
+ * The tour's honesty contract (issue #179).
+ *
+ * The tour's whole argument is that it narrates the real pipeline rather than
+ * replaying a script, and `HelpButton` states that to the user before they
+ * agree to start. Teaching CatatAI is the change most likely to break that,
+ * because the obvious implementation is a canned exchange. These pin the shape
+ * that keeps the claim true.
+ */
+
+const catatai = TOUR_STEPS.find((step) => step.target === '[data-tour="catatai"]')
+
+describe('the CatatAI step', () => {
+  it('exists exactly once, on the anchor the copilot button already carries', () => {
+    const matches = TOUR_STEPS.filter((step) => step.target === '[data-tour="catatai"]')
+    expect(matches).toHaveLength(1)
+  })
+
+  it('is counted by construction rather than by a hand-edited constant', () => {
+    // The failure this prevents is a step added to the array while the dialog
+    // keeps advertising the old number.
+    expect(TOUR_STEP_COUNT).toBe(TOUR_STEPS.length)
+  })
+
+  it('says the copilot reads the consultation including the doctor edits', () => {
+    expect(catatai?.hint).toMatch(/reads the consultation/i)
+    expect(catatai?.hint).toMatch(/your own edits/i)
+  })
+
+  it('says the copilot proposes rather than writes', () => {
+    expect(catatai?.hint).toMatch(/proposes changes/i)
+  })
+
+  /*
+   * The claim that distinguishes this product from a scribe. It is the one
+   * most likely to be cut for brevity, and cutting it turns the tour into an
+   * advertisement for an autonomous note-writer, which this is not.
+   */
+  it('says the copilot can neither approve a note nor retract a red flag', () => {
+    expect(catatai?.hint).toMatch(/never approve a note/i)
+    expect(catatai?.hint).toMatch(/retract a red flag/i)
+  })
+
+  it('is honest that it is inactive, rather than implying a live copilot', () => {
+    expect(catatai?.hint).toMatch(/inactive/i)
+    expect(catatai?.hint).toMatch(/not a scripted conversation|never saved/i)
+  })
+
+  it('lands before the approval step, so the cannot-approve claim precedes it', () => {
+    const catataiAt = TOUR_STEPS.findIndex((step) => step.target === '[data-tour="catatai"]')
+    const approveAt = TOUR_STEPS.findIndex((step) => step.target === '[data-tour="approve"]')
+    expect(catataiAt).toBeGreaterThanOrEqual(0)
+    expect(catataiAt).toBeLessThan(approveAt)
+  })
+
+  it('walks a consultation, so the anchor is on a screen the tour reaches', () => {
+    expect(catatai?.route).toBe('/consultations/:id')
+    expect(catatai?.subject).toBe('flagged')
+  })
+})
+
+/**
+ * A source-scanning tripwire, in the shape the backend uses for invariants the
+ * type system cannot express.
+ *
+ * `HelpButton` promises "Nothing is mocked or replayed" before the user agrees
+ * to start. #179 resolved that by keeping the promise true: the tour describes
+ * the copilot and shows its real panel inactive, and stages no conversation.
+ * If someone later adds a scripted exchange, this test is what makes the
+ * promise a deliberate decision rather than something quietly falsified.
+ */
+describe('the no-mocking promise', () => {
+  // Read from the workspace root rather than `import.meta.url`, which is not a
+  // file: URL under the jsdom environment this suite runs in.
+  const source = readFileSync(resolve(process.cwd(), 'src/demo/HelpButton.tsx'), 'utf8')
+
+  it('is still made to the user before the tour starts', () => {
+    expect(source).toContain('Nothing is mocked or replayed.')
+  })
+
+  it('is still accompanied by the real-pipeline claim it qualifies', () => {
+    expect(source).toMatch(/runs the real pipeline on a simulated transcript/i)
+  })
+})

--- a/frontend/src/demo/DemoTour.tsx
+++ b/frontend/src/demo/DemoTour.tsx
@@ -72,7 +72,7 @@ export interface TourStep {
   hint: string
 }
 
-const TOUR_STEPS: TourStep[] = [
+export const TOUR_STEPS: TourStep[] = [
   {
     label: 'Consultations',
     route: '/consultations',
@@ -112,6 +112,16 @@ const TOUR_STEPS: TourStep[] = [
     subject: 'flagged',
     target: '[data-tour="checklist"]',
     hint: 'A fixed 29-field checklist. A field nobody asked about reads "Not Assessed" rather than vanishing, so a fabricated denial is visible.',
+  },
+  {
+    // Deliberately before Approval: the claim that lands hardest here is the
+    // one about what the copilot cannot do, and the next stop is the control
+    // it cannot press.
+    label: 'CatatAI',
+    route: '/consultations/:id',
+    subject: 'flagged',
+    target: '[data-tour="catatai"]',
+    hint: 'The review copilot. It reads the consultation as it stands, including your own edits, and proposes changes you choose to apply. It can never approve a note or retract a red flag. It is inactive here, because the consultation this tour analyses is never saved, and nothing on this screen is a scripted conversation.',
   },
   {
     label: 'Approval',

--- a/frontend/src/demo/HelpButton.tsx
+++ b/frontend/src/demo/HelpButton.tsx
@@ -91,7 +91,7 @@ export function HelpButton() {
           <p className="mt-2 text-sm leading-relaxed text-ink-muted">
             {TOUR_STEP_COUNT} steps through a consultation the tour analyses for you: the
             transcript, the red flags and where they came from, what the consultation never
-            established, and the approval gate.
+            established, the review copilot, and the approval gate.
           </p>
 
           {/* The three facts a clinician or an evaluator would otherwise have to

--- a/frontend/src/routes/ConsultationReview.tsx
+++ b/frontend/src/routes/ConsultationReview.tsx
@@ -474,8 +474,16 @@ export function ConsultationReview() {
       )}
 
       {/*
-       * Not offered on the tour's consultation, which is not stored, so the
-       * copilot route would 404 on every message (#80).
+       * Rendered inactive on the tour's consultation, which is not stored, so
+       * the copilot route would 404 on every message (#80). It renders at all
+       * because the tour needs the `data-tour="catatai"` anchor to exist, and
+       * a coachmark pointing at an element that is not there is the failure
+       * `DemoTour`'s subject scoring exists to prevent (#179).
+       *
+       * **Keyed on the tour step, which is what closes the panel.** Advancing
+       * or ending the tour remounts this and resets `open` to false, so the
+       * step bar's End control never competes with an open panel. The key is
+       * constant off the tour, so a real review never remounts.
        *
        * Offered on an approved record, where it answers but cannot propose:
        * the backend withholds the tools once `status` is `approved` rather
@@ -483,7 +491,12 @@ export function ConsultationReview() {
        * note they have signed are the same questions, and a copilot that
        * disappears at sign-off looks like a bug from the outside.
        */}
-      {!isEphemeral && <CatatAI consultation={detail} onApply={applyProposal} />}
+      <CatatAI
+        key={isEphemeral ? `tour-${tour.currentStep}` : 'record'}
+        consultation={detail}
+        onApply={applyProposal}
+        demo={isEphemeral}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## What Changed

The guided tour now has a CatatAI step. It is anchored on the copilot's existing `[data-tour="catatai"]` button, which now renders on the tour's consultation in an inactive state that explains itself, so the coachmark has a real target and the doctor sees the real panel.

Closes #179

## The Honesty Claim: Kept, Not Amended

AC3 asked for a decision and this PR takes the first branch: **`HelpButton`'s "Nothing is mocked or replayed" is untouched, because it is still true.**

No scripted exchange was added. The panel renders its own genuine state and says why it is inactive: the tour's consultation is never saved, CatatAI reads a stored record, so there is nothing for it to open. What the step teaches is a description of the copilot, in the same register as every other coachmark hint in the tour, not a staged conversation.

The issue said a tour that only describes the copilot beats one that demonstrates a script while promising nothing is scripted. Amending that sentence would have traded the product's strongest honesty claim for a cosmetic demo, on the screen where an evaluator is most likely to be testing exactly that claim.

A source-scanning tripwire pins it: `DemoTour.test.tsx` asserts the promise string is still present in `HelpButton.tsx`. If someone later adds a canned exchange, that test fails and forces the decision to be deliberate rather than quiet.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `npx impeccable detect` clean on the UI diff

19 tests added across two new colocated files.

`DemoTour.test.tsx` (10): exactly one step targets the copilot anchor; `TOUR_STEP_COUNT` equals `TOUR_STEPS.length` so the dialog's number cannot drift from the array; the hint carries each of the three required claims, with the "never approve a note" and "retract a red flag" halves pinned separately because that is the claim most likely to be cut for brevity; the step is honest that the copilot is inactive; it lands before the Approval step; and the two guard cases on the no-mocking promise.

`CatatAI.test.tsx` (9): the anchor renders in demo mode; no composer, no chips, no expand control; `fetch` is stubbed to throw and is never called; the panel labels itself inactive inside the panel rather than only in the coachmark; it still teaches the three claims; it still closes. Plus a contrast case asserting the real panel keeps its composer and expand control, without which every demo assertion would still pass if the composer had simply been deleted for everybody.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider. The diff is frontend-only and removes a path rather than adding one
- [x] No provider SDK imported outside `backend/src/lib/llm/`. No dependency added
- [x] Deterministic red-flag hits remain unsuppressable by the model (untouched)
- [x] Citations remain ID-constrained; no free-text references accepted (untouched)
- [x] No transcript bodies, note contents, or vault entries written to logs (no logging added)
- [x] Fixtures added are synthetic. The only fixture is `{ id: 'demo-ephemeral' }`, which is the tour's own non-record id

Not on `.claude/rules/security.md`'s explicit-sign-off list: no egress, no tool, no backend change, no authz or logging surface touched.

## Notes For The Reviewer

**How the 404 is prevented, belt and braces.** `submit()` refuses when `demo`, and the composer, the suggestion chips and the expand control are not rendered at all. Rendering nothing that can call the route is the load-bearing half; the function guard is there so the one path to the route refuses regardless of how it is reached. A test stubs `fetch` to throw and asserts it is never called.

Writing that test caught a real bug in my first pass: I had gated the chips on `!demo` but left the `<form>` composer rendering, so a textarea and a Send button were still on screen during the tour. The guard in `submit()` would have stopped the request, but the control should never have been there.

**Why the expand control is hidden in demo mode.** The expanded state is a modal `<dialog>`, which takes the top layer and makes the tour's own step bar inert behind its backdrop. Escape would get out, so it is not a trap, but it is not worth offering for a panel holding four lines of static text (AC8).

**How the panel is guaranteed closed at the finish (AC7).** `ConsultationReview` keys the component on the tour step, so advancing or ending the tour remounts it and resets `open` to false. The key is a constant off the tour, so a real review never remounts. This is why the fix is one line rather than a close-signal prop threaded into the component.

**Step placement.** Deliberately before Approval rather than after: the strongest claim in the step is what the copilot cannot do, and the very next stop is the control it cannot press.

`TOUR_STEPS` is now exported. It was already module-private next to an exported `TOUR_STEP_COUNT` derived from it; exporting the array is what lets the tests assert against the steps rather than against a scraped source file.
