### PR TITLE
feat(ui): capture dictation-grade audio and hint measured Malay mishears for one-tap correction

### DIFF
--- a/docs/trd.md
+++ b/docs/trd.md
@@ -1739,6 +1739,8 @@ Tokens: ILMU beats local. Segments: fail (none delivered). **Ship the hosted pat
 
 **Limits, stated plainly.** n=1 reader, one phone microphone, a non-clinical room; one sample per register; token comparison rather than WER, per the 20.1 convention; the local arm ran in Node CPU rather than browser WASM. The devoicing overlap between both models suggests re-measurement with a clinic-grade microphone before treating it as a provider property. If the provider ships working `verbose_json` segments or punctuation later, the draft-labels verdict in finding 5 is the one to re-measure.
 
+**Revised 16/08/26:** the capture-profile suspicion now has a shipped response: §20.6 turns off the browser's voice-call DSP at the microphone. Every figure in this section was captured with that DSP on; §20.6 holds the re-measurement protocol, and this section's verdicts stand until it runs.
+
 **Cost of the whole gate:** about RM 0.20 of the RM 20 early-access credit.
 
 ### 20.4 The Consent Gate (Resolves §19 Row 18)
@@ -1787,7 +1789,7 @@ The disclosure cites the **PDPA as amended in 2024**, under which voice is biome
 | **Failure copy**   | One message for every upstream reason, so the provider's operational state never reaches a consulting-room screen             |
 | **Provenance**     | `asr_hosted` is sticky for the consultation once any hosted recording contributed, and never downgrades on a later local pass |
 
-**Follow-up, named rather than skipped:** `docs/assets/tech-stack.drawio.png` still draws the hosted adapter dashed and pointing at Qwen. Regenerating it is a `docs-maintainer` task, not part of this change.
+**Follow-up, closed 16/08/26:** `docs/assets/tech-stack.drawio.png` and the doctor-journey diagram now draw the hosted adapter as `ilmu-asr-v4.2`, built, with the audio relayed through the API. The dashed outline remains because the provider sits outside the trust boundary.
 
 ### 20.5 Hosted Draft Turns: Server-Side Split And Label
 
@@ -1819,6 +1821,38 @@ The output of this pass sits behind the identical explicit Apply gate as the on-
 
 - **No per-actor spend cap.** Same posture as the relay (§20) and `analyze` (§13): the 5/min limiter bounds request rate, not cumulative cost.
 - **Not tied to a relay having happened.** Any authenticated session can call this endpoint with arbitrary text within the character bounds; it does not verify the text originated from `/api/asr/transcriptions`.
+
+### 20.6 Capture Constraints: Dictation DSP Off (Addendum To §20.3)
+
+**Status: `Built` (#191).** Ships alongside the red-flag devoicing tolerance (#192, `redflag-list-v6`) and the review-time mishear hints (#193); this section records the capture half and the protocol that judges it.
+
+#### What Changed
+
+`AudioCapture` now requests dictation constraints instead of `{ audio: true }`:
+
+| Constraint         | Value   | Why                                                                                                                                                      |
+| ------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `echoCancellation` | `false` | AEC removes a far end that a dictation capture does not have                                                                                             |
+| `noiseSuppression` | `false` | NS attenuates the low-energy consonant bursts separating b/p and d/t, the §20.3 devoicing family ("patut" for "batuk")                                   |
+| `autoGainControl`  | `true`  | Two speakers sit at different distances from one microphone; a quiet far speaker costs more than gain pumping, and AGC changes level, not spectral shape |
+| `channelCount`     | `1`     | The local path downmixes to 16 kHz mono anyway, and mono roughly halves a hosted upload against the relay's 25 MB cap                                    |
+
+`new MediaRecorder(stream)` is deliberately untouched: default Opus is speech-transparent, and raising `audioBitsPerSecond` inflates a long consultation toward the same 25 MB cap for no measured benefit. A test pins the exact constraints object so a refactor cannot drift back to `{ audio: true }`.
+
+#### What This Rests On, And What It Does Not Claim
+
+- The §20.3 limits paragraph already pointed at the phone-mic audio profile: both ASR arms devoiced the same words at the same spots, which a provider property would not explain.
+- **Every §20.1 to §20.3 measurement was captured with the browser's voice-call DSP on.** That makes the DSP a plausible contributor, not a proven one.
+- **No re-measurement has run yet.** The §20.3 verdicts stand until the protocol below does.
+- Constraint values are ideals per the mediacapture spec: a browser may honour none of them without erroring. `track.getSettings()` reports what actually applied, and every future measurement must record that readout beside its figures.
+
+#### Re-Measurement Protocol (Needs A Human Reader)
+
+1. With this change running locally, one reader re-records the 99.2 s rojak script live through the Record tab, plus the §20.2 reference script as the English control arm (checks the on-device English path did not regress with NS off).
+2. Tick the ILMU consent so the exact blob is visible as the relay request body in devtools; save it locally as `rojak-dsp-off.webm` (synthetic scripted audio per the §20.1 provenance rules; never committed). Record the `getSettings()` readout alongside it.
+3. ILMU arm: `evals/asr-ab.ts` against the saved file, three runs, report under the gitignored `evals/reports/`.
+4. Local arm: `evals/asr-ab.ts` posts to ILMU only, so the on-device comparison is the same session's Record-tab transcript, noted in the report.
+5. Compare the §20.3 token-table devoicing rows (batuk, demam, denggi, semput, bengkak, tekak, tonsil) and record the verdict here. If devoicing persists with the DSP off on a decent microphone, it is a provider property, and the review-time hints (#193) stay the primary mitigation.
 
 ---
 

--- a/frontend/src/audio/AudioCapture.test.tsx
+++ b/frontend/src/audio/AudioCapture.test.tsx
@@ -101,6 +101,9 @@ class FakeMediaRecorder {
 let getUserMedia: () => Promise<{ getTracks: () => { stop: () => void }[] }>
 let tracks: { stop: ReturnType<typeof vi.fn> }[]
 
+/** Every constraints object handed to getUserMedia, so tests can pin them. */
+let gumCalls: unknown[]
+
 /** Swappable per test, so a decode can be made to hang or settle late. */
 let decodeAudioData: () => Promise<unknown>
 
@@ -144,6 +147,7 @@ beforeEach(() => {
   draftHostedTurns.mockRejectedValue(new Error('not configured'))
   decodeAudioData = async () => ({ duration: 1 })
   tracks = [{ stop: vi.fn() }]
+  gumCalls = []
   getUserMedia = async () => ({ getTracks: () => tracks })
   vi.stubGlobal('Worker', FakeWorker)
   vi.stubGlobal('AudioContext', FakeAudioContext)
@@ -151,7 +155,12 @@ beforeEach(() => {
   vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
   // jsdom has no mediaDevices at all, so this defines rather than spies.
   Object.defineProperty(navigator, 'mediaDevices', {
-    value: { getUserMedia: () => getUserMedia() },
+    value: {
+      getUserMedia: (constraints: unknown) => {
+        gumCalls.push(constraints)
+        return getUserMedia()
+      },
+    },
     configurable: true,
   })
   // jsdom reports few cores and no memory, and the hardware floor would hide
@@ -677,6 +686,25 @@ describe('prewarming the speech model', () => {
     expect(workers).toHaveLength(0)
     expect(screen.getByRole('alert').textContent).toMatch(/microphone/i)
     expect(screen.queryByRole('button', { name: /try again/i })).toBeNull()
+  })
+
+  it('requests dictation constraints, not the browser voice-call defaults', async () => {
+    renderCapture()
+    await startRecording()
+
+    // Pinned exactly so a refactor cannot drift back to `{ audio: true }`,
+    // which would re-enable the DSP behind the devoicing family measured in
+    // docs/trd.md §20.3 ("patut" for "batuk").
+    expect(gumCalls).toEqual([
+      {
+        audio: {
+          echoCancellation: false,
+          noiseSuppression: false,
+          autoGainControl: true,
+          channelCount: 1,
+        },
+      },
+    ])
   })
 })
 

--- a/frontend/src/audio/AudioCapture.tsx
+++ b/frontend/src/audio/AudioCapture.tsx
@@ -660,7 +660,25 @@ export function AudioCapture({
     // microphone would otherwise offer Try Again on the previous recording.
     setRetryBlob(null)
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      /*
+       * Dictation constraints, not the defaults: the browser's voice-call DSP
+       * attenuates exactly the low-energy consonant bursts that separate b/p
+       * and d/t, the devoicing family docs/trd.md §20.3 measured on both ASR
+       * arms ("patut" for "batuk"), and echo cancellation has no far end to
+       * cancel here. Gain control stays on because two speakers sit at
+       * different distances from one microphone, and a quiet track costs more
+       * than gain pumping. Values are ideals per the mediacapture spec, never
+       * OverconstrainedError; track.getSettings() reports what was actually
+       * applied, which every TRD §20 measurement must record.
+       */
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: false,
+          noiseSuppression: false,
+          autoGainControl: true,
+          channelCount: 1,
+        },
+      })
       const media = new MediaRecorder(stream)
       chunks.current = []
       media.ondataavailable = (event) => chunks.current.push(event.data)
@@ -780,7 +798,9 @@ export function AudioCapture({
         transcription below for this consultation. The result appears below as lines with guessed{' '}
         <code className="text-ink">Doctor</code> / <code className="text-ink">Patient</code> labels,
         drawn from what each sentence says, not from the voices. Check every line, then apply them
-        to the transcript.
+        to the transcript. On-device transcription is tuned for English and Manglish, and a
+        consultation held mainly in Malay can come back rewritten in English rather than
+        transcribed; for Malay-dominant consultations, the hosted option below may work better.
       </p>
 
       {thin && (
@@ -944,13 +964,14 @@ export function AudioCapture({
             <span className="mt-0.5 flex items-center gap-1 text-xs text-ink-muted">
               <code className="text-ink">ilmu-asr-v4.2</code>
               <InfoTip label="About hosted transcription with ILMU">
-                An early-access service. Its accuracy figures are the provider&apos;s claim until
-                our own measurement is recorded in the technical reference (TRD 20.3). The recording
-                travels from this browser, to our server in Singapore, to ILMU in Malaysia.
-                Retention and training follow ILMU&apos;s standard early-access terms, which we have
-                not varied by agreement. Handled under the PDPA as amended in 2024, under which
-                voice is biometric data and therefore sensitive personal data requiring explicit
-                consent.
+                An early-access service. On our scripted Malay consultation it kept code-switched
+                sentences intact, but sometimes hardened the first consonant of a Malay clinical
+                word, hearing batuk as patut and demam as teman, so check those words when you
+                review the draft (TRD 20.3). The recording travels from this browser, to our server
+                in Singapore, to ILMU in Malaysia. Retention and training follow ILMU&apos;s
+                standard early-access terms, which we have not varied by agreement. Handled under
+                the PDPA as amended in 2024, under which voice is biometric data and therefore
+                sensitive personal data requiring explicit consent.
               </InfoTip>
             </span>
           </div>

--- a/frontend/src/audio/SpeakerAssign.test.tsx
+++ b/frontend/src/audio/SpeakerAssign.test.tsx
@@ -11,14 +11,15 @@ const DRAFT: DraftLine[] = [
   { id: 'seg-1', speaker: 'patient', text: 'Yesterday quite hot.', offsetSeconds: 2.1 },
 ]
 
-function setup() {
+function setup(draft: DraftLine[] = DRAFT) {
   const handlers = {
     onToggle: vi.fn(),
+    onReplace: vi.fn(),
     onSwapAll: vi.fn(),
     onApply: vi.fn(),
     onInsertPlain: vi.fn(),
   }
-  render(<SpeakerAssign draft={DRAFT} {...handlers} />)
+  render(<SpeakerAssign draft={draft} {...handlers} />)
   return handlers
 }
 
@@ -46,5 +47,31 @@ describe('SpeakerAssign', () => {
     expect(onSwapAll).toHaveBeenCalledTimes(1)
     expect(onApply).toHaveBeenCalledTimes(1)
     expect(onInsertPlain).toHaveBeenCalledTimes(1)
+  })
+
+  it('hints a measured mishear and reports the corrected line on tap, touching nothing else', () => {
+    const { onReplace, onToggle } = setup([
+      { id: 'seg-0', speaker: 'patient', text: 'Patut sudah empat hari.' },
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'Replace Patut with Batuk' }))
+    expect(onReplace).toHaveBeenCalledTimes(1)
+    expect(onReplace).toHaveBeenCalledWith('seg-0', 'Batuk sudah empat hari.')
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  it('renders no correction chip on lines without a lexicon hit', () => {
+    setup()
+    expect(screen.queryByRole('button', { name: /^replace /i })).toBeNull()
+  })
+
+  it('renders an independently tappable chip per occurrence of one mishear', () => {
+    const { onReplace } = setup([
+      { id: 'seg-0', speaker: 'patient', text: 'patut pagi, patut malam' },
+    ])
+    const chips = screen.getAllByRole('button', { name: 'Replace patut with batuk' })
+    expect(chips).toHaveLength(2)
+    fireEvent.click(chips[1] as HTMLElement)
+    expect(onReplace).toHaveBeenCalledTimes(1)
+    expect(onReplace).toHaveBeenCalledWith('seg-0', 'patut pagi, batuk malam')
   })
 })

--- a/frontend/src/audio/SpeakerAssign.tsx
+++ b/frontend/src/audio/SpeakerAssign.tsx
@@ -1,6 +1,8 @@
 import { ArrowLeftRight, Check, Type } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { cn } from '../lib/cn.js'
 import { Button } from '../ui/Button.js'
+import { applyConfusable, findConfusables } from './confusables.js'
 import type { DraftLine } from './draft-turns.js'
 
 /**
@@ -15,15 +17,59 @@ import type { DraftLine } from './draft-turns.js'
 const formatOffset = (seconds: number): string =>
   `${Math.floor(seconds / 60)}:${String(Math.floor(seconds % 60)).padStart(2, '0')}`
 
+/**
+ * Line text with measured ASR mishears underlined, each followed by a
+ * one-tap correction chip (docs/trd.md §20.3, issue #193). The chip edits
+ * only on an explicit tap, so the doctor stays the author of every
+ * correction, exactly as with the label toggles. Hints derive from the text
+ * on every render: once corrected, the token no longer matches and the
+ * underline disappears with it.
+ */
+function HintedText({
+  line,
+  onReplace,
+}: {
+  line: DraftLine
+  onReplace: (id: string, nextText: string) => void
+}) {
+  const hints = findConfusables(line.text)
+  if (hints.length === 0) return <span className="text-ink">{line.text}</span>
+
+  const parts: ReactNode[] = []
+  let cursor = 0
+  for (const hint of hints) {
+    if (hint.start > cursor) parts.push(line.text.slice(cursor, hint.start))
+    parts.push(
+      <span key={`${hint.start}-word`} className="underline decoration-dotted underline-offset-2">
+        {hint.found}
+      </span>,
+      <button
+        key={`${hint.start}-chip`}
+        type="button"
+        onClick={() => onReplace(line.id, applyConfusable(line.text, hint))}
+        aria-label={`Replace ${hint.found} with ${hint.suggestion}`}
+        className="mx-1 inline-flex items-center rounded-control border border-line bg-sunken px-1.5 text-xs font-medium text-ink-muted transition-colors hover:bg-line/60"
+      >
+        {hint.suggestion}?
+      </button>,
+    )
+    cursor = hint.end
+  }
+  if (cursor < line.text.length) parts.push(line.text.slice(cursor))
+  return <span className="text-ink">{parts}</span>
+}
+
 export function SpeakerAssign({
   draft,
   onToggle,
+  onReplace,
   onSwapAll,
   onApply,
   onInsertPlain,
 }: {
   draft: readonly DraftLine[]
   onToggle: (id: string) => void
+  onReplace: (id: string, nextText: string) => void
   onSwapAll: () => void
   onApply: () => void
   onInsertPlain: () => void
@@ -47,8 +93,10 @@ export function SpeakerAssign({
       </div>
       <p className="mt-1 text-xs text-ink-muted">
         Labels are guessed from what each sentence says, not from the voices, and can be wrong. Tap
-        a label to flip it. A sentence holding both speakers is best fixed in the transcript box
-        after applying. Plain text joins the turn above it until you label it.
+        a label to flip it. A dotted word is a measured mishear of a Malay clinical word; tap the
+        suggestion after it to correct that word only. A sentence holding both speakers is best
+        fixed in the transcript box after applying. Plain text joins the turn above it until you
+        label it.
       </p>
 
       <ul className="mt-3 flex max-h-80 flex-col gap-1 overflow-y-auto pr-1">
@@ -75,7 +123,7 @@ export function SpeakerAssign({
                   {formatOffset(line.offsetSeconds)}
                 </span>
               )}
-              <span className="text-ink">{line.text}</span>
+              <HintedText line={line} onReplace={onReplace} />
             </p>
           </li>
         ))}

--- a/frontend/src/audio/confusables.test.ts
+++ b/frontend/src/audio/confusables.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { applyConfusable, findConfusables } from './confusables.js'
+
+describe('findConfusables', () => {
+  it.each([
+    ['patut', 'batuk'],
+    ['patuk', 'batuk'],
+    ['teman', 'demam'],
+    ['tenggi', 'denggi'],
+    ['tanggi', 'denggi'],
+    ['sempuk', 'semput'],
+    ['pengkat', 'bengkak'],
+    ['penkak', 'bengkak'],
+    ['kekak', 'tekak'],
+    ['tongso', 'tonsil'],
+    ['tongsel', 'tonsil'],
+  ])('hints the measured pair %s to %s', (found, suggestion) => {
+    expect(findConfusables(`ada ${found} sikit`)).toEqual([
+      { start: 4, end: 4 + found.length, found, suggestion },
+    ])
+  })
+
+  it('preserves the leading capital of the token it flags', () => {
+    expect(findConfusables('Patut sudah empat hari.')).toEqual([
+      { start: 0, end: 5, found: 'Patut', suggestion: 'Batuk' },
+    ])
+  })
+
+  it('flags whole tokens only, never words containing one', () => {
+    expect(findConfusables('sepatutnya berpatutan tema temanku')).toEqual([])
+  })
+
+  it('returns one hint per occurrence, each at its own offset', () => {
+    const hints = findConfusables('patut tadi, patut lagi')
+    expect(hints).toHaveLength(2)
+    expect(hints[0]).toMatchObject({ start: 0, end: 5 })
+    expect(hints[1]).toMatchObject({ start: 12, end: 17 })
+  })
+})
+
+describe('applyConfusable', () => {
+  it('replaces only the tapped occurrence', () => {
+    const text = 'patut tadi, patut lagi'
+    const second = findConfusables(text)[1]
+    if (!second) throw new Error('expected a second hint')
+    expect(applyConfusable(text, second)).toBe('patut tadi, batuk lagi')
+  })
+
+  it('returns the text unchanged when the hint no longer matches', () => {
+    const hint = findConfusables('patut sudah')[0]
+    if (!hint) throw new Error('expected a hint')
+    expect(applyConfusable('typed over completely', hint)).toBe('typed over completely')
+  })
+})

--- a/frontend/src/audio/confusables.ts
+++ b/frontend/src/audio/confusables.ts
@@ -1,0 +1,68 @@
+/**
+ * Measured Malay ASR confusables (docs/trd.md §20.3, issue #193). Both
+ * measured ASR arms harden the first consonant of Malay clinical words, so
+ * the draft review list points at the likely intended word and lets the
+ * doctor fix it in one tap. The table is capped at pairs the §20.3 token
+ * table actually recorded, never phonetic speculation.
+ *
+ * Everyday words ("patut", "teman") are allowed here, unlike in
+ * backend/src/redflags/triggers.ts, because a doctor reviews and applies
+ * every hint, while a trigger acts without review. There is no context gate
+ * either: the measured failure "patut sudah empat hari lah" contains no
+ * other clinical word, so any cheap gate would hide exactly the case this
+ * exists for. A wrong hint costs a glance; a hidden right one costs a wrong
+ * transcript.
+ */
+
+export type ConfusableHint = {
+  /** [start, end) offsets of the flagged token in the text it was found in. */
+  start: number
+  end: number
+  found: string
+  suggestion: string
+}
+
+const CONFUSABLES: ReadonlyMap<string, string> = new Map([
+  ['patut', 'batuk'],
+  ['patuk', 'batuk'],
+  ['teman', 'demam'],
+  ['tenggi', 'denggi'],
+  ['tanggi', 'denggi'],
+  ['sempuk', 'semput'],
+  ['pengkat', 'bengkak'],
+  ['penkak', 'bengkak'],
+  ['kekak', 'tekak'],
+  ['tongso', 'tonsil'],
+  ['tongsel', 'tonsil'],
+])
+
+const matchCase = (suggestion: string, found: string): string =>
+  found.charAt(0) === found.charAt(0).toUpperCase()
+    ? suggestion.charAt(0).toUpperCase() + suggestion.slice(1)
+    : suggestion
+
+/** Whole tokens only: "sepatutnya" never hints, only the bare word does. */
+export function findConfusables(text: string): ConfusableHint[] {
+  const hints: ConfusableHint[] = []
+  for (const match of text.matchAll(/\p{L}+/gu)) {
+    const token = match[0]
+    const suggestion = CONFUSABLES.get(token.toLowerCase())
+    if (suggestion === undefined) continue
+    hints.push({
+      start: match.index,
+      end: match.index + token.length,
+      found: token,
+      suggestion: matchCase(suggestion, token),
+    })
+  }
+  return hints
+}
+
+/**
+ * Replaces exactly the hinted token. Total on stale input: if the text under
+ * the hint has changed, the text comes back untouched rather than corrupted.
+ */
+export function applyConfusable(text: string, hint: ConfusableHint): string {
+  if (text.slice(hint.start, hint.end) !== hint.found) return text
+  return `${text.slice(0, hint.start)}${hint.suggestion}${text.slice(hint.end)}`
+}

--- a/frontend/src/routes/ConsultationNew.test.tsx
+++ b/frontend/src/routes/ConsultationNew.test.tsx
@@ -125,6 +125,21 @@ function MockAudioCapture({
       >
         mock transcribe hosted raw
       </button>
+      {/* A hosted draft carrying a measured Malay mishear (docs/trd.md
+          §20.3), so the tap-to-correct chip can be driven end to end. */}
+      <button
+        type="button"
+        onClick={() =>
+          onTranscript({
+            text: 'Patut sudah empat hari.',
+            segments: [],
+            source: 'asr_hosted',
+            draftTurns: [{ speaker: 'patient', text: 'Patut sudah empat hari.' }],
+          })
+        }
+      >
+        mock transcribe hosted misheard
+      </button>
     </>
   )
 }
@@ -269,6 +284,19 @@ describe('hosted draft-turn labelling', () => {
     expect(screen.queryByRole('button', { name: /apply labels/i })).toBeNull()
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
     expect(textarea.value).toBe('Batuk sudah tiga hari.')
+  })
+
+  it('corrects a measured mishear on tap and applies the corrected line', () => {
+    openRecordTab()
+    fireEvent.click(screen.getByRole('button', { name: 'mock transcribe hosted misheard' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Replace Patut with Batuk' }))
+
+    // The correction consumes its own hint: the chip disappears with it.
+    expect(screen.queryByRole('button', { name: 'Replace Patut with Batuk' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /apply labels/i }))
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    expect(textarea.value).toBe('Patient: Batuk sudah empat hari.')
   })
 
   it('re-ids a second delivery appended to a pending hosted draft without colliding', () => {

--- a/frontend/src/routes/ConsultationNew.tsx
+++ b/frontend/src/routes/ConsultationNew.tsx
@@ -243,6 +243,13 @@ export function ConsultationNew() {
                     current ? current.map((line) => (line.id === id ? flip(line) : line)) : current,
                   )
                 }
+                onReplace={(id, nextText) =>
+                  setDraft((current) =>
+                    current
+                      ? current.map((line) => (line.id === id ? { ...line, text: nextText } : line))
+                      : current,
+                  )
+                }
                 onSwapAll={() => setDraft((current) => (current ? current.map(flip) : current))}
                 onApply={() => {
                   if (!draft) return


### PR DESCRIPTION
## What Changed

Recording now captures dictation-grade audio (browser voice-call DSP off, pinned by test), the Record tab states the Malay on-device limits honestly and the ILMU tooltip carries the measured devoicing caveat, and the draft-label review list underlines measured Malay mishears ("patut") with a one-tap correction chip ("Batuk?") the doctor confirms line by line. TRD 20.6 records the capture change and the human re-measurement protocol.

Closes #191
Closes #193

## Why

TRD 20.3 measured consonant devoicing on both ASR arms at the same words and pointed at the capture audio profile as a contributor; browser noise suppression attenuates exactly the low-energy consonant bursts that separate b/p and d/t. Where the ASR still mishears, correction stays doctor-in-the-loop: the hint lexicon is deterministic (the eleven measured forms only, no LLM), nothing rewrites text without an explicit tap, and the plain-prose fallback path is deliberately out of scope for v1 (recorded in #193).

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`

Frontend 183/183, including the new confusables unit tests, the SpeakerAssign chip render and click contract (independent chips for a repeated mishear), the pinned getUserMedia constraints object, and an end-to-end tap-then-Apply in ConsultationNew. `npx impeccable detect` is clean. frontend-reviewer was dispatched on the diff and returned clean with two nits, both taken (neutral copy tone for the hosted-option sentence; the two-chip test).

## Notes For The Reviewer

Two tier-ordered commits so the hints half is severable: commit 1 is the capture fix, honest copy, and TRD 20.6 (#191); commit 2 is the confusables lexicon and review-time chips (#193). Constraint values are ideals per the mediacapture spec and never throw; TRD 20.6 requires recording track.getSettings() beside any future measurement, and the A/B re-measurement needs a human to re-record the rojak script (protocol in 20.6). A manual browser walk was not run in this session (the local docker DB was down), so a one-minute visual pass on light and dark themes after deploy is worth it. Hint noise on everyday words ("patut", "teman") is accepted and documented in the module comment: any cheap gate would suppress the measured headline failure, and the same pairs stay deliberately rejected in the deterministic red-flag triggers (#194).

🤖 Generated with [Claude Code](https://claude.com/claude-code)