### PR TITLE
fix(ui): drop the simulated-data line from the sign-in form

### DIFF
--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -132,9 +132,6 @@ export function Login() {
             <h1 className="text-2xl font-semibold tracking-tight">
               {mode === 'signin' ? 'Sign In' : 'Create an Account'}
             </h1>
-            <p className="mt-2 text-sm text-ink-muted">
-              All consultations in this prototype are simulated. No real patient data.
-            </p>
 
             {/* Not attached to either sign-in path, because it is neither's
                 fault: the credential was accepted and the browser dropped the


### PR DESCRIPTION
Removes "All consultations in this prototype are simulated. No real patient data." from between the sign-in heading and the first control.

## The Disclosure Still Stands In Two Places

| Where | What it says |
| --- | --- |
| Landing page | Every consultation is simulated, written for testing, and the system is connected to no clinical record system |
| The form itself | "By signing in you accept that this is an evaluation prototype", under the submit button |

So this removes a third statement of the claim, on the one screen whose job is to get a doctor past it, rather than the claim itself.

## Verification

- [x] bun run --cwd frontend typecheck
- [x] bun run --cwd frontend test, 198 pass
- [x] npx impeccable detect frontend/src, clean
- [x] No test asserts the removed string

## Clinical-Safety Checklist

Not applicable by diff: no deid/, lib/llm/, lib/asr/, redflags/, guidelines/ or logging path is touched. The change is copy on an unauthenticated page and carries no clinical content.

https://claude.ai/code/session_01FS7ViinLwxy7QsBz2XJnLx