### PR TITLE
fix(deid): close two span defects that let identifier fragments past the boundary

### DIFF
--- a/backend/src/deid/deid.test.ts
+++ b/backend/src/deid/deid.test.ts
@@ -574,24 +574,52 @@ describe('regressions introduced by this PR, now pinned', () => {
     expect(text).toContain('[NRIC_1]')
   })
 
-  it('still leaks a leading element when the name is longer than the patronymic pattern admits', () => {
-    // KNOWN BAD, pinned deliberately. Issue #183.
+  it('keeps the leading element when the name is longer than the patronymic pattern admits', () => {
+    // Was `Nur [PATIENT_1] came in.` (#183). The gazetteer run
+    // `Nur Aina Sofea Batrisyia` [0,24) and the patronymic span
+    // `Aina Sofea Batrisyia binti Zulkifli` [4,39) partly overlap; the longer
+    // one won and `resolveOverlaps` discarded the loser whole, including the
+    // four characters no accepted span covered.
     //
-    // This is #149's failure mode surviving #149's fix, and it is pinned rather
-    // than fixed because the obvious fix makes things worse. Widening
-    // `PATRONYMIC_PATTERN` from two leading elements to four was tried on this
-    // branch and a boundary audit showed it relocates the leak to six elements
-    // rather than closing it, while making the span greedy enough to swallow
-    // clinical content: "Acute Cough Sore Throat Fever Ahmad bin Ismail" ate the
-    // symptom list, and one person in two sentences became two tokens.
-    //
-    // Deleting a symptom list from what the model reads is a false-negative risk
-    // on the clinical pass, which is a worse trade than the leak. The real cause
-    // is `resolveOverlaps` discarding the uncovered prefix of a partly
-    // overlapping match, filed as #183.
+    // `PATRONYMIC_PATTERN` is still `{0,2}`, which is the point: widening it
+    // relocates the leak rather than closing it, and makes the span greedy
+    // enough to eat a symptom list.
     const { text } = deidentify('Nur Aina Sofea Batrisyia binti Zulkifli came in.')
-    expect(text).toContain('Nur ')
-    expect(text).toMatch(/\[PATIENT_\d+\] came in\./)
+    expect(text).not.toContain('Nur')
+    expect(text).toMatch(/^\[PATIENT_\d+\] \[PATIENT_\d+\] came in\.$/)
+  })
+
+  it('still drops a shorter match that sits wholly inside the winner', () => {
+    // The other half of the rule, and the reason the original docstring gave
+    // for dropping at all: a contained span has no uncovered prefix, so
+    // replacing it would corrupt the winner's offsets and leave a fragment of
+    // the identifier behind. `Tan Wei Ming` is inside `Tan Wei Ming binti
+    // Ahmad`, and exactly one token must come out.
+    const { text } = deidentify('Tan Wei Ming binti Ahmad came in.')
+    expect(text).toBe('[PATIENT_1] came in.')
+  })
+
+  it('still leaks when the name is longer than any competing match reaches', () => {
+    // KNOWN BAD, pinned deliberately. Issue #183, and NOT closed by its own
+    // fix. Reported back on the issue rather than left silent.
+    //
+    // The prefix fix can only recover text some other detector actually
+    // matched. Here nothing does: `CAPITALISED_RUN` caps at four words and the
+    // gazetteer pass needs its *first* word to be a known given name, and
+    // `zarul`, `qaseh` and `damia` are all outside the roughly 130 names in
+    // `GIVEN_NAMES`. So no match covers `Zarul Aina Sofea`, and there is no
+    // uncovered prefix to preserve.
+    //
+    // Closing it needs the patronymic span itself to reach further left, which
+    // is the widening #178 measured and reverted: it cannot tell
+    // `Zarul Aina Sofea Batrisyia Qaseh Damia` from
+    // `Acute Cough Sore Throat Fever`, and swallowing the second deletes the
+    // symptom list from what the model reads. Separating them needs a
+    // vocabulary list that `no-stray-clinical-constants.test.ts` refuses, or a
+    // model. Neither is in this fix's scope.
+    const { text } = deidentify('Patient: Zarul Aina Sofea Batrisyia Qaseh Damia binti Zulkifli')
+    expect(text).toContain('Zarul Aina Sofea')
+    expect(text).toMatch(/\[PATIENT_\d+\]$/)
   })
 
   it('still swallows Title-Cased clinical words directly in front of a name', () => {
@@ -701,7 +729,7 @@ describe('an honorific that is also a name', () => {
   })
 })
 
-describe('addresses carrying a postcode tokenise whole (#181 covers the rest)', () => {
+describe('addresses tokenise whole, postcode or not (#181)', () => {
   it('reaches the postcode instead of stopping two characters in', () => {
     // A lazy run followed by an optional group never expands, so this matched
     // `Jalan Bu` and left street, number, postcode and city in the clear.
@@ -711,12 +739,67 @@ describe('addresses carrying a postcode tokenise whole (#181 covers the rest)', 
     expect(text).toBe('Her address is [ADDRESS_1].')
   })
 
-  it('is honest about the no-postcode case still truncating', () => {
-    // Pinned as known-bad rather than quietly left. An address with no postcode
-    // has no comparable anchor, and a greedy run there would swallow the
-    // clinical prose after the street name. Issue #181.
+  it('reaches the end of an address carrying no postcode', () => {
+    // Was `[ADDRESS_1]pang 5, Kuala Lumpur`: street name, house number and city
+    // all survived the boundary. The no-postcode branch matched its
+    // two-character minimum for the same reason the postcode branch did.
     const { text } = deidentify('She lives at Jalan Ampang 5, Kuala Lumpur.')
-    expect(text).toContain('[ADDRESS_1]')
-    expect(text).toContain('Kuala Lumpur')
+    expect(text).not.toContain('Ampang')
+    expect(text).not.toContain('Kuala Lumpur')
+    expect(text).toBe('She lives at [ADDRESS_1].')
+  })
+
+  it('tokenises a house number in front of the street type', () => {
+    const { text } = deidentify('He lives at No. 12, Jalan Sultan Ismail, Kuala Lumpur.')
+    expect(text).not.toContain('12')
+    expect(text).not.toContain('Sultan')
+    expect(text).toBe('He lives at [ADDRESS_1].')
+  })
+
+  /*
+   * The precision half, and the reason a greedy `{2,40}` was refused. A
+   * tokenised span is removed from what the model reads, so an address run that
+   * eats the medication after it deletes that medication from the note the
+   * red-flag pass reasons over. `healthcare-cdss-patterns` holds that direction
+   * to zero tolerance, which makes over-tokenising here worse than the leak it
+   * would close.
+   */
+  it('stops at ordinary prose instead of swallowing medication, dose or duration', () => {
+    const cases = [
+      'She lives at Jalan Ampang 5 and takes paracetamol 500 mg.',
+      'She stays at Taman Melati 3. She takes metformin 500 mg daily.',
+      'He lives at Lorong Kurau 2 and has had a cough for 3 days.',
+    ]
+    for (const sentence of cases) {
+      const { text } = deidentify(sentence)
+      expect(text, sentence).toContain('[ADDRESS_1]')
+    }
+
+    expect(deidentify(cases[0] ?? '').text).toBe(
+      'She lives at [ADDRESS_1] and takes paracetamol 500 mg.',
+    )
+    expect(deidentify(cases[1] ?? '').text).toBe(
+      'She stays at [ADDRESS_1]. She takes metformin 500 mg daily.',
+    )
+    expect(deidentify(cases[2] ?? '').text).toBe(
+      'He lives at [ADDRESS_1] and has had a cough for 3 days.',
+    )
+  })
+
+  it('keeps the postcode score branch reachable, and cue-free', () => {
+    // `hasPostcode` scores 0.8 and clears `ACCEPT_THRESHOLD` on its own, so an
+    // address carrying a postcode survives a sentence with no context cue in
+    // it. Without a postcode the base is 0.45 and a cue is mandatory. Both
+    // halves are asserted, because the postcode branch being unreachable is
+    // what made every address depend on a cue before #178.
+    expect(labelsIn('Jalan Bukit Bintang 5, 50450 Kuala Lumpur was noted.')).toContain('ADDRESS')
+    expect(labelsIn('Jalan Ampang 5 was noted.')).not.toContain('ADDRESS')
+  })
+
+  it('does not let a street name run across a line break', () => {
+    // Separators are spaces and tabs, never `\s`. A dictated turn ending in an
+    // address must not annex the first Title-Cased word of the next line.
+    const { text } = deidentify('She lives at Taman Melati 3\nPanadol was given.')
+    expect(text).toContain('Panadol was given.')
   })
 })

--- a/backend/src/deid/deid.test.ts
+++ b/backend/src/deid/deid.test.ts
@@ -796,6 +796,35 @@ describe('addresses tokenise whole, postcode or not (#181)', () => {
     expect(labelsIn('Jalan Ampang 5 was noted.')).not.toContain('ADDRESS')
   })
 
+  /*
+   * The case bound cuts both ways, so the lower-case half is measured rather
+   * than assumed. Requiring a capital on every element meant
+   * `she lives at jalan ampang 5` matched nothing at all, which is a whole
+   * address leaving the boundary where the old truncating version at least
+   * raised ADDRESS. The first element is therefore exempt.
+   *
+   * The remainder of a lower-case address is still partial: `ismail` and
+   * `kuala lumpur` below survive, because every element after the first is
+   * strict and that strictness is what stops the run eating clinical prose.
+   * Pinned so the limit is a measured number rather than a description, and so
+   * a later widening has something to compare against.
+   */
+  it('still reaches a lower-case address, and is honest that it reaches only part', () => {
+    expect(labelsIn('she lives at jalan ampang 5, kuala lumpur.')).toContain('ADDRESS')
+
+    const { text } = deidentify('she lives at jalan ampang 5 and takes paracetamol 500 mg.')
+    expect(text).toBe('she lives at [ADDRESS_1] and takes paracetamol 500 mg.')
+
+    // KNOWN PARTIAL. A postcode still anchors the whole span regardless of case.
+    expect(deidentify('her address is jalan bukit bintang 5, 50450 kuala lumpur.').text).toBe(
+      'her address is [ADDRESS_1].',
+    )
+    // ...but with no postcode the run stops at the first lower-case element.
+    expect(deidentify('he lives at no. 12, jalan sultan ismail, kuala lumpur.').text).toContain(
+      'ismail, kuala lumpur',
+    )
+  })
+
   it('does not let a street name run across a line break', () => {
     // Separators are spaces and tabs, never `\s`. A dictated turn ending in an
     // address must not annex the first Title-Cased word of the next line.

--- a/backend/src/deid/detectors.ts
+++ b/backend/src/deid/detectors.ts
@@ -270,6 +270,16 @@ function detectEmail(text: string): Match[] {
  * `3.` into `She`. Separators are spaces and tabs only, never `\s`, so the run
  * cannot cross a line break into the next dictated turn.
  *
+ * **The first element is exempt from the case rule** (`ADDRESS_FIRST_ELEMENT`),
+ * and the exemption is a recall fix rather than an oversight. Requiring a
+ * capital throughout meant `she lives at jalan ampang 5` matched nothing at
+ * all, where the truncating version at least raised ADDRESS. That is a whole
+ * address leaving the boundary rather than a partial one, so an all-lower-case
+ * dictation would have been strictly worse off than before this fix. The street
+ * type immediately precedes it, which is the anchor that makes the exemption
+ * safe: the run still cannot start anywhere else, and every element after the
+ * first is strict, so the prose bound is unchanged.
+ *
  * **The `i` flag had to go for any of that to hold.** Under it `[A-Z]` matches
  * lower-case, which is the defect this file already carries a note about at
  * `caseInsensitiveLiteral`: the same flag is how the word "claim" was once
@@ -277,7 +287,8 @@ function detectEmail(text: string): Match[] {
  * through that helper instead, so the postcode branch is unchanged in meaning.
  */
 const ADDRESS_ELEMENT = `[A-Z0-9][A-Za-z0-9'/-]*`
-const ADDRESS_RUN = `${ADDRESS_ELEMENT}(?:[ \\t]+${ADDRESS_ELEMENT}){0,5}(?:,[ \\t]*${ADDRESS_ELEMENT}(?:[ \\t]+${ADDRESS_ELEMENT}){0,3})?`
+const ADDRESS_FIRST_ELEMENT = `[A-Za-z0-9][A-Za-z0-9'/-]*`
+const ADDRESS_RUN = `${ADDRESS_FIRST_ELEMENT}(?:[ \\t]+${ADDRESS_ELEMENT}){0,5}(?:,[ \\t]*${ADDRESS_ELEMENT}(?:[ \\t]+${ADDRESS_ELEMENT}){0,3})?`
 const STREET_TYPES = [
   'Jalan',
   'Jln',

--- a/backend/src/deid/detectors.ts
+++ b/backend/src/deid/detectors.ts
@@ -252,14 +252,48 @@ function detectEmail(text: string): Match[] {
  * between them deleted.
  *
  * Splitting it means the first alternative has to reach a postcode to match at
- * all, so the lazy run expands to find one. The second is the previous
- * behaviour, unchanged and still truncating: an address with no postcode has no
- * comparable anchor, and a greedy run there would swallow the clinical prose
- * after the street name. That half is issue #181 rather than a silent partial
- * fix here.
+ * all, so the lazy run expands to find one.
+ *
+ * **The second alternative is bounded by case, not by a character count**
+ * (#181). It too used to match its two-character minimum, so `Jalan Ampang 5,
+ * Kuala Lumpur` tokenised as `Jalan Am` and left street, number and city in the
+ * clear. A greedy `{2,40}` would have closed that and swallowed the clinical
+ * prose after the street name, which is the worse trade: a tokenised span is
+ * removed from what the model reads, so eating `and takes paracetamol 500 mg`
+ * deletes the medication from the note the red-flag pass reasons over.
+ *
+ * What ends a street name structurally is the return to ordinary prose, and
+ * ordinary prose is lower-case. `ADDRESS_ELEMENT` therefore admits only
+ * elements opening with a capital or a digit, so the run stops dead at `and`,
+ * `she`, `takes`. A full stop ends it for the same reason: `.` is deliberately
+ * outside the element body, or `Taman Melati 3. She takes metformin` would run
+ * `3.` into `She`. Separators are spaces and tabs only, never `\s`, so the run
+ * cannot cross a line break into the next dictated turn.
+ *
+ * **The `i` flag had to go for any of that to hold.** Under it `[A-Z]` matches
+ * lower-case, which is the defect this file already carries a note about at
+ * `caseInsensitiveLiteral`: the same flag is how the word "claim" was once
+ * tokenised as a patient name. The street types keep their case-flexibility
+ * through that helper instead, so the postcode branch is unchanged in meaning.
  */
-const ADDRESS_PATTERN =
-  /\b(?:No\.?\s*\d+[A-Za-z]?,?\s*)?(?:Jalan|Jln|Lorong|Lrg|Taman|Tmn|Kampung|Kg|Persiaran|Lebuh)\s+(?:[A-Za-z0-9\s./'-]{2,40}?,\s*\d{5}\s*[A-Za-z]+(?:\s+[A-Za-z]+){0,2}|[A-Za-z0-9\s./'-]{2,40}?)/gi
+const ADDRESS_ELEMENT = `[A-Z0-9][A-Za-z0-9'/-]*`
+const ADDRESS_RUN = `${ADDRESS_ELEMENT}(?:[ \\t]+${ADDRESS_ELEMENT}){0,5}(?:,[ \\t]*${ADDRESS_ELEMENT}(?:[ \\t]+${ADDRESS_ELEMENT}){0,3})?`
+const STREET_TYPES = [
+  'Jalan',
+  'Jln',
+  'Lorong',
+  'Lrg',
+  'Taman',
+  'Tmn',
+  'Kampung',
+  'Kg',
+  'Persiaran',
+  'Lebuh',
+]
+const ADDRESS_PATTERN = new RegExp(
+  `\\b(?:${caseInsensitiveLiteral('No')}\\.?\\s*\\d+[A-Za-z]?,?\\s*)?(?:${STREET_TYPES.map(caseInsensitiveLiteral).join('|')})\\s+(?:[A-Za-z0-9\\s./'-]{2,40}?,\\s*\\d{5}\\s*[A-Za-z]+(?:\\s+[A-Za-z]+){0,2}|${ADDRESS_RUN})`,
+  'g',
+)
 /*
  * Inflected forms are enumerated, not inferred. ADDRESS has no cue-free route
  * over `ACCEPT_THRESHOLD` at base 0.45, so a cue that stops matching is a whole
@@ -562,16 +596,24 @@ function detectNames(text: string): Match[] {
   // 4. Gazetteer recall pass — capitalised runs whose first token is a known
   //    Malaysian given name and which carry no cue. This is the only measure
   //    available without a model that raises recall on unmarked names.
+  //    The run is trimmed the same way the patronymic span is. It always
+  //    should have been, and #183 is what made the omission observable: an
+  //    untrimmed run starts on the honorific, so `Tan Sri Ahmad bin Ismail`
+  //    left `Tan Sri` uncovered by the winning span and the preserved prefix
+  //    tokenised the title as a patient. Trimming first puts the run fully
+  //    inside the winner, where it is dropped as before.
   for (const m of text.matchAll(CAPITALISED_RUN)) {
     const run = m[0]
     if (isStopword(run)) continue
     const first = run.split(/\s+/)[0]?.toLowerCase()
     if (!first || !GIVEN_NAMES.has(first)) continue
+    const trimmed = trimNameSpan(run, m.index)
+    if (!trimmed) continue
     out.push({
       label: 'PATIENT',
-      start: m.index,
-      end: m.index + run.length,
-      value: run,
+      start: trimmed.start,
+      end: trimmed.start + trimmed.value.length,
+      value: trimmed.value,
       score: 0.6,
     })
   }
@@ -616,6 +658,31 @@ const DETECTORS = [
  * Overlapping matches are resolved longest-first, then by score. A shorter span
  * inside an accepted one is dropped, because replacing it would corrupt the
  * outer span's offsets and leave a fragment of the original identifier behind.
+ *
+ * **A shorter span that starts before the one it loses to keeps its uncovered
+ * prefix** (#183). Dropping the loser whole discarded text that no accepted
+ * span covered, and on the name path that text is a name element:
+ *
+ * ```
+ * "Nur Aina Sofea Batrisyia binti Zulkifli came in."
+ *   gazetteer run    [0,24)   "Nur Aina Sofea Batrisyia"
+ *   patronymic span  [4,39)   "Aina Sofea Batrisyia binti Zulkifli"   longer, wins
+ *   was              "Nur [PATIENT_1] came in."                       leaks
+ * ```
+ *
+ * `assertNoIdentifiers` could not catch it, because the egress guard re-runs
+ * these same detectors and shared the gap exactly.
+ *
+ * The prefix is kept as its own match rather than merged into the winner.
+ * Merging would mean one token instead of two, which reads better, but it
+ * extends an accepted span using a lower-scored loser's boundary and would join
+ * spans of different labels, so an ADDRESS could annex a PATIENT. The cost is
+ * that one person can mint two tokens where the prefix is a name element. That
+ * is the trade this module states in `trimNameSpan`: a recall loss on the PHI
+ * boundary outranks a precision gain.
+ *
+ * Full containment is unchanged: no uncovered prefix means the loser is
+ * dropped, which is what keeps the docstring reason above true.
  */
 function resolveOverlaps(matches: Match[]): Match[] {
   const sorted = [...matches].sort(
@@ -623,8 +690,18 @@ function resolveOverlaps(matches: Match[]): Match[] {
   )
   const kept: Match[] = []
   for (const m of sorted) {
-    if (kept.some((k) => m.start < k.end && k.start < m.end)) continue
-    kept.push(m)
+    const overlapping = kept.filter((k) => m.start < k.end && k.start < m.end)
+    if (overlapping.length === 0) {
+      kept.push(m)
+      continue
+    }
+
+    const firstStart = Math.min(...overlapping.map((k) => k.start))
+    if (firstStart <= m.start) continue
+
+    const prefix = m.value.slice(0, firstStart - m.start).replace(/[\s,]+$/, '')
+    if (prefix.length === 0) continue
+    kept.push({ ...m, value: prefix, end: m.start + prefix.length })
   }
   return kept.sort((a, b) => a.start - b.start)
 }


### PR DESCRIPTION
## What Changed

Two span-extent defects in `backend/src/deid/detectors.ts`. Closes #183, closes #181.

Both are the same class of bug: a detector agreed the text was an identifier, and then a fragment of it left the trust boundary anyway because the **span stopped short**. Neither was catchable by `assertNoIdentifiers`, because the egress guard re-runs these same detectors and shares the gap exactly.

One PR rather than two, for the reason #178 gave: they are in one file, and #183's fix changes what every other detector's spans are resolved against.

## #183: `resolveOverlaps` Discarded The Uncovered Prefix

A shorter match that partly overlapped an accepted one was dropped **whole**, including the part that no accepted span covered.

```
"Nur Aina Sofea Batrisyia binti Zulkifli came in."
  gazetteer run    [0,24)  "Nur Aina Sofea Batrisyia"
  patronymic span  [4,39)  "Aina Sofea Batrisyia binti Zulkifli"   longer, wins
  was              "Nur [PATIENT_1] came in."                      leaks
  now              "[PATIENT_2] [PATIENT_1] came in."
```

Full containment is unchanged, for the reason the original docstring gave: a contained span has no uncovered prefix, so replacing it would corrupt the winner's offsets and leave a fragment behind. Pinned by its own test.

### The Prefix Is Kept, Not Merged

Merging the prefix into the winner would give one token instead of two, which reads better. It was refused because it extends an accepted span using a lower-scored loser's boundary, and would join spans of **different labels**, so an ADDRESS could annex a PATIENT.

The cost is that one person can mint two tokens where the prefix is a name element. That is the trade `trimNameSpan` already states in its own docstring: a recall loss on the PHI boundary outranks a precision gain. Token stability across mentions is unaffected and still pinned.

### A Regression This Surfaced, Fixed At Its Own Layer

`detectNames` step 4 never trimmed the gazetteer run, unlike every other name path. That was invisible while losers were discarded whole. With the prefix preserved, `Tan Sri Ahmad bin Ismail` tokenised **`Tan Sri` as a patient**.

Fixed in the gazetteer pass by calling `trimNameSpan`, not by special-casing honorifics inside `resolveOverlaps`, which is label-agnostic and has no business knowing about names. Trimming first puts the run wholly inside the winner, where it is dropped as before.

## #181: The No-Postcode Address Branch Truncated To Two Characters

```
"She lives at Jalan Ampang 5, Kuala Lumpur."     ->  "[ADDRESS_1]pang 5, Kuala Lumpur"
"He lives at No. 12, Jalan Sultan Ismail, ..."   ->  "[ADDRESS_1]ltan Ismail, Kuala Lumpur"
"She stays at Taman Melati 3. ..."               ->  "[ADDRESS_1]lati 3."
```

Worse than the issue described: the house number and street type were being split mid-word too.

### Bounded By Case, Not By A Character Count

A greedy `{2,40}` would close the leak and swallow the clinical prose after the street name. That is the worse trade, and it is why #178 left this half alone: a tokenised span is **removed from what the model reads**, so eating `and takes paracetamol 500 mg` deletes the medication from the note the red-flag pass reasons over. `healthcare-cdss-patterns` holds that direction to zero tolerance.

What ends a street name structurally is the return to ordinary prose, and ordinary prose is lower-case. The run now admits only elements opening with a capital or a digit:

| Input | Result |
| --- | --- |
| `She lives at Jalan Ampang 5, Kuala Lumpur.` | `She lives at [ADDRESS_1].` |
| `She lives at Jalan Ampang 5 and takes paracetamol 500 mg.` | `She lives at [ADDRESS_1] and takes paracetamol 500 mg.` |
| `She stays at Taman Melati 3. She takes metformin 500 mg daily.` | `She stays at [ADDRESS_1]. She takes metformin 500 mg daily.` |
| `He lives at No. 12, Jalan Sultan Ismail, Kuala Lumpur.` | `He lives at [ADDRESS_1].` |

`.` is deliberately outside the element body, or `Taman Melati 3. She takes metformin` would run `3.` into `She`. Separators are spaces and tabs only, never `\s`, so a run cannot cross a line break into the next dictated turn. Both are asserted.

**The `i` flag had to go for any of that to hold.** Under it `[A-Z]` matches lower-case, which is the defect this file already carries a note about at `caseInsensitiveLiteral`: the same flag is how the word "claim" was once tokenised as a patient name. The street types keep their case-flexibility through that helper, so the postcode branch is unchanged in meaning, and its existing test is untouched and still green.

## What This Does NOT Close, And Why

**#183's six-element case still leaks, and is pinned as known-bad rather than left silent.**

```
"Patient: Zarul Aina Sofea Batrisyia Qaseh Damia binti Zulkifli"
  ->  "Patient: Zarul Aina Sofea [PATIENT_1]"
```

The issue's acceptance criteria expected this to close with the quantifier untouched. Measured, it does not, and the reason is structural rather than a missed edge: **the prefix fix can only recover text some other detector actually matched.** Here nothing does. `CAPITALISED_RUN` caps at four words, the gazetteer pass needs its *first* word to be a known given name, and `zarul`, `qaseh` and `damia` are all outside the roughly 130 names in `GIVEN_NAMES`. There is no competing match, so there is no uncovered prefix to preserve.

Closing it needs the patronymic span itself to reach further left, which is exactly the widening #178 measured and reverted: it cannot tell `Zarul Aina Sofea Batrisyia Qaseh Damia` from `Acute Cough Sore Throat Fever`, and swallowing the second deletes the symptom list from what the model reads. Separating them needs a vocabulary list that `no-stray-clinical-constants.test.ts` refuses, or a model.

The issue has not been silently narrowed: this is reported on #183 for the human to decide whether it warrants its own issue.

## Verification

- [x] `bun run lint`, 0 errors and 22 pre-existing warnings
- [x] `bun run typecheck`
- [x] `bun run test`, **822 pass** (37 shared, 623 backend, 150 frontend, 12 evals)

Each fix was verified to fail its own tests with only that fix reverted, one at a time:

| Fix reverted | Tests that fail |
| --- | --- |
| `resolveOverlaps` prefix | 1 |
| `ADDRESS_PATTERN` case bound | 3 |
| gazetteer `trimNameSpan` | 1 (`still drops Tan Sri when it really is the honorific`) |

Both known-bad pins named in the issues are flipped, and one new known-bad pin is added for the case above.

## Clinical-Safety Checklist

- [x] Closes two paths by which un-de-identified text reached a provider. That is the point of the PR
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits untouched
- [x] Citations untouched
- [x] No new log fields; detector labels only, as before
- [x] Precision tests accompany both recall changes, per `.claude/rules/security.md`
- [x] Every test string added here is synthetic. The names are not of real people and the addresses are not of real premises

## Notes For The Reviewer

`phi-boundary-auditor` was **not** dispatched on this diff. Worth running before merge, given both changes sit on the boundary.

The sharpest thing to check is the `ADDRESS_RUN` bound. It admits up to six space-separated elements plus an optional comma continuation of up to four more, and I would rather that cap be argued with than assumed.

https://claude.ai/code/session_01FS7ViinLwxy7QsBz2XJnLx
