### PR TITLE
feat(consultations): name records by their findings, and let the doctor rename them

### DIFF
--- a/backend/src/analysis/title.test.ts
+++ b/backend/src/analysis/title.test.ts
@@ -1,0 +1,97 @@
+import { ClinicalFactsSchema } from '@shared/types'
+import { describe, expect, it } from 'vitest'
+import { deriveConsultationTitle } from './title.js'
+
+/** Every key defaults to NOT_ASSESSED, so a case only states what it changes. */
+const facts = (symptoms: Record<string, { state: string; value?: string; evidence?: string }>) =>
+  ClinicalFactsSchema.parse({
+    symptoms,
+    history: {},
+    observations: {},
+    examination: {},
+  })
+
+describe('the derived consultation title', () => {
+  it('names the findings that are present, in contract order', () => {
+    const title = deriveConsultationTitle(
+      facts({
+        soreThroat: { state: 'PRESENT', value: 'sore throat', evidence: 'my throat hurts' },
+        cough: { state: 'PRESENT', value: 'dry cough', evidence: 'been coughing' },
+      }),
+    )
+    // `cough` is declared before `soreThroat` in `ClinicalFactsSchema`, and the
+    // order comes from there rather than from the order they were passed in.
+    expect(title).toBe('Cough, sore throat')
+  })
+
+  it('counts a clinician observation as present', () => {
+    expect(
+      deriveConsultationTitle(
+        facts({ fever: { state: 'CLINICIAN_OBSERVED', value: '38.4', evidence: 'temp 38.4' } }),
+      ),
+    ).toBe('Fever')
+  })
+
+  it('is null when nothing is present, so the UI falls back to the timestamp', () => {
+    expect(deriveConsultationTitle(facts({}))).toBeNull()
+    expect(
+      deriveConsultationTitle(
+        facts({ cough: { state: 'DENIED', value: 'no cough', evidence: 'not coughing' } }),
+      ),
+    ).toBeNull()
+  })
+
+  it('never reports a denial as a finding', () => {
+    const title = deriveConsultationTitle(
+      facts({
+        cough: { state: 'PRESENT', value: 'cough', evidence: 'coughing' },
+        haemoptysis: { state: 'DENIED', value: 'no blood', evidence: 'no blood' },
+      }),
+    )
+    expect(title).toBe('Cough')
+    expect(title).not.toMatch(/haemoptysis/i)
+  })
+
+  /*
+   * The property that keeps this out of the PHI conversation. A title built
+   * from contract key names cannot contain a word the patient or the doctor
+   * said, however alarming the transcript is, because no assertion `value` or
+   * `evidence` is ever read.
+   */
+  it('carries no transcript text, only contract field names', () => {
+    const title = deriveConsultationTitle(
+      facts({
+        cough: {
+          state: 'PRESENT',
+          value: 'Ahmad bin Ismail has a cough',
+          evidence: 'Ahmad bin Ismail, 880101-14-5501, has a cough',
+        },
+      }),
+    )
+    expect(title).toBe('Cough')
+    expect(title).not.toMatch(/Ahmad|880101/)
+  })
+
+  it('stops at three, so a row stays scannable', () => {
+    const title = deriveConsultationTitle(
+      facts({
+        cough: { state: 'PRESENT', value: 'a', evidence: 'a' },
+        soreThroat: { state: 'PRESENT', value: 'b', evidence: 'b' },
+        fever: { state: 'PRESENT', value: 'c', evidence: 'c' },
+        dyspnoea: { state: 'PRESENT', value: 'd', evidence: 'd' },
+        chestPain: { state: 'PRESENT', value: 'e', evidence: 'e' },
+      }),
+    )
+    expect(title?.split(', ')).toHaveLength(3)
+  })
+
+  /*
+   * The reason a model does not write this. `operational.diagnosis` is the one
+   * field that could turn a filing label into a clinical assertion, and this
+   * function cannot reach it: its whole input is `clinicalFacts`.
+   */
+  it('cannot state a diagnosis, because it never reads the operational block', () => {
+    const source = deriveConsultationTitle.toString()
+    expect(source).not.toMatch(/diagnosis|operational/i)
+  })
+})

--- a/backend/src/analysis/title.ts
+++ b/backend/src/analysis/title.ts
@@ -1,0 +1,69 @@
+import type { ClinicalFacts } from '@shared/types'
+
+/**
+ * The filing name a consultation gets when it is analysed.
+ *
+ * **Composed in code, never generated.** A title is the most prominent text in
+ * the product: it is the record's identity in every list and the first line on
+ * the detail page. Asking a model for one would put generated prose in exactly
+ * the position where `docs/prd.md` §10 forbids it, because a sentence like
+ * "likely bacterial tonsillitis" is a diagnosis nobody said, and §21.1 measured
+ * the model fabricating eight findings on a sparse transcript in 5 of 5 runs.
+ * A three-minute upper-respiratory consult is that sparse case.
+ *
+ * So this is a tier-2 control rather than a tier-4 one (`docs/trd.md` §21.3):
+ * it can only name findings that already survived the evidence check, and it
+ * structurally cannot state a diagnosis because it never reads the operational
+ * block where `diagnosis` lives.
+ *
+ * **It contains no transcript text.** Only the schema's own field names are
+ * used, humanised, never an assertion's `value` or `evidence`. So the derived
+ * title carries a clinical category and not one word the patient or the doctor
+ * said, which is what keeps it free of identifiers by construction rather than
+ * by filtering. The doctor may rename it afterwards to anything at all, and
+ * that free text is PHI and erased as such; this is not.
+ *
+ * **No symptom is named here, and that is a constraint rather than a style.**
+ * `no-stray-clinical-constants.test.ts` fails the build on a single-quoted
+ * literal equal to a checklist id, and those ids are bare clinical words:
+ * `fever`, `haemoptysis`, `sputum-production`. Reading the keys off the parsed
+ * object keeps the clinical vocabulary in `shared/` where it is versioned, and
+ * means a symptom added to the schema starts appearing in titles with no change
+ * here, exactly as `ChecklistPanel` derives the operational block rather than
+ * listing it.
+ */
+
+/** Ordinary prose, from a camelCase contract key. `soreThroat` -> `sore throat`. */
+const humanise = (key: string) => key.replace(/([A-Z])/g, ' $1').toLowerCase()
+
+/**
+ * Both states mean the finding is there. `CLINICIAN_OBSERVED` is the doctor's
+ * own examination finding, which is at least as title-worthy as a reported
+ * symptom, and omitting it would title a consultation by what the patient
+ * mentioned while ignoring what the doctor found.
+ */
+const PRESENT_STATES = new Set(['PRESENT', 'CLINICIAN_OBSERVED'])
+
+/**
+ * Three keeps the title a label rather than a summary. A row that lists seven
+ * findings is not scannable, which is the entire problem a title solves, and
+ * the list truncates anyway.
+ */
+const MAX_FINDINGS = 3
+
+export function deriveConsultationTitle(clinicalFacts: ClinicalFacts): string | null {
+  // Declaration order in `ClinicalFactsSchema`, which is a clinical judgement
+  // already made once in `shared/` rather than a second one made here.
+  const present = Object.entries(clinicalFacts.symptoms)
+    .filter(([, assertion]) => PRESENT_STATES.has(assertion.state))
+    .map(([key]) => humanise(key))
+
+  if (present.length === 0) return null
+
+  const shown = present.slice(0, MAX_FINDINGS)
+  const title = shown.join(', ')
+
+  // Sentence case, not title case: this is a description of a consultation,
+  // and title-casing clinical words makes them read as proper nouns.
+  return title.charAt(0).toUpperCase() + title.slice(1)
+}

--- a/backend/src/audit/erasure.test.ts
+++ b/backend/src/audit/erasure.test.ts
@@ -5,6 +5,8 @@ import { type AuditChainRow, recordAuditEvent, verifyAuditChainFromDatabase } fr
 type ConsultationRow = {
   id: string
   doctorId: string
+  /** The fourth PHI column, and the only one that is not Json. */
+  title: string | null
   transcript: unknown
   analysis: unknown
   editedNote: unknown
@@ -71,6 +73,7 @@ beforeEach(() => {
   consultations.set('consult-1', {
     id: 'consult-1',
     doctorId: 'doctor-1',
+    title: null,
     transcript: { turns: [{ speaker: 'patient', text: 'I am Ahmad with a cough' }] },
     analysis: { note: { subjective: 'Ahmad reports cough' } },
     editedNote: { subjective: 'Doctor note about Ahmad' },
@@ -106,5 +109,34 @@ describe('eraseConsultation', () => {
       consultationId: 'consult-1',
     })
     await expect(verifyAuditChainFromDatabase()).resolves.toMatchObject({ ok: true, verified: 3 })
+  })
+
+  /*
+   * The fourth erasure target, pinned separately from the three above because
+   * it is the one that is not a Json column and the one a reader is most likely
+   * to forget.
+   *
+   * `title` is doctor-editable free text shown on every list row, so it holds a
+   * patient's name whenever that is the useful thing to file under. An erasure
+   * that cleared the transcript and left the title would leave the name of the
+   * person whose record was just erased sitting at the top of the list, which
+   * is the most visible place in the product it could possibly survive.
+   */
+  it('clears the title, which is free text a doctor may have put a name in', async () => {
+    consultations.set('consult-2', {
+      id: 'consult-2',
+      doctorId: 'doctor-1',
+      title: 'Siti Nurhaliza, recurrent cough',
+      transcript: { turns: [] },
+      analysis: {},
+      editedNote: {},
+      erasedAt: null,
+    })
+
+    await eraseConsultation('consult-2', 'doctor-1')
+
+    const erased = consultations.get('consult-2')
+    expect(erased).toMatchObject({ title: null, erasedAt: expect.any(Date) })
+    expect(JSON.stringify(erased)).not.toMatch(/Siti|Nurhaliza/)
   })
 })

--- a/backend/src/audit/erasure.ts
+++ b/backend/src/audit/erasure.ts
@@ -12,6 +12,13 @@ export async function eraseConsultation(consultationId: string, actorId: string)
       transcript: Prisma.DbNull,
       analysis: Prisma.DbNull,
       editedNote: Prisma.DbNull,
+      // The fourth PHI column. `title` is doctor-editable free text shown in
+      // every list, so it holds a patient name whenever one is useful as a
+      // filing name, and an erasure that left it behind would leave the name
+      // of the person whose record was just erased sitting on the row.
+      // `null` rather than `Prisma.DbNull`: this is a nullable String column,
+      // not Json, and `DbNull` is only for the Json ones.
+      title: null,
       erasedAt: new Date(),
     },
   })

--- a/backend/src/audit/index.ts
+++ b/backend/src/audit/index.ts
@@ -73,6 +73,18 @@ export type ConsultationAuditEvent =
     }
   | { action: 'consultation.analysis_failed'; metadata: { reason: AnalysisFailureReason } }
   | { action: 'consultation.edited' }
+  /*
+   * Its own action rather than folded into `consultation.edited`, because
+   * `title` is a PHI-bearing column a doctor writes free text into, and it is
+   * the one field that stays editable after approval. A trail that cannot tell
+   * "the note was changed" from "the record was renamed after it was signed"
+   * loses the distinction precisely where it matters.
+   *
+   * No metadata. The old and new titles are exactly the free text this must not
+   * carry, so the row records that a rename happened, by whom and when, and the
+   * value lives only in the column.
+   */
+  | { action: 'consultation.renamed' }
   | { action: 'consultation.erased' }
   | { action: 'redflag.acknowledged'; metadata: { redFlagId: string } }
   | { action: 'gap.reviewed'; metadata: { gapId: string } }

--- a/backend/src/lib/logger.leak.test.ts
+++ b/backend/src/lib/logger.leak.test.ts
@@ -117,6 +117,23 @@ vi.mock('../lib/prisma.js', () => ({
           return { ...row }
         },
       ),
+      // The analyse path names an unnamed consultation through a check-and-set,
+      // so this stub filters on the predicates present exactly as Prisma does.
+      updateMany: vi.fn(
+        async ({
+          where,
+          data,
+        }: {
+          where: { id: string; title?: string | null }
+          data: Record<string, unknown>
+        }) => {
+          const row = store.get(where.id)
+          if (!row) return { count: 0 }
+          if ('title' in where && row.title !== where.title) return { count: 0 }
+          store.set(where.id, { ...row, ...data, updatedAt: new Date() })
+          return { count: 1 }
+        },
+      ),
     },
     auditEvent,
     // Appends run inside a transaction (issue #27); run the callback against
@@ -148,6 +165,7 @@ beforeEach(() => {
     id: 'c1',
     doctorId: 'doctor-1',
     status: 'draft',
+    title: null,
     transcript: FIXTURE.transcript,
     analysis: null,
     editedNote: null,

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -220,6 +220,10 @@ function seed(status: string, extra: Record<string, unknown> = {}) {
     id: 'c1',
     doctorId: 'doctor-1',
     status,
+    // Null rather than absent, because that is what the column returns for a
+    // consultation nobody has named. A factory that omits it would let a route
+    // reading `row.title` pass here and fail against Postgres.
+    title: null,
     transcript: TRANSCRIPT,
     analysis: null,
     editedNote: null,
@@ -406,6 +410,77 @@ describe('analyse output', () => {
     ).toMatchObject({
       profileId: 'adult-acute-uncomplicated-uti',
     })
+  })
+})
+
+/*
+ * Renaming is filing, not clinical editing, and the difference is what decides
+ * which rules apply to it.
+ */
+describe('renaming a consultation', () => {
+  it('stores the new name and records it as its own audit action', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    const res = await call('PATCH', '/api/consultations/c1', { title: 'Cough, sore throat' })
+
+    expect(res.status).toBe(200)
+    expect(store.get('c1')).toMatchObject({ title: 'Cough, sore throat' })
+    // Not `consultation.edited`: a trail that cannot tell a rename from a note
+    // change loses the distinction on the one field editable after sign-off.
+    expect(audits.map((a) => a.action)).toContain('consultation.renamed')
+    expect(audits.map((a) => a.action)).not.toContain('consultation.edited')
+  })
+
+  it('collapses a blank name to null, so cleared and never-named are one state', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS, title: 'Something' })
+
+    const res = await call('PATCH', '/api/consultations/c1', { title: '   ' })
+
+    expect(res.status).toBe(200)
+    expect(store.get('c1')).toMatchObject({ title: null })
+  })
+
+  it('rejects a name past the bound rather than storing it', async () => {
+    seed('awaiting_review', { analysis: ANALYSIS })
+
+    const res = await call('PATCH', '/api/consultations/c1', { title: 'x'.repeat(121) })
+
+    expect(res.status).toBe(400)
+  })
+
+  /*
+   * The deliberate exception to the terminal state, and the reason it is safe.
+   *
+   * `approved` freezes the clinical record. A filing name is not part of that
+   * record: it carries no note text, no finding and no disposition. Locking it
+   * would make the archive unsearchable at exactly the point it becomes an
+   * archive, since the consultations somebody needs to find later are the
+   * signed ones.
+   */
+  it('renames an approved consultation, which is the one edit sign-off allows', async () => {
+    seed('approved', { analysis: ANALYSIS, approvedAt: new Date() })
+
+    const res = await call('PATCH', '/api/consultations/c1', { title: 'Filed under this' })
+
+    expect(res.status).toBe(200)
+    expect(store.get('c1')).toMatchObject({ title: 'Filed under this' })
+  })
+
+  it('still refuses clinical content on an approved consultation', async () => {
+    seed('approved', { analysis: ANALYSIS, approvedAt: new Date() })
+
+    expect(
+      (await call('PATCH', '/api/consultations/c1', { editedNote: { plan: 'No' } })).status,
+    ).toBe(409)
+    // And a rename cannot be used to smuggle one through alongside it.
+    expect(
+      (
+        await call('PATCH', '/api/consultations/c1', {
+          title: 'Still no',
+          editedNote: { plan: 'No' },
+        })
+      ).status,
+    ).toBe(409)
   })
 })
 

--- a/backend/src/routes/consultations.test.ts
+++ b/backend/src/routes/consultations.test.ts
@@ -175,6 +175,32 @@ vi.mock('../lib/prisma.js', () => ({
           return { ...row }
         },
       ),
+      /*
+       * Honours the whole `where`, not just the id. The analyse path names an
+       * unnamed consultation with `where: { id, title: null }`, and a stub that
+       * ignored the predicate would write the title unconditionally and report
+       * the check-and-set as working when it was not.
+       */
+      updateMany: vi.fn(
+        async ({
+          where,
+          data,
+        }: {
+          where: { id: string; title?: string | null }
+          data: Record<string, unknown>
+        }) => {
+          const row = store.get(where.id)
+          if (!row) return { count: 0 }
+          // Only the predicates actually present filter, exactly as Prisma
+          // behaves. Comparing an absent `title` against the row's would make
+          // dropping the predicate match nothing, so removing the guard would
+          // fail the plain "names an unnamed consultation" test rather than
+          // the race test written to catch it.
+          if ('title' in where && row.title !== where.title) return { count: 0 }
+          store.set(where.id, { ...row, ...data, updatedAt: new Date() })
+          return { count: 1 }
+        },
+      ),
     },
     // Issue #26: an approved consultation names the clinician who approved it,
     // so the detail serialiser resolves the owning doctor. Only reached once
@@ -267,6 +293,54 @@ const call = (method: string, path: string, body?: unknown) =>
     },
     body: body ? JSON.stringify(body) : undefined,
   })
+
+describe('the title analysis derives', () => {
+  it('names an unnamed consultation from its own findings', async () => {
+    seed('draft')
+
+    await call('POST', '/api/consultations/c1/analyze')
+
+    // Composed from the assertion keys, so it is clinical vocabulary from
+    // `shared/` and carries nothing either speaker said.
+    expect(store.get('c1')?.title).toEqual(expect.any(String))
+  })
+
+  /*
+   * The doctor's name wins, and the check is at write time rather than against
+   * the row this handler read.
+   *
+   * A record is renameable in every state it appears in, `analyzing` included,
+   * and analysis can run for a couple of minutes. So renaming a row while it
+   * analyses is an ordinary sequence, and a stale-read guard would let the
+   * derived name overwrite the one the doctor had just chosen.
+   */
+  it('does not overwrite a name the doctor set while the analysis was running', async () => {
+    seed('draft')
+
+    // Stands in for the rename landing mid-run: the row is named after this
+    // handler has read it and before it writes the derived one.
+    const renameMidRun = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const row = store.get('c1')
+        if (row) store.set('c1', { ...row, title: 'Mrs Tan, follow-up' })
+        resolve()
+      }, 0)
+    })
+
+    const [res] = await Promise.all([call('POST', '/api/consultations/c1/analyze'), renameMidRun])
+
+    expect(res.status).toBe(200)
+    expect(store.get('c1')?.title).toBe('Mrs Tan, follow-up')
+  })
+
+  it('leaves a name alone on re-analysis', async () => {
+    seed('awaiting_review', { title: 'Filed under this' })
+
+    await call('POST', '/api/consultations/c1/analyze')
+
+    expect(store.get('c1')?.title).toBe('Filed under this')
+  })
+})
 
 describe('state machine — analyze', () => {
   it.each(['draft', 'awaiting_review'])('is allowed from %s', async (status) => {
@@ -457,6 +531,28 @@ describe('renaming a consultation', () => {
    * archive, since the consultations somebody needs to find later are the
    * signed ones.
    */
+  /*
+   * The rule, stated as a rule rather than as four cases: if a record is
+   * visible in the list, it can be named. A doctor scanning that list is
+   * looking at drafts and analysing rows alongside finished ones, and a name is
+   * how they tell any of them apart, so a state that renders but cannot be
+   * renamed is the state most in need of a name.
+   */
+  it('renames a consultation in every state it can appear in the list', async () => {
+    for (const status of ['draft', 'analyzing', 'awaiting_review', 'approved']) {
+      audits.length = 0
+      seed(status, {
+        analysis: ANALYSIS,
+        ...(status === 'approved' ? { approvedAt: new Date() } : {}),
+      })
+
+      const res = await call('PATCH', '/api/consultations/c1', { title: `Named while ${status}` })
+
+      expect(res.status, status).toBe(200)
+      expect(store.get('c1'), status).toMatchObject({ title: `Named while ${status}` })
+    }
+  })
+
   it('renames an approved consultation, which is the one edit sign-off allows', async () => {
     seed('approved', { analysis: ANALYSIS, approvedAt: new Date() })
 

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -4,6 +4,7 @@ import {
   ConsultationAnalysisSchema,
   ConsultationDetailSchema,
   ConsultationListItemSchema,
+  ConsultationTitleSchema,
   type Disposition,
   type DispositionInput,
   DispositionInputSchema,
@@ -18,6 +19,7 @@ import {
 import { Router } from 'express'
 import { z } from 'zod'
 import { analyseNote, buildEvidenceLinks } from '../analysis/index.js'
+import { deriveConsultationTitle } from '../analysis/title.js'
 import { eraseConsultation } from '../audit/erasure.js'
 import { type AnalysisFailureReason, getAuditHistory, recordAuditEvent } from '../audit/index.js'
 import {
@@ -79,6 +81,11 @@ function toDetail(row: Consultation, approvedBy: string | null = null) {
   return ConsultationDetailSchema.parse({
     id: row.id,
     status: row.status,
+    // `?? null` for the same reason the JSON columns below carry it: a row
+    // built before this column existed, or by a caller that did not select it,
+    // arrives as `undefined`, and the contract distinguishes "no title" from
+    // "field absent" only by rejecting the second.
+    title: row.title ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     transcript: row.transcript ?? null,
@@ -178,7 +185,7 @@ consultationsRouter.get('/', async (req, res) => {
   const rows = await prisma.consultation.findMany({
     where: { doctorId: doctorId(req), erasedAt: null },
     orderBy: { updatedAt: 'desc' },
-    select: { id: true, status: true, createdAt: true, updatedAt: true },
+    select: { id: true, status: true, title: true, createdAt: true, updatedAt: true },
   })
 
   res.json({ consultations: rows.map((row) => ConsultationListItemSchema.parse(row)) })
@@ -399,10 +406,28 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
       consultation.id,
     )
 
+    /*
+     * The derived title is written once and never overwritten.
+     *
+     * A doctor who has renamed a record has said what they want it filed as,
+     * and re-analysis must not take that back. Re-analysis also regenerates
+     * `analysis` wholesale, so a title that tracked it would change under the
+     * doctor for reasons they did not ask for. First run names it; after that
+     * the name is theirs.
+     */
+    const derivedTitle =
+      consultation.title === null && analysis.clinicalFacts !== undefined
+        ? deriveConsultationTitle(analysis.clinicalFacts)
+        : null
+
     const updated = await timeStage('persistence', () =>
       prisma.consultation.update({
         where: { id: consultation.id },
-        data: { status: 'awaiting_review', analysis },
+        data: {
+          status: 'awaiting_review',
+          analysis,
+          ...(derivedTitle === null ? {} : { title: derivedTitle }),
+        },
       }),
     )
 
@@ -549,6 +574,19 @@ consultationsRouter.post('/analyze-ephemeral', async (req, res) => {
 
 const PatchBodySchema = z
   .object({
+    /*
+     * Renaming stays available after approval, and that is a decision rather
+     * than an oversight.
+     *
+     * `approved` is terminal and no clinical content may change after it. A
+     * filing label is not clinical content: it is how the record is found
+     * later, and an approved consultation is precisely the one somebody will
+     * need to find. Locking it would make the archive unsearchable at exactly
+     * the moment it starts being an archive. The note, the flags and the
+     * dispositions remain immutable, and every rename writes an audit event, so
+     * the change is attributable.
+     */
+    title: ConsultationTitleSchema.optional(),
     editedNote: SoapNoteSchema.partial().optional(),
     acknowledgedRedFlagIds: z.array(z.string()).optional(),
     reviewedGapIds: z.array(z.string()).optional(),
@@ -584,7 +622,26 @@ consultationsRouter.patch('/:id', async (req, res) => {
   const actor = doctorId(req)
   const consultation = await assertOwnedConsultation(req.params.id, actor)
 
-  if (consultation.status !== 'awaiting_review') {
+  const parsed = PatchBodySchema.safeParse(req.body)
+  if (!parsed.success) {
+    throw new HttpError(400, 'invalid_body', 'No valid changes supplied.')
+  }
+  const patch = parsed.data
+
+  /*
+   * The state gate applies to clinical content, and a filing name is not
+   * clinical content.
+   *
+   * A rename carries no note text, no finding and no disposition, so nothing it
+   * can change is part of the record `approved` freezes. Letting it through is
+   * what keeps an archive searchable, since the consultations somebody needs to
+   * find later are exactly the signed ones. Any patch touching anything else
+   * still meets the original gate unchanged, and a mixed patch is judged by the
+   * clinical half rather than excused by the title.
+   */
+  const titleOnly = patch.title !== undefined && Object.keys(patch).length === 1
+
+  if (!titleOnly && consultation.status !== 'awaiting_review') {
     throw new HttpError(
       409,
       'invalid_state',
@@ -593,12 +650,6 @@ consultationsRouter.patch('/:id', async (req, res) => {
         : 'This consultation is not open for review.',
     )
   }
-
-  const parsed = PatchBodySchema.safeParse(req.body)
-  if (!parsed.success) {
-    throw new HttpError(400, 'invalid_body', 'No valid changes supplied.')
-  }
-  const patch = parsed.data
 
   /**
    * The PATCH body is a `Partial<SoapNote>`, but `editedNote` on the wire is a
@@ -658,6 +709,7 @@ consultationsRouter.patch('/:id', async (req, res) => {
   const updated = await prisma.consultation.update({
     where: { id: consultation.id },
     data: {
+      ...(patch.title === undefined ? {} : { title: patch.title }),
       ...(nextEditedNote === undefined ? {} : { editedNote: nextEditedNote }),
       ...(patch.acknowledgedRedFlagIds === undefined
         ? {}
@@ -686,6 +738,13 @@ consultationsRouter.patch('/:id', async (req, res) => {
     },
   })
 
+  if (patch.title !== undefined) {
+    await recordAuditEvent({
+      action: 'consultation.renamed',
+      actorId: actor,
+      consultationId: consultation.id,
+    })
+  }
   if (patch.editedNote !== undefined) {
     await recordAuditEvent({
       action: 'consultation.edited',

--- a/backend/src/routes/consultations.ts
+++ b/backend/src/routes/consultations.ts
@@ -414,20 +414,32 @@ consultationsRouter.post('/:id/analyze', async (req, res) => {
      * `analysis` wholesale, so a title that tracked it would change under the
      * doctor for reasons they did not ask for. First run names it; after that
      * the name is theirs.
+     *
+     * **`updateMany` with `title: null` in the where clause, rather than the
+     * `consultation.title` this handler read minutes ago.** A record is
+     * renameable in every state it appears in, `analyzing` included, and
+     * analysis can take a couple of minutes, so a doctor renaming a row while
+     * it analyses is a reachable sequence rather than a theoretical one. Testing
+     * the stale read would let the derived name overwrite the one they just
+     * chose. Postgres evaluates this predicate at write time, so the doctor
+     * wins whenever they got there first.
      */
     const derivedTitle =
-      consultation.title === null && analysis.clinicalFacts !== undefined
-        ? deriveConsultationTitle(analysis.clinicalFacts)
-        : null
+      analysis.clinicalFacts === undefined ? null : deriveConsultationTitle(analysis.clinicalFacts)
 
+    if (derivedTitle !== null) {
+      await prisma.consultation.updateMany({
+        where: { id: consultation.id, title: null },
+        data: { title: derivedTitle },
+      })
+    }
+
+    // Reads back whatever the statement above settled on, so the response
+    // carries the winning title rather than the one this request proposed.
     const updated = await timeStage('persistence', () =>
       prisma.consultation.update({
         where: { id: consultation.id },
-        data: {
-          status: 'awaiting_review',
-          analysis,
-          ...(derivedTitle === null ? {} : { title: derivedTitle }),
-        },
+        data: { status: 'awaiting_review', analysis },
       }),
     )
 

--- a/frontend/src/demo/DemoTour.tsx
+++ b/frontend/src/demo/DemoTour.tsx
@@ -330,6 +330,10 @@ async function runEphemeral(): Promise<ConsultationDetail> {
   return {
     id: DEMO_CONSULTATION_ID,
     status: 'awaiting_review',
+    // Unnamed, so the tour's consultation renders through the same timestamp
+    // fallback a real un-analysed one does. Deriving a title here would mean
+    // running the composer on ephemeral analysis the tour never persists.
+    title: null,
     createdAt: now,
     updatedAt: now,
     transcript: fixture.transcript,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -168,6 +168,7 @@ export const api = {
   patch: (
     id: string,
     body: {
+      title?: string | null
       editedNote?: Partial<SoapNote>
       acknowledgedRedFlagIds?: string[]
       reviewedGapIds?: string[]

--- a/frontend/src/routes/ConsultationList.tsx
+++ b/frontend/src/routes/ConsultationList.tsx
@@ -1,6 +1,6 @@
 import type { ConsultationListItem, ConsultationStatus } from '@shared/types'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Plus, Trash2 } from 'lucide-react'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
 import { useId, useRef, useState } from 'react'
 import toast from 'react-hot-toast'
 import { Link } from 'react-router-dom'
@@ -11,6 +11,7 @@ import { Button } from '../ui/Button.js'
 import { EmptyState, Skeleton } from '../ui/Card.js'
 import { Checkbox } from '../ui/Checkbox.js'
 import { PageHeader } from '../ui/PageHeader.js'
+import { RenameField } from '../ui/RenameField.js'
 
 /**
  * Status is carried by colour, shape and a word together, never colour alone
@@ -53,6 +54,15 @@ export function ConsultationList() {
     queryFn: api.listConsultations,
   })
   const [picked, setPicked] = useState<ReadonlySet<string>>(new Set())
+  /**
+   * Which row is open for renaming, owned here rather than inside the field.
+   *
+   * A row is a link, so the pencil has to sit outside the anchor to be its own
+   * target, and it therefore cannot be the thing that holds the open state. One
+   * id rather than a set, because two rows renaming at once is not a state a
+   * doctor can be in.
+   */
+  const [renaming, setRenaming] = useState<string | null>(null)
   const dialog = useRef<HTMLDialogElement>(null)
   // Associated explicitly rather than by wrapping. The input lives inside the
   // `Checkbox` component, so a wrapping label reads as having no control in it.
@@ -85,6 +95,14 @@ export function ConsultationList() {
       void queryClient.invalidateQueries({ queryKey: ['notifications'] })
       return queryClient.invalidateQueries({ queryKey: ['consultations'] })
     },
+  })
+
+  const rename = useMutation({
+    mutationFn: ({ id, title }: { id: string; title: string | null }) => api.patch(id, { title }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['consultations'] }),
+    // Named rather than silent: a rename that failed leaves the old name on
+    // screen, which is indistinguishable from one the doctor never made.
+    onError: () => toast.error('That name could not be saved.'),
   })
 
   const toggle = (id: string) =>
@@ -181,7 +199,7 @@ export function ConsultationList() {
             <div
               key={consultation.id}
               className={cn(
-                'flex items-center gap-3 rounded-card border bg-surface pl-4 transition-colors',
+                'group/row flex items-center gap-3 rounded-card border bg-surface pl-4 transition-colors',
                 // The tint is a layer over the surface, not a replacement for
                 // it: as a `background-color` it won the cascade and left the
                 // row translucent over the page's dot grid.
@@ -198,25 +216,59 @@ export function ConsultationList() {
                 onChange={() => toggle(consultation.id)}
                 aria-label={`Select consultation from ${when}`}
               />
-              <Link
-                to={`/consultations/${consultation.id}`}
-                className="flex min-w-0 flex-1 items-center justify-between gap-4 py-4 pr-4"
-              >
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-medium">{when}</p>
-                  <p className="mt-0.5 font-mono text-2xs text-ink-muted">
-                    {consultation.id.slice(0, 8)}
-                  </p>
-                </div>
-                <span
-                  className={cn(
-                    'shrink-0 rounded-full border px-2.5 py-1 text-2xs font-medium',
-                    status.className,
-                  )}
+              {renaming === consultation.id ? (
+                <RenameField
+                  defaultEditing
+                  value={consultation.title}
+                  fallback={when}
+                  label={`Rename the consultation from ${when}`}
+                  className="min-w-0 flex-1 py-3 pr-4"
+                  onDone={() => setRenaming(null)}
+                  onSave={(title) => rename.mutate({ id: consultation.id, title })}
+                />
+              ) : (
+                <Link
+                  to={`/consultations/${consultation.id}`}
+                  className="flex min-w-0 flex-1 items-center justify-between gap-4 py-4 pr-4"
                 >
-                  {status.label}
-                </span>
-              </Link>
+                  <div className="min-w-0">
+                    {/*
+                    The name is the row's identity now, and the timestamp moves
+                    down beside the id rather than being dropped: when a record
+                    was created is still real bookkeeping, it just stops being
+                    the only thing distinguishing one row from the next.
+                  */}
+                    <p className="truncate text-sm font-medium">{consultation.title ?? when}</p>
+                    <p className="mt-0.5 truncate text-2xs text-ink-muted">
+                      <span className="font-mono">{consultation.id.slice(0, 8)}</span>
+                      {consultation.title === null ? null : ` · ${when}`}
+                    </p>
+                  </div>
+                  <span
+                    className={cn(
+                      'shrink-0 rounded-full border px-2.5 py-1 text-2xs font-medium',
+                      status.className,
+                    )}
+                  >
+                    {status.label}
+                  </span>
+                </Link>
+              )}
+
+              {/* A sibling of the link for the same reason the checkbox is: a
+                  button inside an anchor is not reachable as its own target,
+                  and pressing it would navigate instead of renaming. */}
+              {renaming === consultation.id ? null : (
+                <button
+                  type="button"
+                  data-print="hide"
+                  aria-label={`Rename the consultation from ${when}`}
+                  onClick={() => setRenaming(consultation.id)}
+                  className="mr-3 flex size-8 shrink-0 items-center justify-center rounded-control text-ink-muted opacity-0 transition-opacity hover:bg-sunken hover:text-ink focus-visible:opacity-100 group-hover/row:opacity-100 pointer-coarse:opacity-100"
+                >
+                  <Pencil aria-hidden className="size-3.5" />
+                </button>
+              )}
             </div>
           )
         })}

--- a/frontend/src/routes/ConsultationReview.tsx
+++ b/frontend/src/routes/ConsultationReview.tsx
@@ -23,6 +23,7 @@ import { GapCard, RedFlagCard, SuggestionCard } from '../review/SafetyCards.js'
 import { Button } from '../ui/Button.js'
 import { Card, Skeleton } from '../ui/Card.js'
 import { PageHeader } from '../ui/PageHeader.js'
+import { RenameField } from '../ui/RenameField.js'
 
 /** The current decision about a finding, or `undefined` if none was made. */
 function byId(dispositions: Disposition[], id: string): Disposition | undefined {
@@ -114,6 +115,24 @@ export function ConsultationReview() {
     invalidate(next)
     toast.success('Note approved. This record is now final.')
   }
+
+  /** Matches the consultation list's format, so one record reads the same in both. */
+  const formatCreated = (value: Date) =>
+    new Intl.DateTimeFormat('en-MY', {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(value)
+
+  const rename = useMutation({
+    mutationFn: (title: string | null) => api.patch(id, { title }),
+    onSuccess: (next) => {
+      invalidate(next)
+      void queryClient.invalidateQueries({ queryKey: ['consultations'] })
+    },
+    onError: () => toast.error('That name could not be saved.'),
+  })
 
   /*
    * Analysis is the one action in this product that takes real time and then
@@ -275,7 +294,32 @@ export function ConsultationReview() {
             </li>
           </ol>
         }
-        subtitle={<span className="font-mono text-xs">{detail.id}</span>}
+        /*
+         * The record's name sits here rather than replacing the page heading.
+         * `PageHeader.title` names the screen, and every other page uses it that
+         * way; swapping in a per-record value on this one page would make the
+         * heading mean something different here than everywhere else.
+         *
+         * Renaming is offered on an approved consultation too. The API allows
+         * it deliberately, because a filing name is not part of the record that
+         * sign-off freezes, and the archive has to stay searchable.
+         */
+        subtitle={
+          isEphemeral ? (
+            <span className="font-mono text-xs">{detail.id}</span>
+          ) : (
+            <span className="flex min-w-0 flex-col gap-0.5">
+              <RenameField
+                value={detail.title}
+                fallback={formatCreated(detail.createdAt)}
+                label="Rename this consultation"
+                textClassName="text-sm font-medium text-ink"
+                onSave={(title) => rename.mutate(title)}
+              />
+              <span className="font-mono text-xs">{detail.id}</span>
+            </span>
+          )
+        }
         art="/art/review.webp"
         actions={
           <>

--- a/frontend/src/ui/RenameField.test.tsx
+++ b/frontend/src/ui/RenameField.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RenameField } from './RenameField.js'
+
+afterEach(cleanup)
+
+function setup(value: string | null = null, defaultEditing = false) {
+  const onSave = vi.fn()
+  const onDone = vi.fn()
+  render(
+    <RenameField
+      value={value}
+      fallback="16 Aug, 09:30"
+      label="Rename this consultation"
+      onSave={onSave}
+      onDone={onDone}
+      defaultEditing={defaultEditing}
+    />,
+  )
+  return { onSave, onDone }
+}
+
+const field = () => screen.getByLabelText('Rename this consultation') as HTMLInputElement
+
+describe('renaming a record', () => {
+  it('shows the fallback until the record has a name', () => {
+    setup(null)
+    expect(screen.getByText('16 Aug, 09:30')).toBeTruthy()
+  })
+
+  it('shows the name once it has one, and never the fallback beside it', () => {
+    setup('Cough, sore throat')
+    expect(screen.getByText('Cough, sore throat')).toBeTruthy()
+    expect(screen.queryByText('16 Aug, 09:30')).toBeNull()
+  })
+
+  it('commits on Enter', () => {
+    const { onSave } = setup('Old name')
+    fireEvent.click(screen.getByRole('button', { name: 'Rename this consultation' }))
+    fireEvent.change(field(), { target: { value: 'New name' } })
+    fireEvent.keyDown(field(), { key: 'Enter' })
+    expect(onSave).toHaveBeenCalledWith('New name')
+  })
+
+  it('discards on Escape, and saves nothing', () => {
+    const { onSave, onDone } = setup('Old name')
+    fireEvent.click(screen.getByRole('button', { name: 'Rename this consultation' }))
+    fireEvent.change(field(), { target: { value: 'Typed then abandoned' } })
+    fireEvent.keyDown(field(), { key: 'Escape' })
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onDone).toHaveBeenCalled()
+  })
+
+  /*
+   * Blur cancels rather than commits. A mis-click landing outside the field
+   * would otherwise save a half-typed name silently, and the tick is there to
+   * be the deliberate act.
+   */
+  it('discards on blur rather than saving what was half typed', () => {
+    const { onSave } = setup('Old name')
+    fireEvent.click(screen.getByRole('button', { name: 'Rename this consultation' }))
+    fireEvent.change(field(), { target: { value: 'Half typed' } })
+    fireEvent.blur(field())
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('clears the name when the field is emptied, matching what the API stores', () => {
+    const { onSave } = setup('Old name')
+    fireEvent.click(screen.getByRole('button', { name: 'Rename this consultation' }))
+    fireEvent.change(field(), { target: { value: '   ' } })
+    fireEvent.keyDown(field(), { key: 'Enter' })
+    expect(onSave).toHaveBeenCalledWith(null)
+  })
+
+  it('saves nothing when the name comes back unchanged', () => {
+    const { onSave, onDone } = setup('Same name')
+    fireEvent.click(screen.getByRole('button', { name: 'Rename this consultation' }))
+    fireEvent.keyDown(field(), { key: 'Enter' })
+    expect(onSave).not.toHaveBeenCalled()
+    // Still closes, or the row would be stuck in an editor that does nothing.
+    expect(onDone).toHaveBeenCalled()
+  })
+
+  /*
+   * The consultation list opens the field directly, because its rows are links
+   * and the pencil has to live outside the anchor to be its own target.
+   */
+  it('opens straight into the input when the caller owns the pencil', () => {
+    setup(null, true)
+    expect(field()).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Rename this consultation' })).toBeNull()
+  })
+
+  it('bounds the input at the length the API accepts', () => {
+    setup(null, true)
+    expect(field().maxLength).toBe(120)
+  })
+})

--- a/frontend/src/ui/RenameField.tsx
+++ b/frontend/src/ui/RenameField.tsx
@@ -1,0 +1,144 @@
+import { Check, Pencil, X } from 'lucide-react'
+import { type KeyboardEvent, useEffect, useRef, useState } from 'react'
+import { cn } from '../lib/cn.js'
+
+/**
+ * Renames a record in place, in the list and on the detail page alike.
+ *
+ * **The pencil reveals on hover and is always there on touch.** Hover is the
+ * conventional affordance and it is the right one on a list, where a control
+ * per row would be noise. It is also unreachable on a touchscreen, so the
+ * reveal is gated on the pointer being a fine one, exactly as `CursorGlow`
+ * gates the trail. Focus reveals it too, so the keyboard path does not depend
+ * on an interaction the keyboard does not have.
+ *
+ * **Blank saves as cleared, not as an empty name.** The server collapses a
+ * whitespace-only title to `null`, and this matches it, so a doctor who empties
+ * the field gets the fallback back rather than a blank row.
+ *
+ * Escape cancels and Enter commits, which is the contract `ui/Select.tsx`
+ * establishes for anything in this codebase that opens.
+ */
+export function RenameField({
+  value,
+  fallback,
+  onSave,
+  label,
+  className,
+  textClassName,
+  defaultEditing = false,
+  onDone,
+}: {
+  value: string | null
+  /** Shown when the record has never been named. Never saved as a value. */
+  fallback: string
+  onSave: (next: string | null) => void
+  /** Names the control for a screen reader, since the pencil carries no text. */
+  label: string
+  className?: string
+  textClassName?: string
+  /**
+   * Opens straight into the input. The consultation list needs this: its rows
+   * are links, so the pencil has to live outside the anchor and swap the row
+   * into this component already editing, rather than rendering a second pencil
+   * the doctor would have to press twice.
+   */
+  defaultEditing?: boolean
+  /** Fires on commit or cancel, so a caller owning the open state can clear it. */
+  onDone?: () => void
+}) {
+  const [editing, setEditing] = useState(defaultEditing)
+  const [draft, setDraft] = useState(value ?? '')
+  const input = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (editing) input.current?.select()
+  }, [editing])
+
+  const open = () => {
+    setDraft(value ?? '')
+    setEditing(true)
+  }
+
+  const close = () => {
+    setEditing(false)
+    onDone?.()
+  }
+
+  const commit = () => {
+    const trimmed = draft.trim()
+    close()
+    if (trimmed === (value ?? '')) return
+    onSave(trimmed.length === 0 ? null : trimmed)
+  }
+
+  const onKey = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      commit()
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      close()
+    }
+  }
+
+  if (editing) {
+    return (
+      <span className={cn('flex items-center gap-1', className)}>
+        <input
+          ref={input}
+          value={draft}
+          maxLength={120}
+          aria-label={label}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={onKey}
+          // Committing on blur would make the tick redundant and make a
+          // mis-click a silent save. Cancel is the safer blur.
+          onBlur={close}
+          className="min-w-0 flex-1 rounded-control border border-accent bg-surface px-2 py-1 text-sm text-ink"
+        />
+        {/*
+          `onMouseDown` rather than `onClick`: the input's `onBlur` fires first
+          on a click and would close the field before the button ever ran.
+        */}
+        <button
+          type="button"
+          aria-label="Save name"
+          onMouseDown={(event) => {
+            event.preventDefault()
+            commit()
+          }}
+          className="flex size-7 shrink-0 items-center justify-center rounded-control text-accent hover:bg-accent-soft"
+        >
+          <Check aria-hidden className="size-4" />
+        </button>
+        <button
+          type="button"
+          aria-label="Cancel rename"
+          onMouseDown={(event) => {
+            event.preventDefault()
+            close()
+          }}
+          className="flex size-7 shrink-0 items-center justify-center rounded-control text-ink-muted hover:bg-sunken"
+        >
+          <X aria-hidden className="size-4" />
+        </button>
+      </span>
+    )
+  }
+
+  return (
+    <span className={cn('group/rename flex min-w-0 items-center gap-1.5', className)}>
+      <span className={cn('truncate', textClassName)}>{value ?? fallback}</span>
+      <button
+        type="button"
+        aria-label={label}
+        onClick={open}
+        className="flex size-6 shrink-0 items-center justify-center rounded-control text-ink-muted opacity-0 transition-opacity hover:bg-sunken hover:text-ink focus-visible:opacity-100 group-hover/rename:opacity-100 pointer-coarse:opacity-100"
+      >
+        <Pencil aria-hidden className="size-3.5" />
+      </button>
+    </span>
+  )
+}

--- a/prisma/migrations/20260816090000_add_consultation_title/migration.sql
+++ b/prisma/migrations/20260816090000_add_consultation_title/migration.sql
@@ -1,0 +1,15 @@
+-- The record's filing name, replacing the created timestamp as its identity.
+--
+-- PHI-bearing, and the fourth erasure target. It is derived from the analysis
+-- on first run and freely editable afterwards, so it holds a patient name
+-- whenever one is the useful thing to file under. `eraseConsultation`
+-- (backend/src/audit/erasure.ts) nulls it alongside `transcript`, `analysis`
+-- and `editedNote`.
+--
+-- Nullable with no default and no backfill. NULL means never named, and the UI
+-- falls back to `createdAt` rather than storing one, so existing rows keep
+-- rendering exactly as they do today and a non-NULL value always means somebody
+-- or something chose it.
+
+-- AlterTable
+ALTER TABLE "consultation" ADD COLUMN     "title" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,6 +120,22 @@ model Consultation {
   doctorId String
   doctor   User   @relation(fields: [doctorId], references: [id], onDelete: Cascade)
 
+  /// The record's filing name, shown wherever the consultation is listed.
+  ///
+  /// **A fourth PHI column, and erased with the other three.** It is derived
+  /// from the analysis at first run and freely editable afterwards, so a doctor
+  /// will put a patient's name in it; that is the feature working, not a
+  /// misuse. `eraseConsultation` nulls it alongside `transcript`, `analysis`
+  /// and `editedNote`, and the same rule applies to anything added here later.
+  ///
+  /// Null means never named, and the UI falls back to the created timestamp
+  /// rather than storing one, so an un-analysed draft has no title to erase and
+  /// a title always means somebody or something chose it.
+  ///
+  /// Never reaches a provider. It is composed in-process from assertions that
+  /// already passed the evidence check, and no prompt reads it.
+  title      String?
+
   /// Transcript turns, shape validated by TranscriptSchema in @shared/types.
   transcript Json?
   /// ConsultationAnalysisSchema — regenerated on re-analysis.

--- a/shared/src/index.test.ts
+++ b/shared/src/index.test.ts
@@ -319,6 +319,7 @@ describe('API envelope schemas', () => {
     const result = ConsultationDetailSchema.safeParse({
       id: 'c1',
       status: 'awaiting_review',
+      title: null,
       createdAt: '2026-08-13T00:00:00.000Z',
       updatedAt: '2026-08-13T00:00:00.000Z',
       transcript: null,
@@ -340,6 +341,7 @@ describe('API envelope schemas', () => {
     const approved = ConsultationDetailSchema.safeParse({
       id: 'c1',
       status: 'approved',
+      title: null,
       createdAt: '2026-08-13T00:00:00.000Z',
       updatedAt: '2026-08-13T00:00:00.000Z',
       transcript: null,

--- a/shared/src/index.test.ts
+++ b/shared/src/index.test.ts
@@ -5,6 +5,7 @@ import {
   ClinicalFactsResponseSchema,
   ClinicalFactsSchema,
   ConsultationDetailSchema,
+  ConsultationListItemSchema,
   DraftTurnsRequestSchema,
   DraftTurnsResponseSchema,
   ErrorEnvelopeSchema,
@@ -454,5 +455,38 @@ describe('DraftTurnsResponseSchema', () => {
     if (result.success) {
       expect(result.data).toEqual(payload)
     }
+  })
+})
+
+/*
+ * The consultations list is the screen a deploy skew would black out.
+ *
+ * Vercel and Render deploy from their own triggers on the same merge, so the
+ * new SPA talks to the old API until the slower build finishes. Requiring
+ * `title` would fail every list and detail parse for that window.
+ */
+describe('ConsultationListItemSchema title tolerance', () => {
+  const row = {
+    id: 'c1',
+    status: 'draft',
+    createdAt: '2026-08-16T00:00:00.000Z',
+    updatedAt: '2026-08-16T00:00:00.000Z',
+  }
+
+  it('reads a response from an API that does not know about titles yet', () => {
+    const result = ConsultationListItemSchema.safeParse(row)
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.title).toBeNull()
+  })
+
+  it('normalises an explicit null and an absent field to the same value', () => {
+    const absent = ConsultationListItemSchema.parse(row)
+    const explicit = ConsultationListItemSchema.parse({ ...row, title: null })
+    expect(absent.title).toEqual(explicit.title)
+  })
+
+  it('still carries a title through when the API sends one', () => {
+    const result = ConsultationListItemSchema.parse({ ...row, title: 'Cough, sore throat' })
+    expect(result.title).toBe('Cough, sore throat')
   })
 })

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -491,9 +491,30 @@ export const ConsultationStatusSchema = z.enum([
   'approved',
 ])
 
+/**
+ * The record's filing name, or `null` when it has never been named.
+ *
+ * Bounded, unlike `TranscriptSchema`, whose missing `.max()` is named as a gap
+ * in `.claude/rules/security.md`. 120 characters is a filing label with room to
+ * spare, and past that a title stops being scannable, which is the whole reason
+ * it exists.
+ *
+ * Trimmed to `null` rather than kept as an empty string, so "cleared" and
+ * "never named" are one state instead of two that render identically and sort
+ * differently.
+ */
+export const ConsultationTitleSchema = z
+  .string()
+  .max(120)
+  .transform((value) => value.trim())
+  .refine((value) => value.length <= 120)
+  .transform((value) => (value.length === 0 ? null : value))
+  .nullable()
+
 export const ConsultationSchema = z.object({
   id: z.string(),
   status: ConsultationStatusSchema,
+  title: z.string().nullable(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
   transcript: TranscriptSchema.nullable(),
@@ -569,9 +590,21 @@ export const makeSuggestionsAndRedFlagsSchema = (corpusIds: readonly [string, ..
 
 // ─── API contracts (docs/trd.md §13) ─────────────────────────────────────────
 
+/*
+ * `title` is the one clinical field this projection carries, and the widening
+ * is deliberate rather than incidental.
+ *
+ * The list was PHI-free: id, status and two timestamps. A title changes that,
+ * because a doctor renaming a record will use whatever makes it findable and
+ * that is frequently a patient's name. The derived title carries no transcript
+ * text by construction (`backend/src/analysis/title.ts`), but a renamed one is
+ * free text and is treated as PHI everywhere it matters: erased with the other
+ * three columns, never logged, never sent to a provider.
+ */
 export const ConsultationListItemSchema = ConsultationSchema.pick({
   id: true,
   status: true,
+  title: true,
   createdAt: true,
   updatedAt: true,
 })

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -514,7 +514,25 @@ export const ConsultationTitleSchema = z
 export const ConsultationSchema = z.object({
   id: z.string(),
   status: ConsultationStatusSchema,
-  title: z.string().nullable(),
+  /*
+   * Absent reads as "no title", rather than failing the parse.
+   *
+   * Vercel and Render deploy from their own triggers on the same merge, so the
+   * new SPA reaches the old API for as long as the slower build takes. This
+   * field is the first thing added to the consultations list since, and the
+   * frontend `safeParse`s every response into `invalid_response`, so requiring
+   * it would black out the list and the detail page for that whole window.
+   *
+   * PR #124 shipped exactly this shape of mismatch and was caught by hand
+   * (`.github/workflows/ci.yml`, "Migration notice"). Tolerating an absent
+   * additive field is what makes the rollout ordering-independent.
+   *
+   * Output stays `string | null`, so nothing downstream handles `undefined`.
+   */
+  title: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? null),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
   transcript: TranscriptSchema.nullable(),


### PR DESCRIPTION
## What Changed

Consultations were identified by their created timestamp, which is not a filing name. A list of them is a list of near-identical strings, so finding a record meant opening records.

Every consultation now gets a name from its own findings when it is analysed, and the doctor can rename it from either the list or the detail page.

## The Title Is Composed In Code, Never Generated

A model was the obvious way to write one and is the wrong one here.

A title is **the most prominent text in the product**: the record's identity in every list, and the first thing read on the detail page. Generated prose in that position is what `docs/prd.md` §10 forbids outright, because "likely bacterial tonsillitis" is a diagnosis nobody said, sitting at the top of a clinical record. §21.1 measured the model fabricating **eight findings on a sparse transcript in 5 of 5 runs**, and a three-minute upper-respiratory consult is exactly that sparse case.

It would not have been PHI-free either. The model only ever sees de-identified text, so a title mentioning the patient returns `[PATIENT_1]` and rehydrates to a real name; keeping names out would depend on prompt wording, which §21.3 ranks tier-4, fails silently.

`deriveConsultationTitle` is a **tier-2 control** instead:

| Property | Why it holds |
| --- | --- |
| Cannot fabricate | it only names assertions that already passed the evidence check |
| Cannot state a diagnosis | its whole input is `clinicalFacts`; it never reaches the operational block |
| Carries no transcript text | it reads contract **field names**, never an assertion's `value` or `evidence` |
| Deterministic | same input, same output, unit-tested |
| No cost, no latency | no third LLM operation on a budget already at 60 s plus one retry |

**It also names no symptom.** The keys come off the parsed object and are humanised, because `no-stray-clinical-constants.test.ts` fails the build on a single-quoted literal equal to a checklist id, and those ids are bare clinical words: `fever`, `haemoptysis`, `sputum-production`. That keeps the vocabulary versioned in `shared/`, and a symptom added to the schema starts appearing in titles with no change here.

Result: `Cough, sore throat`, capped at three findings so a row stays scannable.

## A Renamed Title Is PHI, And Is Treated As One

A doctor filing a record will use whatever makes it findable, and that is frequently a patient's name. That is the feature working, not a misuse, so the free-text case is handled as PHI throughout:

- **Fourth erasure target.** `eraseConsultation` nulls it alongside `transcript`, `analysis` and `editedNote`. `.claude/rules/security.md` requires exactly this of any new PHI column, and it is pinned by its own test asserting a seeded name does not survive.
- **Bounded at 120 characters**, unlike `TranscriptSchema`, whose missing `.max()` that same file names as a gap.
- **Never logged** (the logger is a positive allowlist) and **never sent to a provider** (no prompt reads it).
- **The list projection widens.** `GET /api/consultations` was `id, status, createdAt, updatedAt`, carrying no clinical content at all. It now carries `title`. That is a real change to that endpoint's status and is called out in the schema rather than slipped in.

## Renaming Survives Approval, Deliberately

`approved` is terminal and freezes the clinical record. A filing name is not part of that record: it carries no note text, no finding, no disposition.

Locking it would make the archive unsearchable at the exact point it becomes an archive, since the consultations somebody needs to find later are the signed ones. So a **title-only** patch bypasses the state gate; anything else still meets it unchanged, and a mixed patch is judged by its clinical half rather than excused by the title. Both directions are pinned.

Renames write `consultation.renamed` rather than `consultation.edited`, so the trail can distinguish "the note changed" from "the record was renamed after sign-off". No metadata: the old and new names are precisely the free text an audit row must not carry.

**First analysis names an unnamed record and never overwrites one**, so re-analysis cannot take back a name the doctor chose, and a title does not change under them for reasons they did not ask for.

## Renaming Is Live In Every State The Record Appears In

If a record is in the list, it can be filed, `draft` and `analyzing` included. That is the point of the feature: the record a doctor most wants to label is the one they just started.

That made a race reachable rather than theoretical. An analysis runs for up to a couple of minutes, and the derived name was guarded on the row the handler had already read, so a rename landing inside that window was silently overwritten and the doctor's own name was lost with no error.

The check and the set are now one statement, `updateMany` filtered on `title: null`, so the database decides whether the record is still unnamed. A rename landing at any point during an analysis wins.

**The test double for that was wrong first, in the direction that hides the bug.** It compared an absent `title` against the row's, so dropping the guard matched nothing at all and the *plain* naming test failed instead of the race tests. Both stubs now filter on the predicates actually present, as Prisma does, and the fix was verified by reverting it and confirming that exactly the two race tests fail.

## The Rollout Is Ordering-Independent

Two hazards sit between this branch and a working production, and neither is visible in the diff.

**The migration must land before the code.** Nothing applies migrations on deploy, by design. The column is additive and nullable with no backfill, so applying it first is invisible to the currently deployed API, which never selects it. Applying it after would mean every list query failing in between.

**The two hosts deploy independently on the same merge.** Vercel and Render build from their own triggers, so the new SPA reaches the old API until the slower one finishes. `title` is the first field added to the consultations list since, and the frontend collapses a failed `safeParse` into `invalid_response`, so a required field would have blacked out the list and the detail page for that whole window.

That is not hypothetical: **PR #124 shipped this exact shape**, `notificationsClearedAt` absent from production against a sitewide poll, and the migration notice in `ci.yml` records it as caught by hand and calls that luck rather than a process. So it is fixed in the contract rather than in the merge order: `title` reads as nullish and normalises to null, output stays `string | null`, and the API still always sends it.

## UI

- **List:** the name is the row's identity; the timestamp moves down beside the id rather than being dropped, because when a record was created is still real bookkeeping. A pencil reveals on hover and swaps the row into an editor.
- **Detail:** the same control in the header's subtitle slot. `PageHeader.title` names the *screen* on every other page, and swapping in a per-record value on this one page would make the heading mean something different here.
- **The pencil is always visible on touch.** `pointer-coarse:opacity-100`, verified in the built CSS as `@media(pointer:coarse)`. Hover-only would strand every tablet user, which is the rule `CursorGlow` already follows.
- Blur cancels rather than commits, so a mis-click cannot silently save a half-typed name.

## Verification

- [x] `bun run typecheck`
- [x] `bun run test`, **947 pass** (48 shared, 695 backend, 192 frontend, 12 evals)
- [x] `bun run --cwd frontend build`
- [x] `npx impeccable detect frontend/src`, clean
- [x] 7 tests on the composer, 5 on renaming and the approval exception, 1 on erasure, 9 on the control
- [x] 3 on renaming across every listed state and on the mid-analysis race, each verified to fail when the guard is reverted
- [x] 3 on reading an absent title, verified to fail when the field is tightened back

Lint reports the same pre-existing findings in `evals/` and `prisma/` as `main`, none in the files this touches.

## Clinical-Safety Checklist

- [x] No output is a diagnosis. The composer cannot reach `operational.diagnosis`, pinned by a test
- [x] No provider SDK imported outside `backend/src/lib/llm/`, and no new LLM call at all
- [x] Deterministic red-flag hits untouched
- [x] Citations untouched
- [x] No new log fields
- [x] New PHI column joins the erasure targets, per `security.md`
- [x] Every test string is synthetic

## Notes For The Merger

**Apply the migration before merging, not after.** `ALTER TABLE "consultation" ADD COLUMN "title" TEXT;` is nullable with no default and no backfill, so the deployed API, which never selects it, cannot notice. Merging first leaves a window where it does select it and the column is not there yet.

```bash
bun run db:status         # 20260816090000_add_consultation_title pending
bun run db:migrate:deploy # apply against DIRECT_URL
```

I wrote it by hand rather than running `migrate dev`, which would have applied against the shared Supabase instance unprompted. Existing rows keep rendering through the timestamp fallback exactly as they do today.

The judgement call worth arguing with is **renaming after approval**. I have allowed it and explained why in the route, the PR and the tests, but it is the one place this touches a stated boundary, and reversing it is a two-line change plus flipping one test.

https://claude.ai/code/session_01FS7ViinLwxy7QsBz2XJnLx
