### PR TITLE
test(copilot): measure the #185 tool-call rate and pin the phantom-click detector

### DIFF
--- a/backend/src/copilot/index.test.ts
+++ b/backend/src/copilot/index.test.ts
@@ -1,6 +1,7 @@
 import type { ConsultationDetail } from '@shared/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { StreamChunk, StreamRequest } from '../lib/llm/types.js'
+import { hasPhantomClickInstruction } from './phantom-click.js'
 
 /**
  * The copilot's de-identification boundary, which is the part of this feature
@@ -281,5 +282,52 @@ describe('a signed note', () => {
 
     expect(captured?.system).toContain('[PATIENT_1]')
     expect(captured?.system).not.toContain(PATIENT)
+  })
+})
+
+/**
+ * The phantom-click pin from GitHub issue #185, driven through the real turn
+ * rather than against a string, so it holds over what the doctor actually
+ * receives. The detector's own cases live in `phantom-click.test.ts`; what is
+ * added here is that it sees the pipeline's output, after the reasoning filter
+ * has taken its cut and after rehydration.
+ *
+ * That distinction is the whole reason this one is not a string test. A model
+ * that reasons about clicking inside a `<think>` block and then answers
+ * cleanly has not pointed the doctor at anything, and a detector run over the
+ * raw stream would call that a defect.
+ */
+describe('pointing at a card that was never rendered', () => {
+  it('flags a turn that says click while proposing nothing', async () => {
+    chunks = [
+      { type: 'text', text: 'That belongs in the plan. Click Apply on the card to add it.' },
+    ]
+
+    const out = await drain('add a safety net to the plan')
+    const text = out
+      .filter((chunk) => chunk.type === 'token')
+      .map((chunk) => chunk.text)
+      .join('')
+    const proposals = out.filter((chunk) => chunk.type === 'proposal').length
+
+    expect(proposals).toBe(0)
+    expect(hasPhantomClickInstruction(text, proposals)).toBe(true)
+  })
+
+  it('says nothing when the click language was only in the reasoning block', async () => {
+    chunks = [
+      { type: 'text', text: '<think>I should tell them to click Apply.</think>' },
+      { type: 'text', text: 'The plan does not yet say when she should return.' },
+    ]
+
+    const out = await drain('does the plan say when she should come back?')
+    const text = out
+      .filter((chunk) => chunk.type === 'token')
+      .map((chunk) => chunk.text)
+      .join('')
+    const proposals = out.filter((chunk) => chunk.type === 'proposal').length
+
+    expect(text).not.toMatch(/click/i)
+    expect(hasPhantomClickInstruction(text, proposals)).toBe(false)
   })
 })

--- a/backend/src/copilot/phantom-click.test.ts
+++ b/backend/src/copilot/phantom-click.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import { hasPhantomClickInstruction } from './phantom-click.js'
+
+/**
+ * The phantom-click detector (GitHub issue #185).
+ *
+ * This is a regression guard, not a reproduction of a defect. It was measured at
+ * 0 of 90 turns on the shipped prompt. It exists because the two prompt
+ * revisions trialled for #185 both moved the model toward talking about cards,
+ * and one of them started claiming a card was waiting when none was; both were
+ * rejected on the measurements, but the next attempt will push the same way.
+ * See §25 of `docs/trd.md`.
+ *
+ * The false-positive cases matter as much as the true ones. This runs over
+ * clinical prose, where `pressure` is in every set of vitals, so a detector that
+ * cried wolf on a blood-pressure reading would be discarded within a week and
+ * the real signal would go with it.
+ *
+ * Every inflection is spelled out below rather than sampled, because the bug
+ * this replaced was an inflection bug in both directions at once: a shared
+ * suffix group accepted `tapes` and silently dropped `tapping`, `tapped`,
+ * `clicked` and `pressed`. A detector that misses the past tense misses "once
+ * you have clicked Apply", which is the defect stated in the most natural way.
+ */
+
+describe('a turn that points at a card it never rendered', () => {
+  it('flags a click instruction when nothing was proposed', () => {
+    expect(
+      hasPhantomClickInstruction('You can click Apply on the card to add that to the plan.', 0),
+    ).toBe(true)
+  })
+
+  it('flags every inflection of all three verbs', () => {
+    for (const word of [
+      'click',
+      'clicks',
+      'clicked',
+      'clicking',
+      'tap',
+      'taps',
+      'tapped',
+      'tapping',
+      'press',
+      'presses',
+      'pressed',
+      'pressing',
+    ]) {
+      expect(hasPhantomClickInstruction(`You can ${word} Apply to accept it.`, 0)).toBe(true)
+    }
+  })
+
+  it('flags the past tense, which is how the defect is stated most naturally', () => {
+    // The regression that motivated spelling the inflections out. A doctor
+    // reading "once you have clicked Apply" has been told a card exists.
+    expect(hasPhantomClickInstruction('Once you have clicked Apply, the plan will read:', 0)).toBe(
+      true,
+    )
+    expect(hasPhantomClickInstruction('Tapping Apply will add it to the plan.', 0)).toBe(true)
+  })
+
+  it('ignores case', () => {
+    expect(hasPhantomClickInstruction('CLICK the button.', 0)).toBe(true)
+  })
+})
+
+describe('what must not be flagged', () => {
+  it('says nothing about a turn that did render a card', () => {
+    expect(hasPhantomClickInstruction('Proposed for the plan. Click Apply to accept it.', 1)).toBe(
+      false,
+    )
+  })
+
+  it('does not read a blood pressure as an instruction to press something', () => {
+    expect(hasPhantomClickInstruction('Blood pressure was 128/76 at triage.', 0)).toBe(false)
+    expect(hasPhantomClickInstruction('There is no record of her pressure today.', 0)).toBe(false)
+  })
+
+  it('does not match the word inside a longer one', () => {
+    for (const word of [
+      'clickbait',
+      'tapering',
+      'tapestry',
+      'tapas',
+      'taped',
+      'tapes',
+      'pressure',
+      'depress',
+      'compress',
+      'depressed',
+    ]) {
+      expect(hasPhantomClickInstruction(`The note mentions ${word} in passing.`, 0)).toBe(false)
+    }
+  })
+
+  it('does not read a steroid taper as an instruction to tap something', () => {
+    // `tapering` is in every plan that steps a dose down, and the pattern this
+    // replaced matched it.
+    expect(hasPhantomClickInstruction('Consider tapering the steroids over a week.', 0)).toBe(false)
+  })
+
+  it('says nothing about ordinary prose with no card language', () => {
+    expect(hasPhantomClickInstruction('The plan does not yet say when she should return.', 0)).toBe(
+      false,
+    )
+  })
+})
+
+/**
+ * Pinned as limitations rather than left to be discovered as bugs. Both are
+ * examination verbs that collide with the UI sense, and neither is worth the
+ * complexity of resolving: distinguishing them needs the surrounding clause,
+ * and this is a screening diagnostic whose matches the eval prints for a human
+ * to confirm. They are recorded here so that a future non-zero reading is read
+ * as "check the printed examples" rather than as a confirmed defect.
+ */
+describe('known false positives, accepted deliberately', () => {
+  it('matches palpation described with press or tap', () => {
+    expect(hasPhantomClickInstruction('She presses on the tragus and it hurts.', 0)).toBe(true)
+    expect(hasPhantomClickInstruction('Pressing over the sinuses reproduced the pain.', 0)).toBe(
+      true,
+    )
+  })
+})
+
+/**
+ * The gaps, pinned so they are known rather than discovered. Issue #185's prose
+ * says the model must never tell the doctor to "click, tap or approve"
+ * something, while the regex it then specifies is `/click|tap|press/i`. The
+ * regex is what is implemented, and these cases are why.
+ */
+describe('known blind spots, accepted deliberately', () => {
+  it('leaves ordinary approval talk alone, which is why approve is not in the pattern', () => {
+    // Hard rule 3 requires the model to be able to say this. A pattern matching
+    // `approve` would flag the rule working correctly.
+    expect(hasPhantomClickInstruction('I cannot approve a note; sign-off is yours alone.', 0)).toBe(
+      false,
+    )
+    expect(hasPhantomClickInstruction('Two items remain unchecked before you approve.', 0)).toBe(
+      false,
+    )
+  })
+
+  it('misses a bare approve with no click verb', () => {
+    // The one instance actually observed was "Click approve to apply", which
+    // this catches on the `click` branch, so dropping `approve` from the
+    // pattern loses nothing that has been seen. Closing this would mean
+    // matching `approve` near an apply-ish word, which is a clause parser in
+    // disguise.
+    expect(hasPhantomClickInstruction('Approve to apply this change.', 0)).toBe(false)
+  })
+
+  it('misses a claim that a card exists when none does', () => {
+    // A distinct failure class, found while measuring #185: a turn asserting
+    // "the card is waiting for your review" with zero proposals points at a
+    // nonexistent affordance without using any of the three verbs. It does not
+    // occur on the shipped prompt (0 of 90 turns) but appeared at 3 of 90 under
+    // one rejected prompt revision, which is what makes it worth naming.
+    expect(
+      hasPhantomClickInstruction('Proposal sent to update the objective. The card is waiting.', 0),
+    ).toBe(false)
+  })
+})

--- a/backend/src/copilot/phantom-click.ts
+++ b/backend/src/copilot/phantom-click.ts
@@ -1,0 +1,69 @@
+/**
+ * Detects a copilot turn that tells the doctor to click something it never
+ * rendered (GitHub issue #185).
+ *
+ * **This is a diagnostic, not a control.** Nothing in `runCopilotTurn` calls
+ * it, and no answer that trips it is suppressed or rewritten. That is
+ * deliberate. The only thing a runtime guard could do here is edit clinical
+ * prose to fix a wording problem, and `prompt.ts` is explicit that the schemas
+ * carry safety while the prompt carries usefulness and register. A phantom
+ * click is a register defect, so the prompt is where it is addressed and this
+ * is how it is watched.
+ *
+ * It is exported rather than left as a literal inside each caller so that the
+ * unit pin and `evals/copilot-proposals.ts` cannot drift apart. A pin that has
+ * quietly stopped meaning what the measurement means is worse than no pin.
+ *
+ * Measured at 0 of 90 turns on the shipped prompt (§25 of `docs/trd.md`), so it
+ * watches a failure that is not currently happening. It is kept because both
+ * prompt revisions trialled for #185 moved the model toward talking about
+ * cards, and the second began asserting that a card was waiting when none had
+ * been rendered. Neither shipped, but the next attempt will push the same way.
+ *
+ * **The 0 of 54 measured against production on 16/08/26 does not carry over to
+ * this pattern.** That run scored with an earlier regex that was blind to
+ * `presses`, `pressed` and `pressing`, so its zero is evidence about a narrower
+ * question than the one asked here. The turn texts were not kept, so it cannot
+ * be rescored; the eval now persists every turn, so the next detector change is
+ * a rescan rather than a re-measure.
+ */
+
+/**
+ * Anchored on both sides, and inflected **per verb** rather than through one
+ * shared suffix group.
+ *
+ * The anchoring is what keeps the clinical register out. `pressure` is in every
+ * set of vitals and `tapering` in every plan that steps a dose down, and both
+ * begin with one of these verbs.
+ *
+ * The per-verb spelling is not stylistic. A shared `(?:s|es|ing)?` group forms
+ * a cross-product, which both over- and under-matches: it accepts `tapes`
+ * (`tap` + `es`), and it misses `tapping` entirely, because English doubles the
+ * consonant and `tap` + `ing` spells `taping`. Missing it matters more than the
+ * false positive, since "after tapping Apply" is an ordinary phantom click on a
+ * touch device. The `-ed` forms are here for the same reason: "once you have
+ * clicked Apply" is the defect, not a description of it.
+ *
+ * What it still cannot separate is palpation: "a pressing sensation" and "press
+ * on the abdomen" both match, and telling them from a UI instruction needs the
+ * surrounding clause. Those are pinned as accepted false positives in the test,
+ * and the eval prints the matching text rather than trusting the count.
+ *
+ * `approve` is deliberately absent, though the issue's prose names it. It is
+ * ordinary vocabulary here, including in hard rule 3, so matching it would flag
+ * the model correctly refusing to approve a note. The one instance ever
+ * observed was "Click approve to apply", which the `click` branch catches
+ * anyway. Two blind spots follow from that and are pinned in the test: a bare
+ * "Approve to apply", and a turn claiming a card exists ("the card is waiting
+ * for your review") without using any of the three verbs.
+ *
+ * Exported for that display only. The decision belongs to
+ * `hasPhantomClickInstruction`, which also requires that no card was rendered;
+ * matching this pattern on a turn that did propose is not a defect at all.
+ */
+export const CLICK_INSTRUCTION =
+  /\b(?:click(?:s|ed|ing)?|tap(?:s|ped|ping)?|press(?:es|ed|ing)?)\b/i
+
+export function hasPhantomClickInstruction(text: string, proposalCount: number): boolean {
+  return proposalCount === 0 && CLICK_INSTRUCTION.test(text)
+}

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -2101,3 +2101,84 @@ Restated here only far enough to be findable, with the detail kept in DESIGN.md:
 ### Public Build Inputs
 
 Anything prefixed `VITE_` is inlined into the bundle and is therefore public. The two the app reads are in §7. No secret may ever carry that prefix.
+
+---
+
+## 25. Review Copilot Tool-Call Behaviour
+
+**Status: `Measured`** (GitHub issue #185)
+
+Appended rather than inserted, per the convention §22 records: renumbering would break the `§19, row N` cross-references in both documents.
+
+### 25.1 The Reported Failure And What Was Actually There
+
+The report was that CatatAI answers a doctor's edit request in prose instead of calling `edit_note_section`, at "roughly one call in three". That figure came from three turns captured during a screenshot session, one of which produced a card. It is not a rate.
+
+Measured properly, the headline rate is **22 of 36 (61%)** locally and **26 of 36 (72%)** against production. More usefully, the misses are not one failure:
+
+| Class of miss                                             | Count (of 36) | Is it a defect?                                               |
+| --------------------------------------------------------- | ------------- | ------------------------------------------------------------- |
+| Content is already in the note, and the model says so     | 9             | **No.** A card duplicating existing wording wastes the review |
+| Replacement wording written into the answer, no tool call | 4             | **Yes.** This is the reported bug                             |
+| Stream truncated mid-answer                               | 1             | Separate anomaly, unexplained                                 |
+
+Excluding the correct declines, the tool-call rate is **22 of 27 (81%)**. The defect is roughly one edit request in nine, not one in three.
+
+### 25.2 Why It Was Invisible To The Suite
+
+Every unit test stubs the provider, so the suite fixes what the model returns. No stub can answer whether the real model reaches for a tool when a doctor phrases a request the way doctors phrase them. The measurement lives in `evals/copilot-proposals.ts`, which drives the real route over HTTP, and is deliberately **not** a Vitest: it spends an LLM call per turn and its results move with the provider.
+
+### 25.3 Method
+
+Three arms, `EVAL_REPS=3`, 90 turns per run, one fresh conversation per turn with empty history, serial so the route's 30/min limiter is never approached.
+
+- **Edit Requests (12).** Imperatives about the record that never name a tool, a proposal or a schema section, because the reported reproduction was that the tool fires reliably only when the request names the mechanism.
+- **Questions (12).** Held at parity with the edit arm. Six are near misses on the same clinical subject matter ("does the objective record the throat findings?" against "the objective should say the throat was red").
+- **Bare Statements (6).** Watched, **not scored**. Whether "she is allergic to penicillin" is dictation or context is not decidable from the sentence, so this arm has no target.
+
+A change is an improvement only if the edit rate rises while the question rate does not. Forcing a tool call every turn would raise the headline number and ruin the product.
+
+### 25.4 Two Prompt Revisions Were Trialled And Both Rejected
+
+Rule 5 in `buildCopilotSystemPrompt` is entirely defensive: it describes the mechanism once and then polices tense, with worked examples of overclaiming and none of using the tool. The obvious fix is a positive trigger. It does not work, and the measurements say why.
+
+| Metric (90 turns each)                    | Shipped prompt | v1 add positive trigger | v2 remove the template |
+| ----------------------------------------- | -------------- | ----------------------- | ---------------------- |
+| Edit requests producing a card            | 22/36          | 21/36                   | 21/36                  |
+| Correct "already present" declines        | 9              | 11                      | 11                     |
+| Replacement wording in prose, no tool     | 4              | 4                       | 3                      |
+| Unsolicited proposals on questions        | **0/36**       | **0/36**                | **0/36**               |
+| False-completion claims                   | **0/90**       | **0/90**                | **0/90**               |
+| Literal `"Proposed for the"` with no card | 2              | **7**                   | **0**                  |
+| Claims a card exists when none does       | **0/90**       | **0/90**                | **3/90**               |
+
+**v1 tripled the failure it targeted.** Rule 5 lists `"Proposed for the plan:"` as a _correct_ phrasing for use after a tool call. The model treats it as an output template and reproduces it _instead of_ calling the tool. Emphasising the correct phrasings made the template more salient, not less.
+
+**v2 removed the template and introduced something worse.** The literal phrasing went to zero, but the model began asserting that a card existed: "Proposal sent to update the **objective** section. The card is waiting for your review", with no card. That is the #170 false-completion failure in a form the past-tense wording ban does not cover, and it is more dangerous than unhelpful prose, because it is a false claim about system state rather than a missing affordance.
+
+**Neither shipped.** The prompt is unchanged. The finding that matters is the mechanism: worked examples in a prompt act as output templates, and a rule that demonstrates the wording to use after an action will get the wording without the action.
+
+### 25.5 The Phantom-Click Diagnostic
+
+A turn telling the doctor to click something while rendering no card asserts an affordance that is not on screen. `hasPhantomClickInstruction` in `backend/src/copilot/phantom-click.ts` is a **diagnostic, not a control**: nothing in `runCopilotTurn` calls it, and no answer is suppressed or rewritten. The only thing a runtime guard could do is edit clinical prose to fix a wording problem, and §21 is explicit that the schemas carry safety while the prompt carries register.
+
+Measured at **0 of 90** on the shipped prompt. It is exported so the unit pin and the eval share one definition, which mattered immediately: the first pattern was wrong in both directions, accepting `tapes` while dropping `tapping`, `tapped`, `clicked` and `pressed`. Per-verb inflection fixes it. Accepted limits, all pinned in the test:
+
+- `press` and `pressing` still match palpation. `pressure` and `tapering` are correctly excluded, which is what matters.
+- `approve` is deliberately absent though the issue's prose names it: it is ordinary vocabulary here, including in hard rule 3, so matching it would flag the model correctly refusing to approve a note.
+- A claim that a card exists, without any of the three verbs, is not caught. This is the v2 failure class above.
+
+### 25.6 Evaluation Durability
+
+Two separate losses during this work, with different causes and only one shared fix:
+
+- **The scoring rule changed.** The phantom-click pattern was corrected mid-measurement, and the completed production run recorded only counts, so it could not be rescored and its phantom figure was withdrawn rather than reported.
+- **The run did not finish.** Three attempts were killed around ten minutes by the harness running them, and an end-of-run write recorded nothing at all.
+
+An evaluation that spends real model calls must treat its **raw per-turn outputs as the artefact and the summary as derived**, because the scoring rule will change and the run will be interrupted, and neither is unusual enough to plan around separately. `evals/copilot-proposals.ts` therefore writes every turn to `reports/copilot-proposals-<label>.json` as it completes, resumes from that transcript, and bounds each turn with `EVAL_TURN_TIMEOUT_MS` after one turn held a stream open past ten minutes and stalled an entire invocation.
+
+### 25.7 What Stays Open
+
+- The defect is real but small (about 4 in 36) and no prompt revision has beaten it without introducing a worse one. A tool-description change was out of scope here because #185 fixes the tool surface; that is the untried lever.
+- One turn in 36 truncated mid-answer, emitting four characters. Cause unknown, not reproduced, not investigated.
+- The bare-statement arm sits near 78% and is unexplained: the model proposes readily on "she is allergic to penicillin" while declining on explicit imperatives. Whether that is correct is undecided, so it has no target.

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -2168,6 +2168,8 @@ Measured at **0 of 90** on the shipped prompt. It is exported so the unit pin an
 - `approve` is deliberately absent though the issue's prose names it: it is ordinary vocabulary here, including in hard rule 3, so matching it would flag the model correctly refusing to approve a note.
 - A claim that a card exists, without any of the three verbs, is not caught. This is the v2 failure class above.
 
+**A clean phantom-click count therefore cannot gate a prompt change.** v2 scored 0 of 90 here while asserting three times that a card was waiting for review, because it never used the word "click". Read on this diagnostic alone, the more dangerous of the two revisions looks like the safer one. The count is evidence about one phrasing of one failure, not about whether the model is pointing the doctor at things that are not there.
+
 ### 25.6 Evaluation Durability
 
 Two separate losses during this work, with different causes and only one shared fix:

--- a/evals/copilot-proposals.ts
+++ b/evals/copilot-proposals.ts
@@ -1,0 +1,377 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { type CopilotProposal, CopilotProposalSchema, type CopilotTurn } from '@shared/types'
+import {
+  CLICK_INSTRUCTION,
+  hasPhantomClickInstruction,
+} from '../backend/src/copilot/phantom-click.js'
+
+/**
+ * Measures how often CatatAI answers an edit request with a proposal card
+ * rather than with prose (GitHub issue #185).
+ *
+ * **This is a measurement, not a test, and must never become one.** It spends a
+ * real LLM call per turn and its results move with the provider. `bun run test`
+ * stays deterministic and free precisely because this lives outside it. The
+ * behaviour it measures is invisible to the suite by construction: every unit
+ * test stubs the provider, so no stub can tell you whether the real model
+ * reaches for a tool when a doctor phrases a request the way doctors do.
+ *
+ * **Both directions are measured, because only one of them is a bug.** Forcing
+ * a tool call on every turn would raise the headline number and ruin the
+ * product: a copilot that proposes an edit when the doctor asked a question is
+ * worse than one that occasionally declines to. So the run reports the tool
+ * rate on requests that *should* propose alongside the unsolicited rate on
+ * questions that should *not*, and a prompt change is only an improvement if
+ * the first rises while the second does not. A third arm of bare statements is
+ * reported without a target, because it is where a careless fix does its damage
+ * and neither answer there is clearly right.
+ *
+ * It drives `POST /api/consultations/:id/copilot` over HTTP rather than
+ * importing `runCopilotTurn`, for the reason `run.ts` gives: that route is the
+ * one a doctor's panel calls, so there is no second copy of the pipeline here
+ * to drift from the first.
+ *
+ * Usage, against a consultation that already exists so the run creates no rows:
+ *
+ *   EVAL_API_URL=https://catatmd.vercel.app \
+ *   EVAL_ORIGIN=https://catatmd.vercel.app \
+ *   EVAL_CONSULTATION_ID=<an unapproved consultation on the guest account> \
+ *   EVAL_LABEL=before \
+ *   bunx tsx copilot-proposals.ts
+ *
+ * Every turn is written to `reports/copilot-proposals-<EVAL_LABEL>.json`, so a
+ * later correction to the phantom-click pattern is a rescan of that file rather
+ * than another 90 LLM calls. The run is resumable from that transcript, and
+ * `EVAL_MAX_TURNS` caps one invocation, so a full run can be walked forward in
+ * chunks when whatever is running it will not let a process live long enough:
+ *
+ *   EVAL_LABEL=before EVAL_MAX_TURNS=20 bunx tsx copilot-proposals.ts   # repeat
+ */
+
+const API_URL = process.env.EVAL_API_URL ?? 'http://localhost:3001'
+const ORIGIN = process.env.EVAL_ORIGIN ?? 'http://localhost:5173'
+const CONSULTATION_ID = process.env.EVAL_CONSULTATION_ID ?? ''
+const REPS = Number(process.env.EVAL_REPS ?? '3')
+
+/** Names the saved transcript, so a before-run and an after-run sit side by side. */
+const LABEL = process.env.EVAL_LABEL ?? 'run'
+
+/** Ceiling on one turn. See the note in `runTurn`. */
+const TURN_TIMEOUT_MS = Number(process.env.EVAL_TURN_TIMEOUT_MS ?? '120000')
+
+/**
+ * Edit requests in the register a doctor actually uses mid-review: an
+ * imperative about the record, with no mention of tools, proposals or sections
+ * by their schema name. The issue's reproduction is that the tool fires
+ * reliably only when the request names the mechanism ("propose that as an edit
+ * to the plan section"), so no prompt here is allowed to name it.
+ */
+const EDIT_REQUESTS = [
+  'add a safety net to the plan',
+  'the plan should tell her when to come back',
+  'put the fever reading in the objective',
+  'the assessment does not mention the tonsillar swelling, add it',
+  'note that I dispensed the medicine in the plan',
+  'the plan needs the MC duration spelled out',
+  'add that she should return if she cannot swallow',
+  'the objective should say the throat was red',
+  'mention the three day history in the subjective',
+  'add review in three days to the plan',
+  'tighten the subjective, it is too wordy',
+  'the plan is missing what to do if the fever comes back',
+]
+
+/**
+ * Questions that must NOT produce a card. A copilot that proposes here is
+ * editing the record because it was asked to read it, which is the regression
+ * that a naive fix to the rate above would introduce.
+ *
+ * Held at parity with the edit arm on purpose. Before a prompt change these
+ * guard a failure that is not happening; after one that adds a positive "call
+ * the tool" trigger they guard the failure that change actively induces, so the
+ * arm carrying the risk must not be the thinner one. The second six are
+ * deliberately near misses: same clinical subject matter as the edit requests
+ * above, same sections named, but phrased to ask what the record contains
+ * rather than to change it.
+ */
+const CONTROL_REQUESTS = [
+  'what did the patient say about their symptoms?',
+  'what is still missing before I can sign this off?',
+  'what guidance supports the current plan?',
+  'is the assessment consistent with the transcript?',
+  'what would another GP question about this note?',
+  'summarise what this consultation established',
+  'does the plan say when she should come back?',
+  'is the MC duration written down anywhere in the note?',
+  'does the objective record the throat findings?',
+  'is the three day history captured in the subjective?',
+  'which parts of the note does the guidance actually support?',
+  'is anything in the subjective repeated?',
+]
+
+/**
+ * Bare statements of clinical fact, which are neither of the above.
+ *
+ * **Watched, not scored, because the correct behaviour is genuinely unsettled.**
+ * A doctor who says "she is allergic to penicillin" mid-review may be giving
+ * context or may be dictating; a human reading the transcript could not tell you
+ * which either. So this arm has no target and nothing here counts for or against
+ * a fix.
+ *
+ * It exists because it is where a careless fix does its damage. The cheap way to
+ * raise the tool-call rate is to teach the model that any sentence about the
+ * record is a request to change it, and that lesson lands here first: these
+ * become unsolicited edits while the question arm above stays clean and reports
+ * no regression at all. What matters is the size of the move between two runs,
+ * not the level. A jump from near zero to near everything means the fix stopped
+ * distinguishing a request from a remark.
+ */
+const STATEMENTS = [
+  'the patient also mentioned she is pregnant',
+  'she is allergic to penicillin',
+  'i examined the chest and it was clear',
+  'her temperature was 38.2 when the nurse checked',
+  'she has been taking paracetamol at home',
+  'this is her second visit for the same problem',
+]
+
+interface TurnResult {
+  prompt: string
+  kind: 'edit' | 'control' | 'statement'
+  proposals: CopilotProposal[]
+  tools: string[]
+  text: string
+  error?: string
+}
+
+async function signIn(): Promise<string> {
+  const response = await fetch(`${API_URL}/api/auth/guest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Origin: ORIGIN },
+  })
+  if (!response.ok) {
+    throw new Error(`guest sign-in failed: ${response.status} ${await response.text()}`)
+  }
+  const cookies = response.headers.getSetCookie()
+  if (cookies.length === 0) throw new Error('guest sign-in returned no session cookie')
+  return cookies.map((c) => c.split(';')[0]).join('; ')
+}
+
+/** Reads the `data:` frames the copilot route writes and collects one turn. */
+async function runTurn(
+  prompt: string,
+  kind: TurnResult['kind'],
+  cookie: string,
+  history: CopilotTurn[],
+): Promise<TurnResult> {
+  const base: TurnResult = { prompt, kind, proposals: [], tools: [], text: '' }
+
+  /*
+   * Bounded, because an unbounded turn stalls the whole run rather than just
+   * itself. Observed on "her temperature was 38.2 when the nurse checked": one
+   * turn held the stream open past ten minutes and the invocation recorded
+   * nothing at all. A turn that cannot finish is data too, so it is recorded as
+   * an error and excluded from the rates rather than blocking the arm behind it.
+   */
+  const response = await fetch(`${API_URL}/api/consultations/${CONSULTATION_ID}/copilot`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Origin: ORIGIN, Cookie: cookie },
+    body: JSON.stringify({ message: prompt, history }),
+    signal: AbortSignal.timeout(TURN_TIMEOUT_MS),
+  })
+
+  if (!response.ok || !response.body) {
+    return { ...base, error: `${response.status} ${(await response.text()).slice(0, 200)}` }
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  while (true) {
+    const { value, done } = await reader.read().catch((cause) => {
+      base.error = `stream aborted after ${TURN_TIMEOUT_MS}ms: ${String(cause)}`.slice(0, 200)
+      return { value: undefined, done: true as const }
+    })
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    while (buffer.includes('\n\n')) {
+      const split = buffer.indexOf('\n\n')
+      const frame = buffer.slice(0, split)
+      buffer = buffer.slice(split + 2)
+      const line = frame.split('\n').find((entry) => entry.startsWith('data:'))
+      if (!line) continue
+      let event: unknown
+      try {
+        event = JSON.parse(line.slice(5).trim())
+      } catch {
+        continue
+      }
+      const e = event as { type?: string; text?: string; name?: string; message?: string }
+      if (e.type === 'token' && typeof e.text === 'string') base.text += e.text
+      if (e.type === 'tool' && typeof e.name === 'string') base.tools.push(e.name)
+      if (e.type === 'proposal') {
+        const parsed = CopilotProposalSchema.safeParse((event as { proposal?: unknown }).proposal)
+        if (parsed.success) base.proposals.push(parsed.data)
+      }
+      if (e.type === 'error') base.error = e.message ?? 'stream error'
+    }
+  }
+
+  return base
+}
+
+function rate(results: TurnResult[], predicate: (r: TurnResult) => boolean): string {
+  const usable = results.filter((r) => !r.error)
+  if (usable.length === 0) return 'n/a (0 usable turns)'
+  const hits = usable.filter(predicate).length
+  return `${hits}/${usable.length} (${Math.round((hits / usable.length) * 100)}%)`
+}
+
+async function main() {
+  if (!CONSULTATION_ID) {
+    throw new Error(
+      'Set EVAL_CONSULTATION_ID to an unapproved consultation on the account this signs in as. ' +
+        'This eval deliberately creates no consultation of its own: there is no deletion ' +
+        'endpoint (#80), so a run that created rows could not clean up after itself.',
+    )
+  }
+
+  const cookie = await signIn()
+
+  const plan = [
+    ...EDIT_REQUESTS.map((p) => ({ prompt: p, kind: 'edit' as const })),
+    ...CONTROL_REQUESTS.map((p) => ({ prompt: p, kind: 'control' as const })),
+    ...STATEMENTS.map((p) => ({ prompt: p, kind: 'statement' as const })),
+  ]
+
+  /*
+   * The whole run flattened, so a turn is addressed by one index and resuming
+   * is "start at `results.length`" rather than arithmetic over reps.
+   */
+  const schedule = Array.from({ length: REPS }, (_, i) => i + 1).flatMap((rep) =>
+    plan.map((entry) => ({ ...entry, rep })),
+  )
+
+  /*
+   * Every turn's text is kept, which is the difference between rescoring and
+   * re-measuring. The phantom-click figure is only as good as the pattern that
+   * scored it, and the first version of that pattern was wrong in both
+   * directions, so a run measured under it could not be checked against the
+   * correction: nothing but the counts had been written down. Detectors get
+   * corrected. Only the counts being durable is the part that made that
+   * expensive.
+   *
+   * Written after **every turn**, not at the end, for the same reason and one
+   * more: a full run is roughly half an hour of real LLM calls, and every
+   * attempt so far has been killed around the ten-minute mark by the harness
+   * running it. An end-of-run write throws away everything a partial run
+   * learned.
+   */
+  await mkdir(new URL('reports/', import.meta.url), { recursive: true })
+  const transcriptPath = new URL(`reports/copilot-proposals-${LABEL}.json`, import.meta.url)
+
+  /*
+   * Resumable, which is what makes the previous paragraph useful rather than
+   * merely consoling. A killed run leaves a transcript; the next invocation
+   * picks up at the turn after the last one recorded. `EVAL_MAX_TURNS` caps how
+   * many new turns one invocation attempts, so the run can be walked forward in
+   * chunks that finish inside whatever time limit is killing it.
+   *
+   * The saved schedule is compared before resuming. Appending to a transcript
+   * whose earlier turns answered different prompts would produce a rate over a
+   * prompt set that never existed, which is worse than starting again.
+   */
+  const schedulePrompts = schedule.map((entry) => entry.prompt)
+  let results: TurnResult[] = []
+  if (existsSync(transcriptPath)) {
+    const prior = JSON.parse(await readFile(transcriptPath, 'utf8'))
+    const matches =
+      prior.CONSULTATION_ID === CONSULTATION_ID &&
+      JSON.stringify(prior.schedule) === JSON.stringify(schedulePrompts)
+    if (matches) {
+      results = prior.results
+      console.log(`resuming: ${results.length} of ${schedule.length} turns already recorded`)
+    } else {
+      console.log('existing transcript is for a different run, starting again')
+    }
+  }
+
+  const persist = () =>
+    writeFile(
+      transcriptPath,
+      JSON.stringify({ CONSULTATION_ID, REPS, schedule: schedulePrompts, results }, null, 2),
+    )
+
+  const budget = Number(process.env.EVAL_MAX_TURNS ?? String(schedule.length))
+  const stopAt = Math.min(schedule.length, results.length + budget)
+
+  for (const { prompt, kind, rep } of schedule.slice(results.length, stopAt)) {
+    // Serial, and each turn is a fresh conversation with empty history. The
+    // route's limiter allows 30/min and a turn takes seconds, so serial
+    // execution stays under it without sleeping; more importantly, a shared
+    // history would let one turn's answer steer the next and the rate would
+    // stop being per-prompt.
+    const result = await runTurn(prompt, kind, cookie, [])
+    results.push(result)
+    await persist()
+    const mark = result.error ? 'ERR' : result.proposals.length > 0 ? 'CARD' : 'prose'
+    console.log(`  [rep ${rep}] ${mark.padEnd(5)} ${kind.padEnd(7)} ${prompt}`)
+    if (result.error) console.log(`         error: ${result.error}`)
+  }
+
+  if (results.length < schedule.length) {
+    console.log(
+      `\nincomplete: ${results.length} of ${schedule.length} turns. ` +
+        'Run again with the same EVAL_LABEL to continue. No rates are reported ' +
+        'until the run finishes, because a partial run is not a rate.',
+    )
+    return
+  }
+
+  const edits = results.filter((r) => r.kind === 'edit')
+  const controls = results.filter((r) => r.kind === 'control')
+  const statements = results.filter((r) => r.kind === 'statement')
+
+  console.log('\n=== issue #185 measurement ===')
+  console.log(`consultation: ${CONSULTATION_ID}`)
+  console.log(
+    `reps: ${REPS}, turns: ${results.length}, errors: ${results.filter((r) => r.error).length}`,
+  )
+  console.log('')
+  console.log(`tool-call rate on edit requests   ${rate(edits, (r) => r.proposals.length > 0)}`)
+  console.log(`   (higher is better)`)
+  console.log(`unsolicited proposals on questions ${rate(controls, (r) => r.proposals.length > 0)}`)
+  console.log(`   (lower is better; a fix that raises this is a regression)`)
+  console.log(
+    `proposals on bare statements       ${rate(statements, (r) => r.proposals.length > 0)}`,
+  )
+  console.log(`   (watched, not scored: compare the move between runs, not the level)`)
+  console.log(
+    `phantom click instructions         ${rate(results, (r) => hasPhantomClickInstruction(r.text, r.proposals.length))}`,
+  )
+  console.log(`   (must be 0: telling the doctor to click a card that does not exist)`)
+
+  const phantoms = results.filter(
+    (r) => !r.error && hasPhantomClickInstruction(r.text, r.proposals.length),
+  )
+  if (phantoms.length > 0) {
+    console.log('\nphantom examples:')
+    for (const p of phantoms.slice(0, 3)) {
+      // A window around the match rather than the sentence, so the one pattern
+      // in `phantom-click.ts` stays the only definition of what a match is.
+      const at = p.text.search(CLICK_INSTRUCTION)
+      const window = p.text
+        .slice(Math.max(0, at - 80), at + 80)
+        .replace(/\s+/g, ' ')
+        .trim()
+      console.log(`  "${p.prompt}" -> ...${window}...`)
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/evals/tsconfig.json
+++ b/evals/tsconfig.json
@@ -4,7 +4,12 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["**/*.ts", "../backend/src/fixtures/**/*.ts", "../backend/src/guidelines/**/*.ts"],
+  "include": [
+    "**/*.ts",
+    "../backend/src/fixtures/**/*.ts",
+    "../backend/src/guidelines/**/*.ts",
+    "../backend/src/copilot/phantom-click.ts"
+  ],
   "exclude": ["reports"],
   "references": [{ "path": "../shared" }]
 }


### PR DESCRIPTION
Closes nothing. #185 stays open: the defect is real, smaller than reported, and no prompt revision has beaten it without introducing a worse one.

## What This Ships

The measurement, not a fix. `backend/src/copilot/prompt.ts` is **unchanged**.

- `evals/copilot-proposals.ts`, a three-arm measurement driving the real SSE route over HTTP
- `backend/src/copilot/phantom-click.ts`, the detector AC3 asks for, exported so the pin and the eval share one definition
- `docs/trd.md` §25, the measured finding

## The Reported Rate Was Not A Rate

"Roughly one call in three" was three turns captured during a screenshot session, one of which produced a card. Over 90 turns:

| | Local | Production |
| --- | --- | --- |
| Edit requests producing a card | 22/36 (61%) | 26/36 (72%) |
| Unsolicited proposals on questions | 0/36 | 0/18 |

The misses are three different things, and only one is a defect:

| Class | Count of 36 | Defect? |
| --- | --- | --- |
| Content already in the note, model says so | 9 | No. A duplicate card wastes the review |
| Replacement wording in prose, no tool call | 4 | **Yes** |
| Stream truncated mid-answer | 1 | Separate, unexplained |

Excluding correct declines: **22/27 (81%)**. About one edit request in nine, not one in three.

## Two Prompt Revisions, Both Rejected

| Metric, 90 turns each | Shipped | v1 positive trigger | v2 remove template |
| --- | --- | --- | --- |
| Edit requests producing a card | 22/36 | 21/36 | 21/36 |
| Replacement wording in prose, no tool | 4 | 4 | 3 |
| Unsolicited on questions | 0/36 | 0/36 | 0/36 |
| False-completion claims | 0/90 | 0/90 | 0/90 |
| Literal `"Proposed for the"`, no card | 2 | **7** | **0** |
| Claims a card exists when none does | 0/90 | 0/90 | **3/90** |

**v1 tripled the failure it targeted.** Rule 5 lists `"Proposed for the plan:"` as *correct* wording for use after a tool call. The model treats it as an output template and reproduces it instead of calling the tool. Emphasising the correct phrasings made the template more salient.

**v2 removed the template and introduced something worse:** "Proposal sent to update the **objective** section. The card is waiting for your review", with no card. That is the #170 false-completion failure in a form the past-tense ban does not cover, and a false claim about system state is worse than unhelpful prose.

The transferable finding is the mechanism: **worked examples in a prompt act as output templates, and a rule demonstrating the wording to use after an action will get the wording without the action.**

## Acceptance Criteria

- [x] Measure first, record in `docs/trd.md` — §25, both environments, per-class
- [ ] **Raise the rate without raising unsolicited proposals** — not achieved. Both attempts measured and rejected. The question arm held at 0/36 throughout
- [x] Pin `/click|tap|press/i` with zero proposals — `phantom-click.test.ts` plus a stubbed-turn case in `index.test.ts`
- [x] No tool-surface change — `tools.ts` and `tools.test.ts` untouched
- [x] Signed-note path unchanged — untouched, its tests still pass

**AC3 discrepancy, flagged rather than silently resolved.** The issue's prose says "click, tap or **approve**"; the regex it specifies is `/click|tap|press/i`. The regex is implemented. `approve` is ordinary vocabulary here, including in hard rule 3, so matching it would flag the model correctly refusing to approve a note. The one instance ever observed, "Click approve to apply", is caught on the `click` branch anyway. Both resulting blind spots are pinned as tests.

## Notes For Review

- The detector is a **diagnostic, not a control**. Nothing in `runCopilotTurn` calls it and no answer is suppressed. Per §21, schemas carry safety and the prompt carries register; a phantom click is a register defect, so a runtime guard would mean editing clinical prose to fix a wording problem.
- Its first pattern was wrong in both directions, accepting `tapes` while dropping `tapping`, `tapped`, `clicked` and `pressed`. One shared suffix group produced four false negatives and one false positive at once, which is why inflections are now enumerated per verb and every one is pinned. Anyone touching that pattern will reach for the compact form for the same reason I did.
- **A clean phantom-click count cannot gate a prompt change.** v2 scored 0/90 on the detector while claiming three times that a card was waiting, because it never used the word "click". On this diagnostic alone the more dangerous revision looks like the safer one.
- The production phantom-click figure is **withdrawn, not zero**. It was scored with the superseded pattern and its turn texts were not kept.
- Two separate data losses drove the durability work: the scoring rule changed, and then runs kept dying at ten minutes. Only the second is fixed by per-turn writes. The eval now persists every turn, resumes from the transcript, and bounds each turn after one held a stream open past ten minutes.

## Verification

831 tests pass. `bun run typecheck` and `bun run lint` clean. Confidentiality scan clean.
