### PR TITLE
test(llm): pin the ASR relay as the only audio egress, not just rule it

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -50,7 +50,7 @@ Maps to OWASP LLM01 Prompt Injection, LLM02 Sensitive Information Disclosure, LL
 
 The hosted-ASR relay is the one audio egress (issue #154; `docs/trd.md` §20). Audio cannot be de-identified, so this path is governed by bounds, audit, and per-consultation consent, where consent is **required but not yet built**: the interaction ships with #155, the API enforces no consent signal today, and until then no client UI invokes the route.
 
-- `backend/src/routes/asr.ts` calling `transcribeWithIlmu` (`backend/src/lib/asr/ilmu.ts`) is the only path audio may take out of the API. No other module may call an ASR provider, and a provider SDK import here is a critical defect. The relay is native fetch by design; note that `no-stray-provider-sdk.test.ts`'s inventory names LLM vendors, so an ASR vendor SDK would currently pass it. The ban is this rule, not yet a guard.
+- `backend/src/routes/asr.ts` calling `transcribeWithIlmu` (`backend/src/lib/asr/ilmu.ts`) is the only path audio may take out of the API. No other module may call an ASR provider, and a provider SDK import here is a critical defect. **Two guards enforce this rather than review alone** (issue #172): `backend/src/lib/asr/no-stray-fetch.test.ts` pins the per-file inventory of outbound `fetch` calls in `backend/src`, today exactly one, in `ilmu.ts`; and `no-stray-provider-sdk.test.ts`'s package inventory now names transcription vendors alongside LLM ones, so an ASR SDK trips the same guard. The relay is native fetch by design, because ILMU publishes no SDK, which is why the call site needed a guard of its own: an SDK inventory structurally cannot see an egress that imports nothing.
 - `ILMU_API_KEY` is read only through `env`. Key unset means the route fails closed and visibly: 503 `asr_unavailable`, before any body is buffered and with no upstream call.
 - Nothing is persisted and no content is logged on this path. The audio exists in request-scoped memory only, the log line carries allowlisted fields only, and the audit pair (`asr.hosted_relayed` / `asr.hosted_relay_failed`) records billed seconds, a model id, and a closed failure reason, never content. The upstream response body is never read on a failure path, and a redirect is refused rather than followed, because on this route a request body is patient audio and a response body is a transcript.
 - Bounds, all of them deliberate: a route-level `express.raw` cap of 25 MB with `inflate: false` (ILMU's own request cap, unforgeable via `Content-Encoding`), the dedicated `hostedAsrRateLimit` (5/min per `clientKey`), a process-wide in-flight gate (`MAX_CONCURRENT_RELAYS`, 503 when full, because the per-key limiter cannot bound memory), a 120 s `AbortSignal.timeout`, and no retries.
@@ -133,7 +133,15 @@ OWASP promoted Software Supply Chain Failures to A03:2025, and it is this repo's
 - Before adding a dependency: prefer well-known, actively maintained packages, check open advisories, and avoid versions published in the last few days. Most malicious releases are pulled within hours, so a short cooldown catches them.
 - Keep the CI secret surface at one entry (`secrets.VERCEL_TOKEN`). Project and org IDs are identifiers, not credentials, and stay inline.
 - **Not built today:** no `bun audit`, no Dependabot or Renovate, no secret scanning, no SAST. The "Confidentiality check" greps engagement terms, not credentials. State this as an open gap rather than implying coverage.
-- **Architectural invariants are enforced by source-scanning guard tests.** Three exist: `backend/src/audit/no-stray-audit-writes.test.ts`, `backend/src/clinical-versions/no-stray-clinical-constants.test.ts`, and `backend/src/lib/llm/no-stray-provider-sdk.test.ts`, which pins the single-provider-SDK rule under "LLM Egress" above. Follow that shape for any invariant the type system cannot express, and check the open issues rather than this line for which one is worth writing next.
+- **Architectural invariants are enforced by source-scanning guard tests.** Six exist, all named `no-stray-*`, so `find backend/src -name 'no-stray-*.test.ts'` is the authority rather than this list:
+  - `audit/no-stray-audit-writes.test.ts`: every audit write goes through `recordAuditEvent`
+  - `clinical-versions/no-stray-clinical-constants.test.ts`: version constants have one home
+  - `deid/no-stray-brand-casts.test.ts`: only `deid/` mints the `Deidentified` brand
+  - `routes/no-stray-approval.test.ts`: `approved` is unreachable without an explicit clinician action
+  - `lib/llm/no-stray-provider-sdk.test.ts`: one provider SDK repo-wide, LLM and transcription vendors alike
+  - `lib/asr/no-stray-fetch.test.ts`: the outbound `fetch` inventory under "ASR Egress"
+
+  Follow that shape for any invariant the type system cannot express, and check the open issues rather than this line for which one is worth writing next.
 
 ## Changes That Need Explicit Human Sign-Off
 

--- a/backend/src/lib/asr/no-stray-fetch.test.ts
+++ b/backend/src/lib/asr/no-stray-fetch.test.ts
@@ -1,0 +1,204 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * GitHub issue #172, closing a gap left open by #171.
+ *
+ * `.claude/rules/security.md` says the ASR relay is the only path audio may
+ * take out of the API, and that no other module may call an ASR provider. Until
+ * now that was a sentence rather than a check. The sibling guard
+ * `no-stray-provider-sdk.test.ts` catches a vendor arriving as an SDK import;
+ * this one catches the case that guard structurally cannot see, which is the
+ * case the relay itself is built on: an outbound call made with native `fetch`
+ * and no dependency to notice.
+ *
+ * Three decisions, all deliberate:
+ *
+ * 1. **Calls are resolved from the AST, never matched as text.** Measured on
+ *    the real file before writing this: `backend/src/lib/asr/ilmu.ts` contains
+ *    two occurrences of the string `fetch`, one of which is the prose in its
+ *    own header explaining why native fetch was chosen over the SDK. A text
+ *    scan would either count that comment or need an `isComment` heuristic to
+ *    excuse it. Parsing means prose naming the pattern cannot trip the guard,
+ *    which matters most for a rule whose documentation has to discuss it.
+ * 2. **The inventory is pinned per file, not allowlisted by path.** A second
+ *    outbound call inside the file already permitted to make one is exactly the
+ *    change worth catching, and a path allowlist would wave it through. Same
+ *    argument as the per-file pin in `no-stray-brand-casts.test.ts`.
+ * 3. **The scan keys on the call site, not on the hostname.** The ILMU base URL
+ *    lives in `env`, so a hostname scan would read a variable name and prove
+ *    nothing. What is invariant is that an outbound call exists at all.
+ *
+ * Scope is `backend/src` only. The SPA calls `fetch` on every screen and is a
+ * different boundary entirely: it holds no provider key and reaches only our
+ * own API. Test files are exempt because a test that stubs or asserts on
+ * `fetch` is describing the boundary rather than crossing it.
+ */
+const REPO_ROOT = fileURLToPath(new URL('../../../../', import.meta.url))
+
+const SCANNED_DIR = 'backend/src'
+
+/**
+ * The complete, intended inventory of outbound `fetch` calls in the API.
+ *
+ * One entry, and it is the audio egress the rule names. `transcribeWithIlmu`
+ * uses native fetch because ILMU publishes no SDK (checked against the npm
+ * registry when this guard was written, so there is no package name for
+ * `no-stray-provider-sdk.test.ts` to pin either), and because importing a
+ * second vendor SDK would trip that guard by design.
+ *
+ * Adding an entry here is the reviewable decision this test exists to force:
+ * every one is a new path by which data leaves the API without passing the
+ * de-identification gate, which raw audio structurally cannot pass.
+ */
+const EXPECTED_FETCH_CALLS: ReadonlyMap<string, number> = new Map([
+  ['backend/src/lib/asr/ilmu.ts', 1],
+])
+
+function sourceFiles(): string[] {
+  const found: string[] = []
+
+  const walk = (absolute: string) => {
+    for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+      const child = join(absolute, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name !== 'node_modules') walk(child)
+      } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+        found.push(relative(REPO_ROOT, child).replaceAll('\\', '/'))
+      }
+    }
+  }
+
+  walk(join(REPO_ROOT, SCANNED_DIR))
+  return found
+}
+
+/**
+ * True for the call forms that actually reach the network.
+ *
+ * `fetch(...)` covers the global. The property form covers `globalThis.fetch`
+ * and any aliased holder, which is the shape someone reaches for when working
+ * around a guard they have noticed.
+ */
+function isFetchCall(node: ts.Node): boolean {
+  if (!ts.isCallExpression(node)) return false
+  const callee = node.expression
+  if (ts.isIdentifier(callee)) return callee.text === 'fetch'
+  if (ts.isPropertyAccessExpression(callee)) return callee.name.text === 'fetch'
+  return false
+}
+
+function fetchCalls(paths: readonly string[]): string[] {
+  const found: string[] = []
+
+  for (const path of paths) {
+    const text = readFileSync(join(REPO_ROOT, path), 'utf8')
+    const source = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true)
+
+    const visit = (node: ts.Node) => {
+      if (isFetchCall(node)) {
+        const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1
+        found.push(`${path}:${line}`)
+      }
+      ts.forEachChild(node, visit)
+    }
+
+    visit(source)
+  }
+
+  return found
+}
+
+/** `['a.ts:1', 'a.ts:9']` to `{ 'a.ts': 2 }`. */
+function countByFile(locations: readonly string[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const location of locations) {
+    const path = location.slice(0, location.lastIndexOf(':'))
+    counts.set(path, (counts.get(path) ?? 0) + 1)
+  }
+  return counts
+}
+
+describe('only the ASR relay egresses with fetch (issue #172)', () => {
+  it('finds source to scan, so an empty pass means something', () => {
+    const scanned = sourceFiles()
+
+    // A walk that silently returns nothing passes every assertion below
+    // forever. The floor is deliberately well under the real count so it
+    // survives ordinary refactoring, and well over zero.
+    expect(
+      scanned.length,
+      'scanned almost no files under backend/src; the walk is broken or the tree moved',
+    ).toBeGreaterThan(20)
+
+    expect(
+      scanned,
+      'the one file the inventory pins was not scanned, so the inventory below proves nothing',
+    ).toContain('backend/src/lib/asr/ilmu.ts')
+  })
+
+  it('excludes test files, which describe the boundary rather than cross it', () => {
+    expect(sourceFiles().every((path) => !path.endsWith('.test.ts'))).toBe(true)
+  })
+
+  it('resolves the call forms that reach the network', () => {
+    const forms = [
+      'await fetch(url)',
+      'fetch(url, { method: "POST" })',
+      'const r = await globalThis.fetch(url)',
+      'const r = await undici.fetch(url)',
+    ]
+
+    for (const form of forms) {
+      const source = ts.createSourceFile('probe.ts', form, ts.ScriptTarget.Latest, true)
+      let hits = 0
+      const visit = (node: ts.Node) => {
+        if (isFetchCall(node)) hits += 1
+        ts.forEachChild(node, visit)
+      }
+      visit(source)
+
+      expect(hits, `${JSON.stringify(form)} should be caught exactly once`).toBe(1)
+    }
+  })
+
+  it('does not fire on prose or on unrelated identifiers', () => {
+    const benign = [
+      '// Native fetch and FormData, deliberately not the OpenAI SDK',
+      'const note = "the relay calls fetch(url) directly"',
+      'const data = await prefetch(url)',
+      'const rows = await repository.fetchAll()',
+      'type Fetcher = typeof fetch',
+    ]
+
+    for (const form of benign) {
+      const source = ts.createSourceFile('probe.ts', form, ts.ScriptTarget.Latest, true)
+      let hits = 0
+      const visit = (node: ts.Node) => {
+        if (isFetchCall(node)) hits += 1
+        ts.forEachChild(node, visit)
+      }
+      visit(source)
+
+      expect(hits, `${JSON.stringify(form)} should not be caught`).toBe(0)
+    }
+  })
+
+  it('matches the intended inventory exactly, file by file', () => {
+    const actual = countByFile(fetchCalls(sourceFiles()))
+
+    expect(
+      Object.fromEntries([...actual].sort()),
+      'An outbound fetch call appeared, moved, or disappeared in backend/src. ' +
+        'The ASR relay is the only egress that may make one, because audio ' +
+        'cannot be de-identified and is therefore governed by bounds, audit ' +
+        'and per-consultation consent instead. Text egress goes through ' +
+        'deid/ then LLMClient. If a new outbound call is genuinely required, ' +
+        'adding it to EXPECTED_FETCH_CALLS is the reviewable decision this ' +
+        'test exists to force.',
+    ).toEqual(Object.fromEntries([...EXPECTED_FETCH_CALLS].sort()))
+  })
+})

--- a/backend/src/lib/llm/no-stray-provider-sdk.test.ts
+++ b/backend/src/lib/llm/no-stray-provider-sdk.test.ts
@@ -49,8 +49,20 @@ const SCANNED_TREES = [
  * Exact package names. Scoped families that publish one adapter per provider
  * are matched by prefix below instead, because enumerating them goes stale the
  * day a new provider ships.
+ *
+ * **Transcription vendors belong here too** (issue #172). The list named LLM
+ * vendors only, so an ASR SDK was a second egress that would have passed the
+ * build: `.claude/rules/security.md` bans one under "ASR Egress", and until now
+ * nothing checked. Audio is the worse case of the two, because it cannot be
+ * de-identified at all.
+ *
+ * ILMU itself contributes no entry. It publishes no npm package (checked
+ * against the registry when this list was extended), which is precisely why
+ * `backend/src/lib/asr/ilmu.ts` is written against native fetch, and why that
+ * call is pinned separately by `no-stray-fetch.test.ts`.
  */
 const PROVIDER_PACKAGES = new Set([
+  // Text
   'openai',
   '@google/genai',
   '@google/generative-ai',
@@ -59,9 +71,17 @@ const PROVIDER_PACKAGES = new Set([
   'cohere-ai',
   'groq-sdk',
   'replicate',
+  // Transcription
+  '@deepgram/sdk',
+  'assemblyai',
+  '@google-cloud/speech',
+  '@aws-sdk/client-transcribe',
+  'microsoft-cognitiveservices-speech-sdk',
+  '@azure/cognitiveservices-speech-sdk',
+  'revai-node-sdk',
 ])
 
-const PROVIDER_SCOPES = ['@ai-sdk/', '@mistralai/']
+const PROVIDER_SCOPES = ['@ai-sdk/', '@mistralai/', '@speechmatics/']
 
 /** `import x from 'y'`, `import 'y'`, `require('y')`, `await import('y')`. */
 const SPECIFIER = /(?:\bfrom\s*|\bimport\s*|\bimport\s*\(\s*|\brequire\s*\(\s*)['"]([^'"]+)['"]/g
@@ -155,6 +175,14 @@ describe('only lib/llm imports a provider SDK (issue #81)', () => {
       'ai',
       '@ai-sdk/openai',
       '@mistralai/mistralai',
+      // Transcription vendors, added by #172. An ASR SDK is the egress this
+      // list used to miss entirely.
+      '@deepgram/sdk',
+      '@deepgram/sdk/client',
+      'assemblyai',
+      '@google-cloud/speech',
+      '@aws-sdk/client-transcribe',
+      '@speechmatics/batch-client',
     ]) {
       expect(isProviderSdk(specifier), `${specifier} should be caught`).toBe(true)
     }
@@ -166,6 +194,11 @@ describe('only lib/llm imports a provider SDK (issue #81)', () => {
       './ai.js',
       '../lib/llm/index.js',
       'vitest',
+      // Neighbours of the transcription entries that must not be swept up:
+      // one is our own AWS client for a different service, one is a lookalike.
+      '@aws-sdk/client-s3',
+      'assemblyai-utils',
+      './asr/ilmu.js',
     ]) {
       expect(isProviderSdk(specifier), `${specifier} should not be caught`).toBe(false)
     }


### PR DESCRIPTION
## What Changed

The audio-egress boundary is now a failing build rather than a sentence in `.claude/rules/security.md`. Both findings deferred from #171 are closed: a new guard pins the outbound `fetch` inventory, and the provider-SDK guard's package list now covers transcription vendors as well as LLM ones.

Closes #172

## The Inventory, Verified Rather Than Assumed

AC1 asked for the real inventory to be checked during implementation rather than taken from the issue. It was, and it matches what the issue expected:

- **Exactly one production `fetch(` in `backend/src`**, at `backend/src/lib/asr/ilmu.ts:106`.
- **The copilot route from #170 carries none.** It imports `LLMResponseError` from `lib/llm/` and egresses through `LLMClient`. Its only mention of `fetch` is a comment about the *browser* reading the SSE stream.
- **ILMU publishes no npm package.** Checked against the registry rather than guessed, so there is no package name to add to `PROVIDER_PACKAGES` either. This is the whole reason the call site needed its own guard: an SDK inventory structurally cannot see an egress that imports nothing.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`

**The guard was mutation-tested, not just observed passing.** A probe file containing `await fetch("https://example.com")` was planted in `backend/src/lib/asr/`, the suite was run, and the inventory assertion failed naming the probe by path. The probe was then removed. A source-scanning test that has never been seen to fail is indistinguishable from one that walks zero files.

Five cases in the new file: the anti-vacuity floor (over 20 files scanned, and the one pinned file present among them), test-file exclusion, the call forms that reach the network, the benign forms that must not fire, and the per-file inventory itself.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider. This diff removes the possibility of an unnoticed one; it adds no code that runs in production
- [x] No provider SDK imported outside `backend/src/lib/llm/`. The guard that enforces this is what the diff strengthens
- [x] Deterministic red-flag hits remain unsuppressable by the model (untouched)
- [x] Citations remain ID-constrained; no free-text references accepted (untouched)
- [x] No transcript bodies, note contents, or vault entries written to logs (untouched)
- [x] Fixtures added are synthetic (none added)

Not on the explicit-sign-off list: this adds a guard rather than relaxing one, and ships no runtime code.

## Notes For The Reviewer

**Why the AST, when the sibling guard uses text with a comment-skip.** `ilmu.ts` contains two occurrences of the string `fetch`, and one of them is the prose in its own header explaining why native fetch was chosen over the SDK. A text scan would either count that comment or need a heuristic to excuse it. Parsing means a rule whose documentation has to discuss the pattern cannot trip over its own explanation. This follows the argument already made at length in `no-stray-brand-casts.test.ts`.

**Why per-file counts rather than a path allowlist.** A second outbound call inside the file already permitted to make one is exactly the change worth catching, and a path allowlist waves it through.

**Why the scan keys on the call site, not the hostname.** The ILMU base URL lives in `env`, so a hostname scan would read a variable name and prove nothing. What is invariant is that an outbound call exists at all.

**One correction slightly outside the strict diff, flagged rather than slipped in.** `security.md` claimed three source-scanning guards existed. The real count was five before this change: it was missing `no-stray-brand-casts.test.ts` and `no-stray-approval.test.ts`. Adding a sixth meant the number had to be right, so the line is now a list of all six plus the `find` command that generates it, which makes the next staleness a command away rather than a recount.

`PROVIDER_PACKAGES` gains seven transcription vendors and one scope prefix (`@speechmatics/`). The repo-wide import inventory assertion is unchanged and still `['openai']`, per AC2. Three new negative cases guard the additions against over-matching: `@aws-sdk/client-s3` (a different AWS service), `assemblyai-utils` (a lookalike), and a relative import of our own ASR module.
