### PR TITLE
feat(redflags): tolerate measured ASR devoicing variants as redflag-list-v6

### DIFF
--- a/backend/src/redflags/malay-triggers.test.ts
+++ b/backend/src/redflags/malay-triggers.test.ts
@@ -251,3 +251,50 @@ describe('genuine Malay denials still suppress', () => {
     expect(ruleIds(patient('Tak ada demam, tak ada menggigil.'))).toEqual([])
   })
 })
+
+describe('measured ASR devoicing variants (docs/trd.md §20.3, issue #192)', () => {
+  // Both measured ASR arms harden the first consonant of Malay clinical words
+  // ("patut" for "batuk", "sempuk" for "semput"), so the emergency matchers
+  // tolerate the variant wherever its reading is bounded. Zero tolerance for
+  // false negatives outranks precision here too.
+  it.each([
+    ['haemoptysis', 'Patut sampai berdarah semalam.'],
+    ['haemoptysis', 'Patuk-patuk keluar darah.'],
+    ['significant-dyspnoea', 'Sempuk bila naik tangga.'],
+  ])('%s fires on the devoiced variant "%s"', (id, text) => {
+    expect(ruleIds(patient(text))).toContain(id)
+  })
+
+  it('does not fire haemoptysis on everyday "patut", because the widening rides on the darah context', () => {
+    expect(ruleIds(patient('Patut la rehat rumah dulu.'))).not.toContain('haemoptysis')
+  })
+
+  it('still suppresses a devoiced variant behind a trailing negator', () => {
+    expect(ruleIds(patient('Takde sempuk pun.'))).not.toContain('significant-dyspnoea')
+  })
+
+  it('still suppresses a devoiced variant denied in reply to a screening question', () => {
+    expect(
+      ruleIds(
+        transcript([
+          { speaker: 'doctor', text: 'Ada sempuk tak?' },
+          { speaker: 'patient', text: 'Takde.' },
+        ]),
+      ),
+    ).not.toContain('significant-dyspnoea')
+  })
+
+  it('cannot silence a v5 fire behind a negated everyday word in the same turn', () => {
+    // Pins the append-only design. A widened /[bp]atu[kt]/ spends findSpan's
+    // single exec on the negated "Tak patut sampai berdarah" and silences the
+    // genuine "batuk berdarah" after it, losing a v5 fire (caught in review
+    // of #192). The devoiced forms are separate later patterns, so every
+    // pattern that fired under v5 still gets its own attempt under v6.
+    expect(
+      ruleIds(patient('Tak patut sampai berdarah, tapi batuk berdarah sejak pagi.')),
+    ).toContain('haemoptysis')
+    expect(ruleIds(patient('Takde sempuk masa rehat, tapi semput bila naik tangga.'))).toContain(
+      'significant-dyspnoea',
+    )
+  })
+})

--- a/backend/src/redflags/triggers.ts
+++ b/backend/src/redflags/triggers.ts
@@ -14,8 +14,8 @@ import type { RedFlagTrigger } from './types.js'
  * changes. Recorded with every analysis (docs/trd.md §15).
  */
 export const RED_FLAG_LIST_VERSION: ClinicalArtefactVersion = {
-  id: 'redflag-list-v5',
-  effectiveDate: '2026-08-15',
+  id: 'redflag-list-v6',
+  effectiveDate: '2026-08-16',
 }
 
 const URTI_PROFILES: readonly ProfileId[] = ['adult-acute-urti']
@@ -248,6 +248,22 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /kahak\s+(?:ada\s+)?(?:ber)?darah/i,
         /darah\s+dalam\s+kahak/i,
         /ludah\s+(?:ber)?darah/i,
+        // The devoiced forms both measured ASR arms produce for "batuk"
+        // ("patut", "patuk"; docs/trd.md §20.3), appended AFTER the originals
+        // rather than widened into them: findSpan gives each pattern one exec
+        // per turn, so a widened pattern whose leftmost match landed on a
+        // negated everyday "tak patut ... berdarah" would spend that one
+        // attempt and silence a genuine "batuk berdarah" later in the same
+        // turn. Appended patterns can only add fires. The darah context
+        // bounds the everyday word "patut"; the residual over-fire ("luka tu
+        // patut berdarah") is accepted, because firing is the direction this
+        // engine must fail in. "teman" for "demam" is deliberately absent
+        // everywhere: bare /\bdemam\b/ further down is deliberately broad, so
+        // that variant would fire on every mention of a companion. "tenggi"
+        // for "denggi" and "pengkat" for "bengkak" have no trigger to widen;
+        // the transcript mishear hints carry those pairs instead.
+        /patu[kt](?:-patu[kt])?\s+(?:sampai\s+)?(?:ber)?darah/i,
+        /patu[kt](?:-patu[kt])?\s+(?:sampai\s+)?(?:keluar|ada)\s+darah/i,
       ]),
     clinicalSource: NAG_SCOPE_NOTE,
     listVersion: RED_FLAG_LIST_VERSION.id,
@@ -282,6 +298,11 @@ export const REDFLAG_TRIGGERS: readonly RedFlagTrigger[] = [
         /na[fp]as\s+pendek/i,
         /\btercungap/i,
         /\btermengah/i,
+        // "sempuk", the measured devoiced form of "semput" (docs/trd.md
+        // §20.3), appended after the originals for the same one-exec reason
+        // as the patu[kt] patterns in haemoptysis; not a Malay word, so no
+        // innocent reading needs bounding.
+        /\bsempuk\b/i,
       ]) ??
       findDeniedAbility(transcript, [
         /(?<!\b(?:tak|tidak)\s)\b(?:boleh|dapat|larat)\s+(?:nak\s+)?(?:tarik\s+)?(?:ber)?na[fp]as/i,


### PR DESCRIPTION
## What Changed

The haemoptysis and breathlessness matchers now also fire on the ASR devoicing variants measured in TRD 20.3 ("patut"/"patuk" for "batuk" with the darah context retained, "sempuk" for "semput"), appended as separate patterns under redflag-list-v6.

Closes #192

## Why

Both measured ASR arms harden the first consonant of Malay clinical words, so a real "batuk berdarah" can reach the engine spelled "patut sudah berdarah" and match nothing. Patient safety must not depend on the ASR spelling an emergency phrase correctly.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`

New tests in backend/src/redflags/malay-triggers.test.ts: devoiced positives ("Patut sampai berdarah semalam.", "Patuk-patuk keluar darah.", "Sempuk bila naik tangga."), the innocent-word bound ("Patut la rehat rumah dulu." raises nothing), trailing-negator and question-denial suppression for the devoiced form, and a monotonicity regression pinning that no v5 fire is lost under v6. Backend suite 678/678 on a serial run; parallel local runs flake with 5 s timeouts on this machine (known issue), CI is the arbiter.

## Clinical-Safety Checklist

- [x] No new path sends un-de-identified text to a provider — egress still goes through `deid/` then `LLMClient`
- [x] No provider SDK imported outside `backend/src/lib/llm/`
- [x] Deterministic red-flag hits remain unsuppressable by the model
- [x] Citations remain ID-constrained; no free-text references accepted
- [x] No transcript bodies, note contents, or vault entries written to logs
- [x] Fixtures added are synthetic

## Notes For The Reviewer

clinical-safety-reviewer was dispatched on this diff and found a blocker in the first cut: widening the original patterns in place ([bp]atu[kt]) let a negated everyday "tak patut ... berdarah" consume findSpan's single exec per pattern and silence a genuine "batuk berdarah" later in the same turn, losing a v5 fire. The shipped design appends the devoiced forms as separate later patterns instead, which is strictly additive, and the new monotonicity test fails under the widened design. Deliberate rejections are recorded in the trigger comments: no "teman" widening for demam (everyday word against a deliberately broad bare demam), and no new denggi or bengkak triggers (nothing exists to widen; the review-time mishear hints in #193 carry those pairs). mergeRedFlags and rule-before-LLM ordering untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recognition of Malay speech-recognition variants for coughing blood and significant shortness of breath.
  * Better distinguishes genuine denials and screening-question responses from valid red-flag matches.

* **Tests**
  * Added coverage for contextual matching, denial handling, and later valid matches after negated phrases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->