### PR TITLE
fix(asr): make hosted transcription usable end to end

### DIFF
--- a/backend/src/deid/deid.test.ts
+++ b/backend/src/deid/deid.test.ts
@@ -2,7 +2,12 @@ import type { Transcript } from '@shared/types'
 import { describe, expect, it } from 'vitest'
 import { FIXTURES } from '../fixtures/index.js'
 import { detect } from './detectors.js'
-import { assertNoIdentifiers, deidentify, deidentifyTranscript } from './index.js'
+import {
+  assertNoIdentifiers,
+  deidentify,
+  deidentifyTranscript,
+  sliceDeidentified,
+} from './index.js'
 import { isStructurallyValidNric } from './nric.js'
 import { RequestTokenVault } from './vault.js'
 
@@ -830,5 +835,67 @@ describe('addresses tokenise whole, postcode or not (#181)', () => {
     // address must not annex the first Title-Cased word of the next line.
     const { text } = deidentify('She lives at Taman Melati 3\nPanadol was given.')
     expect(text).toContain('Panadol was given.')
+  })
+})
+
+/*
+ * Slicing happens after the gate, never before it, because detection is
+ * context-sensitive: `Ahmad Ismail` is one PATIENT span only while the two
+ * words are adjacent. De-identifying chunk by chunk would let an identifier
+ * straddling a boundary through, so the whole text is gated once and the
+ * result is cut.
+ */
+describe('sliceDeidentified', () => {
+  const gated = (text: string) => deidentify(text).text
+
+  it('returns the value untouched when it already fits', () => {
+    const content = gated('doctor good morning patient i have a cough')
+    expect(sliceDeidentified(content, 600)).toEqual([content])
+  })
+
+  it('cuts only on whitespace, so every piece is a substring of the whole', () => {
+    const content = gated('one two three four five six seven eight nine ten eleven twelve')
+    for (const piece of sliceDeidentified(content, 20)) {
+      expect(content).toContain(piece)
+    }
+  })
+
+  it('loses no word across the cuts', () => {
+    const content = gated('one two three four five six seven eight nine ten eleven twelve')
+    const words = (text: string) => text.split(/\s+/).filter(Boolean)
+    expect(sliceDeidentified(content, 20).flatMap(words)).toEqual(words(content))
+  })
+
+  /*
+   * The case that matters most: a vault token split into `[PATIENT` and `_1]`
+   * would stop matching the token pattern, and `assertNoIdentifiers` strips
+   * tokens before re-running detection, so a broken one could read as a leaked
+   * identifier or slip past as ordinary words.
+   */
+  it('never splits a vault token, at any budget', () => {
+    const content = gated('Ahmad bin Ismail called about his cough and his fever today')
+    expect(content).toMatch(/\[PATIENT_1\]/)
+    for (let budget = 4; budget < content.length; budget += 1) {
+      for (const piece of sliceDeidentified(content, budget)) {
+        expect(piece).not.toMatch(/\[[A-Z]+_\d*$/)
+        expect(piece).not.toMatch(/^_?\d*\]/)
+      }
+    }
+  })
+
+  it('ships a single word longer than the budget whole rather than cutting it', () => {
+    const content = gated('supercalifragilisticexpialidocious cough')
+    const pieces = sliceDeidentified(content, 5)
+    expect(pieces.some((piece) => piece.includes('supercalifragilisticexpialidocious'))).toBe(true)
+    expect(pieces.flatMap((piece) => piece.split(/\s+/)).filter(Boolean)).toEqual(
+      content.split(/\s+/).filter(Boolean),
+    )
+  })
+
+  it('yields no empty piece, whatever the whitespace looks like', () => {
+    const content = gated('one   two \n\n three    four')
+    for (const piece of sliceDeidentified(content, 6)) {
+      expect(piece.trim()).not.toBe('')
+    }
   })
 })

--- a/backend/src/deid/index.ts
+++ b/backend/src/deid/index.ts
@@ -90,6 +90,49 @@ export function serialiseTranscript(transcript: Transcript): string {
  * enforcement gap docs/trd.md §5 records, where the type system guarantees the
  * *shape* of what reaches `LLMClient` but not its *provenance*.
  */
+/**
+ * Splits an already-gated value into whitespace-bounded pieces that are still
+ * `Deidentified`.
+ *
+ * **It lives here because this is the module that owns the brand.** The caller
+ * that needs it, the turn-labelling pass, cannot slice for itself: rebranding a
+ * substring anywhere else is the `as Deidentified` cast that
+ * `no-stray-brand-casts.test.ts` fails the build on, and rightly so.
+ *
+ * **Slicing after the gate rather than chunking before it is the whole point.**
+ * Detection is context-sensitive: `Ahmad Ismail` is one PATIENT span only while
+ * the two words are adjacent, so de-identifying chunk by chunk would let any
+ * identifier straddling a boundary through. Running `deidentify` once over the
+ * whole text and cutting the result keeps detection at full context, and every
+ * piece inherits a guarantee the whole already earned.
+ *
+ * Cuts fall on whitespace, never inside a word, so a vault token cannot be
+ * split into a `[PATIENT` and a `_1]` that no longer reads as one.
+ *
+ * The safety net is unchanged and per piece: each one goes to `LLMClient`
+ * separately, so `assertNoIdentifiers` runs on each rather than once on the
+ * whole, which makes this strictly more checked than the unsliced path.
+ */
+export function sliceDeidentified(content: Deidentified, maxChars: number): Deidentified[] {
+  if (content.length <= maxChars) return [content]
+
+  const pieces: Deidentified[] = []
+  const words = content.split(/(\s+)/)
+  let current = ''
+  for (const part of words) {
+    // A single word longer than the budget still goes out whole: cutting it
+    // would break the alignment the caller reconstructs against.
+    if (current !== '' && current.length + part.length > maxChars && part.trim() !== '') {
+      pieces.push(markDeidentified(current.trimEnd()))
+      current = ''
+    }
+    if (current === '' && part.trim() === '') continue
+    current += part
+  }
+  if (current.trim() !== '') pieces.push(markDeidentified(current.trimEnd()))
+  return pieces
+}
+
 export function assertNoIdentifiers(content: Deidentified, operation: string): void {
   const withoutTokens = content.replace(TOKEN_PATTERN, ' ')
   const leaked = detect(withoutTokens)

--- a/backend/src/draft-turns/index.test.ts
+++ b/backend/src/draft-turns/index.test.ts
@@ -96,3 +96,121 @@ describe('draftTurns', () => {
     })
   })
 })
+
+/*
+ * Chunking (#189 follow-up).
+ *
+ * The pass is a verbatim echo guarded by word-for-word reconstruction, so one
+ * drifted word discarded every label in the call. Measured against production,
+ * 653 characters labelled cleanly and 1,335 returned `draft_failed`, while a
+ * real consultation is several thousand: the pass failed on the input it
+ * exists for.
+ */
+describe('draftTurns over a consultation-length transcript', () => {
+  /** Long enough to cross several chunk boundaries, in the unpunctuated
+   * lowercase shape the hosted relay actually returns (docs/trd.md 20.3). */
+  const longStream = (() => {
+    const unit =
+      'doctor good morning what brings you in today patient i have had a cough for four days and my throat hurts when i swallow '
+    let text = ''
+    while (text.length < 2_400) text += unit
+    return text.trim()
+  })()
+
+  it('splits the work rather than sending one oversized call', async () => {
+    const { text: content } = deidentify(longStream)
+    const spy = stubClient(async (request) => {
+      const chunk = (request as unknown as { content: string }).content
+      return { turns: [{ speaker: 'doctor', text: chunk }] }
+    })
+
+    await draftTurns(content)
+
+    expect(spy.mock.calls.length).toBeGreaterThan(1)
+    for (const call of spy.mock.calls) {
+      const chunk = (call[0] as unknown as { content: string }).content
+      expect(chunk.length).toBeLessThanOrEqual(600)
+    }
+  })
+
+  it('keeps every word of the transcript across the boundaries', async () => {
+    const { text: content } = deidentify(longStream)
+    stubClient(async (request) => {
+      const chunk = (request as unknown as { content: string }).content
+      return { turns: [{ speaker: 'doctor', text: chunk }] }
+    })
+
+    const turns = await draftTurns(content)
+    const words = (text: string) => text.split(/\s+/).filter(Boolean)
+    expect(words(turns.map((turn) => turn.text).join(' '))).toEqual(words(content))
+  })
+
+  /*
+   * A rejected chunk fails the whole pass, deliberately.
+   *
+   * Keeping the other chunks and giving the rejected one its neighbour's
+   * speaker was the tempting alternative, and it fabricates attribution: up to
+   * a chunk of patient speech presented as the doctor's, with nothing marking
+   * it invented. Failing is safe because the client's fallback drafts labels on
+   * the device and says on screen that they are guesses.
+   */
+  it('fails rather than inventing a speaker for a rejected chunk', async () => {
+    const { text: content } = deidentify(longStream)
+    let call = 0
+    stubClient(async (request) => {
+      const chunk = (request as unknown as { content: string }).content
+      call += 1
+      if (call === 2) return { turns: [{ speaker: 'patient', text: 'not the input' }] }
+      return { turns: [{ speaker: 'doctor', text: chunk }] }
+    })
+
+    await expect(draftTurns(content)).rejects.toBeInstanceOf(DraftTurnsError)
+  })
+
+  it('never opens more than four provider calls at once', async () => {
+    const { text: content } = deidentify(longStream)
+    let live = 0
+    let peak = 0
+    stubClient(async (request) => {
+      live += 1
+      peak = Math.max(peak, live)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      live -= 1
+      return {
+        turns: [{ speaker: 'doctor', text: (request as unknown as { content: string }).content }],
+      }
+    })
+
+    await draftTurns(content)
+
+    expect(peak).toBeLessThanOrEqual(4)
+    expect(peak).toBeGreaterThan(1)
+  })
+
+  it('still fails when no chunk survives, so a broken pass is never a draft', async () => {
+    const { text: content } = deidentify(longStream)
+    stubClient(async () => ({ turns: [{ speaker: 'doctor', text: 'not the input at all' }] }))
+
+    await expect(draftTurns(content)).rejects.toBeInstanceOf(DraftTurnsError)
+  })
+
+  it('reports a provider outage as llm_failed rather than a reconstruction mismatch', async () => {
+    const { text: content } = deidentify(longStream)
+    stubClient(async () => {
+      throw new LLMResponseError('provider is down', 'draft_turns')
+    })
+
+    await expect(draftTurns(content)).rejects.toMatchObject({ reason: 'llm_failed' })
+  })
+
+  it('leaves a short transcript as exactly one call', async () => {
+    const { text: content } = deidentify('doctor good morning patient i have a cough')
+    const spy = stubClient(async (request) => ({
+      turns: [{ speaker: 'doctor', text: (request as unknown as { content: string }).content }],
+    }))
+
+    await draftTurns(content)
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/backend/src/draft-turns/index.ts
+++ b/backend/src/draft-turns/index.ts
@@ -1,6 +1,6 @@
 import { type DraftTurn, DraftTurnsResponseSchema } from '@shared/types'
 import type { DraftTurnsFailureReason } from '../audit/index.js'
-import { DeidentificationError } from '../deid/index.js'
+import { DeidentificationError, sliceDeidentified } from '../deid/index.js'
 import type { Deidentified } from '../deid/types.js'
 import { getLLMClient } from '../lib/llm/index.js'
 import { DRAFT_TURNS_SYSTEM_PROMPT } from './prompt.js'
@@ -28,7 +28,111 @@ export class DraftTurnsError extends Error {
   }
 }
 
+/**
+ * How much de-identified text goes into one labelling call.
+ *
+ * The pass is a verbatim echo guarded by word-for-word reconstruction, so a
+ * single drifted word discards every label in the call. That makes the failure
+ * rate a function of length, and measured against production it is not a slow
+ * curve: 180 characters labelled cleanly, 653 labelled cleanly in 19.5 s, and
+ * 1,335 returned `draft_failed`. A real consultation is several thousand, so
+ * the unchunked pass failed on exactly the input it exists for.
+ *
+ * 600 sits inside the range that was reliably passing rather than at the edge
+ * of it. Chunks run concurrently, so wall-clock stays near one call rather
+ * than multiplying, and a chunk that does fail now costs its own labels
+ * instead of the transcript's.
+ */
+const CHUNK_CHARS = 600
+
+/**
+ * Adjacent turns from different chunks that share a speaker are one turn.
+ *
+ * A chunk boundary is arbitrary, so a doctor sentence split across two calls
+ * comes back as two same-speaker turns. Merging keeps the review list showing
+ * the speaker changes the doctor is there to check, rather than the places the
+ * text happened to be cut.
+ */
+function mergeAdjacent(turns: readonly DraftTurn[]): DraftTurn[] {
+  const merged: DraftTurn[] = []
+  for (const turn of turns) {
+    const last = merged.at(-1)
+    if (last && last.speaker === turn.speaker) last.text = `${last.text} ${turn.text}`
+    else merged.push({ ...turn })
+  }
+  return merged
+}
+
 export async function draftTurns(content: Deidentified): Promise<DraftTurn[]> {
+  const chunks = sliceDeidentified(content, CHUNK_CHARS)
+
+  /*
+   * Concurrent, because the bound that matters is the caller's: the client
+   * gives this pass 150 s and the adapter allows 60 s plus one retry, so
+   * sequential chunks would blow through both on any real consultation.
+   *
+   * A rejected chunk keeps its text and loses only its labels, which is the
+   * point of chunking at all. The whole pass still fails if *every* chunk
+   * fails, so a broken model or a blocked egress is never dressed up as a
+   * successful draft.
+   */
+  /*
+   * A rejected chunk fails the whole pass rather than being papered over.
+   *
+   * The tempting alternative was to keep the other chunks' labels and give the
+   * rejected one its neighbour's speaker. That fabricates attribution: up to
+   * `CHUNK_CHARS` of patient speech is presented as the doctor's, nothing in
+   * the response marks it as invented, and it flows into the note and the
+   * red-flag engine that way. Doctor review does not redeem it, because what
+   * is being reviewed is an undisclosed guess.
+   *
+   * Failing is safe here precisely because the client's fallback is now a real
+   * one: it drafts labels on the device from the same prose and says on screen
+   * that they are guesses. An honest local guess beats a server guess wearing
+   * the model's authority.
+   */
+  const drafted = await mapWithLimit(chunks, MAX_CONCURRENT_CHUNKS, draftChunk)
+
+  return mergeAdjacent(drafted.flat())
+}
+
+/**
+ * The fan-out bound.
+ *
+ * `Promise.all` over the chunks was unbounded, and the request cap is 30,000
+ * characters (`MAX_DRAFT_TEXT_CHARACTERS`), so one request could open 50
+ * concurrent provider calls where it previously opened one, and the 5/min
+ * limiter would let a single caller hold hundreds in flight. That is the
+ * unbounded-consumption shape `MAX_CONCURRENT_RELAYS` already guards on the
+ * audio route (OWASP LLM10).
+ *
+ * Four keeps a consultation-length transcript inside roughly two waves, so the
+ * latency win survives, while the worst case stays a number the provider quota
+ * and the instance can carry.
+ */
+const MAX_CONCURRENT_CHUNKS = 4
+
+async function mapWithLimit<T, R>(
+  items: readonly T[],
+  limit: number,
+  run: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let next = 0
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      const index = next
+      next += 1
+      const item = items[index]
+      if (item === undefined) continue
+      results[index] = await run(item)
+    }
+  })
+  await Promise.all(workers)
+  return results
+}
+
+async function draftChunk(content: Deidentified): Promise<DraftTurn[]> {
   const client = getLLMClient()
 
   let turns: readonly DraftTurn[]
@@ -40,9 +144,11 @@ export async function draftTurns(content: Deidentified): Promise<DraftTurn[]> {
       schema: DraftTurnsResponseSchema,
       schemaName: 'draft_turns',
       temperature: 0,
-      // The output is a verbatim echo of the input plus labels, so it is
-      // structurally bounded by the 50k-char request cap; the adapter's 8192
-      // default would clip exactly the long transcripts this pass is for.
+      // The output is a verbatim echo of one chunk plus labels, so it is
+      // structurally bounded by `CHUNK_CHARS` and sits far inside this ceiling.
+      // The ceiling stays because the adapter's 8192 default is the wrong
+      // shape of bound for an echo, and a clipped echo fails reconstruction
+      // rather than degrading.
       maxTokens: 16_384,
     })
     turns = response.turns

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -1801,13 +1801,39 @@ The §20.2 sentence-scoring heuristic reads segment boundaries and punctuation, 
 
 #### Mechanism
 
-`POST /api/asr/draft-turns` (§13), session-guarded, own limiter (`draftTurnsRateLimit`, 5/min per client key), body `{ text }` trimmed to 1..30,000 chars (`MAX_DRAFT_TEXT_CHARACTERS`, reconciled with the 16,384-token output ceiling: the response echoes the input verbatim, and at a conservative 2.5 chars/token for code-switched Malay a 30,000-char echo plus JSON scaffolding stays inside the ceiling, where a larger cap would pay the full output budget for a guaranteed truncation failure):
+`POST /api/asr/draft-turns` (§13), session-guarded, own limiter (`draftTurnsRateLimit`, 5/min per client key), body `{ text }` trimmed to 1..30,000 chars (`MAX_DRAFT_TEXT_CHARACTERS`, reconciled with the 16,384-token output ceiling: the response echoes the input verbatim, and at a conservative 2.5 chars/token for code-switched Malay the echo is now per chunk rather than per request, so the ceiling has ample headroom; the cap remains the bound on how much text one request may submit, and therefore on the fan-out below):
 
 1. `deidentify(text)` mints the branded content plus a request-scoped vault before anything leaves the API, the same PHI-boundary gate every other egress uses. `detected` labels are kept for the audit row.
-2. `LLMClient.generate`, operation `draft_turns`, `temperature: 0`, `maxTokens: 16_384`, output constrained to `DraftTurnsResponseSchema` (`{ turns: [{ speaker: 'doctor' | 'patient', text }] }`, 1 to 600 turns, each turn's text 1 to 4,000 chars), system prompt in `backend/src/draft-turns/prompt.ts`.
-3. **Reconstruction guard** (`backend/src/draft-turns/reconstruction.ts`). The model's turns are trusted only for boundaries and speaker labels, never for their text. Each turn is canon-aligned word-for-word against the input (lowercased; letters, digits, `[]`, `_` kept, so a pseudonym token compares as one word), then the shipped turn text is re-sliced from the input's own characters, not from the model's. Punctuation and casing changes are forgiven during comparison but excluded from the output; a paraphrase, drop, reorder, translation, or split token discards the whole draft. This is stronger than a string diff: the guarantee is that shipped text is provably the input's own characters, not merely similar to it.
-4. Per-turn `vault.rehydrate`, then a **second** schema parse against `DraftTurnsResponseSchema` after rehydration, because a restored span can push a turn past the 4,000-char cap. This failure is classified `not_reconstructed` and happens before the audit row is written.
-5. Exactly one audit row is written after the LLM call is attempted: `asr.hosted_draft_labelled` on success or `asr.hosted_draft_failed` with a closed `reason` (`llm_failed` or `not_reconstructed`) on failure (§15). Pre-egress rejections (`401`, `400`, `429`, a `DeidentificationError`) write no row, mirroring the relay pair (§15).
+2. **`sliceDeidentified` cuts the gated value into 600-character, whitespace-bounded chunks**, at most four in flight at once. Detail and rationale in §20.6 below.
+3. `LLMClient.generate` **per chunk**, operation `draft_turns`, `temperature: 0`, `maxTokens: 16_384`, output constrained to `DraftTurnsResponseSchema` (`{ turns: [{ speaker: 'doctor' | 'patient', text }] }`, 1 to 600 turns, each turn's text 1 to 4,000 chars), system prompt in `backend/src/draft-turns/prompt.ts`.
+4. **Reconstruction guard** (`backend/src/draft-turns/reconstruction.ts`). The model's turns are trusted only for boundaries and speaker labels, never for their text. Each turn is canon-aligned word-for-word against the input (lowercased; letters, digits, `[]`, `_` kept, so a pseudonym token compares as one word), then the shipped turn text is re-sliced from the input's own characters, not from the model's. Punctuation and casing changes are forgiven during comparison but excluded from the output; a paraphrase, drop, reorder, translation, or split token discards the whole draft. This is stronger than a string diff: the guarantee is that shipped text is provably the input's own characters, not merely similar to it.
+5. Per-turn `vault.rehydrate`, then a **second** schema parse against `DraftTurnsResponseSchema` after rehydration, because a restored span can push a turn past the 4,000-char cap. This failure is classified `not_reconstructed` and happens before the audit row is written.
+6. Exactly one audit row is written after the LLM call is attempted: `asr.hosted_draft_labelled` on success or `asr.hosted_draft_failed` with a closed `reason` (`llm_failed` or `not_reconstructed`) on failure (§15). Pre-egress rejections (`401`, `400`, `429`, a `DeidentificationError`) write no row, mirroring the relay pair (§15).
+
+#### Chunking, And Why The Pass Needed It
+
+Measured against production on 16/08/26, before chunking:
+
+| Input       | Result                   |
+| ----------- | ------------------------ |
+| 180 chars   | labelled, 16 s           |
+| 653 chars   | labelled, 19.5 s         |
+| 1,335 chars | `502 draft_failed`, 22 s |
+
+A real consultation is several thousand characters, so the pass failed on exactly the input it exists for, and the failure was invisible: the client swallowed it and delivered unlabelled prose.
+
+**The cause is the reconstruction guard's granularity, not the guard itself.** Word-for-word alignment is all-or-nothing across whatever was submitted, so one drifted word in four thousand discarded every label. Shrinking the unit shrinks the blast radius without weakening the guarantee, because each chunk is still aligned and re-sliced in full.
+
+- **`sliceDeidentified` (`backend/src/deid/index.ts`) cuts the value after the gate, never before it.** Detection is context-sensitive: `Ahmad Ismail` is one `PATIENT` span only while the two words are adjacent, so de-identifying chunk by chunk would let an identifier straddling a boundary through. The whole text is gated once and the result is cut, so every piece inherits a guarantee the whole already earned.
+- **It lives in `deid/` because that module owns the brand.** Rebranding a substring anywhere else is the `as Deidentified` cast `no-stray-brand-casts.test.ts` fails the build on. The function takes a `Deidentified` and returns `Deidentified[]`, so it is a brand-preserving transform and cannot launder a raw string.
+- **Cuts land only on whitespace**, so a vault token can never be split into a `[PATIENT` and a `_1]` that no longer matches `TOKEN_PATTERN`. A single word longer than the budget ships whole rather than being cut.
+- **`assertNoIdentifiers` now runs per chunk** rather than once per request, which is strictly more checking than the unsliced path.
+- **600 characters, at most 4 concurrent.** The size sits inside the range that was reliably passing rather than at its edge. The concurrency bound matters because `MAX_DRAFT_TEXT_CHARACTERS` is 30,000: unbounded fan-out would open up to 50 provider calls for one request, the unbounded-consumption shape `MAX_CONCURRENT_RELAYS` already guards against on the audio route (OWASP LLM10).
+- **A rejected chunk fails the whole pass.** Keeping the surviving chunks and giving the rejected one its neighbour's speaker was considered and refused: it fabricates attribution, presenting up to 600 characters of patient speech as the doctor's with nothing in the response marking it invented, and it would flow into the note and the red-flag engine that way. Failing is safe because the client's fallback is a real one (`proseToDraft`), drafting on-device labels that the review step already describes as guesses.
+
+Measured after, same 2,543-character unpunctuated Malay stream: **11 turns, both speakers, every word verbatim, 37.9 s**, against a 150 s client deadline.
+
+**Open:** partial success is not available. One rejected chunk still costs the transcript its server labels, where per-chunk reporting could keep the rest. That needs a contract field marking a turn as undrafted so the client can render it unlabelled rather than inheriting a guess, and is deliberately not bundled here.
 
 #### Failure Taxonomy And Fallback
 

--- a/frontend/src/audio/AudioCapture.tsx
+++ b/frontend/src/audio/AudioCapture.tsx
@@ -235,6 +235,18 @@ export function AudioCapture({
   const [overridden, setOverridden] = useState(false)
   const [seconds, setSeconds] = useState(0)
   const [chunkProgress, setChunkProgress] = useState<{ done: number; total: number } | null>(null)
+  /**
+   * Seconds spent in the current hosted phase.
+   *
+   * The relay and the labelling pass are each one request with no progress to
+   * report, so neither can honestly show a percentage. That left both phases as
+   * a static sentence for twenty seconds or more, which is indistinguishable
+   * from a hung screen and was read as one.
+   *
+   * Elapsed time is the honest alternative: a measured number that proves the
+   * run is alive without claiming any fraction of it is done.
+   */
+  const [hostedSeconds, setHostedSeconds] = useState(0)
   /** The audio behind the current or failed run, so Try Again can rerun it. */
   const [retryBlob, setRetryBlob] = useState<Blob | null>(null)
   /**
@@ -495,6 +507,15 @@ export function AudioCapture({
     return () => window.clearInterval(id)
   }, [phase])
 
+  // Restarts per phase, so the labelling pass counts from zero rather than
+  // carrying the upload's total forward and reading as one long stall.
+  useEffect(() => {
+    if (phase !== 'uploading' && phase !== 'labelling') return
+    setHostedSeconds(0)
+    const id = window.setInterval(() => setHostedSeconds((value) => value + 1), 1000)
+    return () => window.clearInterval(id)
+  }, [phase])
+
   const transcribeLocal = useCallback(
     async (blob: Blob) => {
       setError(null)
@@ -721,17 +742,21 @@ export function AudioCapture({
    * download through them is how a healthy load reads as a hang. So 100 gets
    * its own honest sentence, as does the merge tail after the last chunk.
    */
+  const elapsed = `${Math.floor(hostedSeconds / 60)}:${String(hostedSeconds % 60).padStart(2, '0')}`
+
   const status =
     phase === 'uploading'
       ? // Says where the audio is going while it is going there, and does not
         // pretend to a percentage: the relay is one request with no progress
         // to report, and an invented bar here would be the exact dishonesty
-        // the measured one below exists to avoid.
-        'Sending this recording to ILMU for transcription. It is leaving this device.'
+        // the measured one below exists to avoid. The elapsed count is the
+        // honest substitute, and it is what distinguishes a slow relay from a
+        // hung screen.
+        `Sending this recording to ILMU for transcription, ${elapsed} elapsed. It is leaving this device.`
       : phase === 'labelling'
         ? // Progress-free for the same reason as the upload, and honest about
           // the wait and the review gate that follows it.
-          'Drafting Doctor / Patient labels from the transcript. This can take up to two and a half minutes, and you will review every line before anything is applied.'
+          `Drafting Doctor / Patient labels from the transcript, ${elapsed} elapsed. This can take up to two and a half minutes, and you will review every line before anything is applied.`
         : phase === 'loading-model'
           ? progress === null
             ? 'Preparing the speech model. The first run downloads it once and the browser caches it.'

--- a/frontend/src/audio/SpeakerAssign.test.tsx
+++ b/frontend/src/audio/SpeakerAssign.test.tsx
@@ -11,7 +11,7 @@ const DRAFT: DraftLine[] = [
   { id: 'seg-1', speaker: 'patient', text: 'Yesterday quite hot.', offsetSeconds: 2.1 },
 ]
 
-function setup(draft: DraftLine[] = DRAFT) {
+function setup(draft: DraftLine[] = DRAFT, canInsertPlain = true) {
   const handlers = {
     onToggle: vi.fn(),
     onReplace: vi.fn(),
@@ -19,7 +19,7 @@ function setup(draft: DraftLine[] = DRAFT) {
     onApply: vi.fn(),
     onInsertPlain: vi.fn(),
   }
-  render(<SpeakerAssign draft={draft} {...handlers} />)
+  render(<SpeakerAssign draft={draft} canInsertPlain={canInsertPlain} {...handlers} />)
   return handlers
 }
 
@@ -43,7 +43,7 @@ describe('SpeakerAssign', () => {
     const { onSwapAll, onApply, onInsertPlain } = setup()
     fireEvent.click(screen.getByRole('button', { name: /swap all/i }))
     fireEvent.click(screen.getByRole('button', { name: /apply labels/i }))
-    fireEvent.click(screen.getByRole('button', { name: /insert as plain/i }))
+    fireEvent.click(screen.getByRole('button', { name: /append as plain/i }))
     expect(onSwapAll).toHaveBeenCalledTimes(1)
     expect(onApply).toHaveBeenCalledTimes(1)
     expect(onInsertPlain).toHaveBeenCalledTimes(1)
@@ -73,5 +73,24 @@ describe('SpeakerAssign', () => {
     fireEvent.click(chips[1] as HTMLElement)
     expect(onReplace).toHaveBeenCalledTimes(1)
     expect(onReplace).toHaveBeenCalledWith('seg-0', 'patut pagi, batuk malam')
+  })
+})
+
+/*
+ * Appending unlabelled text is only ever a continuation: the parser folds a
+ * line with no prefix into the turn above it and drops it when there is none.
+ * Offered on an empty transcript it produced zero turns and disabled Start
+ * Consultation, so the doctor blocked themselves with the button beside the
+ * one that works.
+ */
+describe('the plain-text control', () => {
+  it('is hidden when there is no turn for the text to join', () => {
+    setup(DRAFT, false)
+    expect(screen.queryByRole('button', { name: /plain text/i })).toBeNull()
+  })
+
+  it('is offered once the transcript already has a turn', () => {
+    setup(DRAFT, true)
+    expect(screen.getByRole('button', { name: /plain text/i })).toBeTruthy()
   })
 })

--- a/frontend/src/audio/SpeakerAssign.tsx
+++ b/frontend/src/audio/SpeakerAssign.tsx
@@ -2,6 +2,7 @@ import { ArrowLeftRight, Check, Type } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { cn } from '../lib/cn.js'
 import { Button } from '../ui/Button.js'
+import { InfoTip } from '../ui/InfoTip.js'
 import { applyConfusable, findConfusables } from './confusables.js'
 import type { DraftLine } from './draft-turns.js'
 
@@ -66,6 +67,7 @@ export function SpeakerAssign({
   onSwapAll,
   onApply,
   onInsertPlain,
+  canInsertPlain,
 }: {
   draft: readonly DraftLine[]
   onToggle: (id: string) => void
@@ -73,15 +75,37 @@ export function SpeakerAssign({
   onSwapAll: () => void
   onApply: () => void
   onInsertPlain: () => void
+  /**
+   * Whether there is already a labelled turn for plain text to join.
+   *
+   * Inserting unlabelled text is only ever a continuation: the parser folds a
+   * line with no `Doctor:` or `Patient:` prefix into the turn above it, and
+   * drops it entirely when there is no turn above. So on an empty transcript
+   * this control produced zero turns and disabled Start Consultation, which is
+   * the doctor blocking themselves with the button next to the one that works.
+   */
+  canInsertPlain: boolean
 }) {
   return (
     <div className="mt-4 border-t border-line pt-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <p className="text-sm font-medium">
+        <p className="flex items-center gap-2 text-sm font-medium">
           Draft Labels
-          <span className="ml-2 text-xs font-normal text-ink-muted">
+          <span className="text-xs font-normal text-ink-muted">
             {draft.length} line{draft.length === 1 ? '' : 's'}
           </span>
+          {/*
+            The mechanics live in the tip; the one sentence below does not,
+            because it is the only part that changes what the doctor does. A
+            reader who takes these for finished labels applies them unread, and
+            that is the mislabel the review step exists to catch.
+          */}
+          <InfoTip label="How draft labels work">
+            Tap a label to flip it. A dotted word is a measured mishear of a Malay clinical word;
+            tap the suggestion after it to correct that word only. A sentence holding both speakers
+            is best fixed in the transcript box after applying. Plain text joins the turn above it
+            until you label it.
+          </InfoTip>
         </p>
         <Button
           size="sm"
@@ -92,11 +116,7 @@ export function SpeakerAssign({
         </Button>
       </div>
       <p className="mt-1 text-xs text-ink-muted">
-        Labels are guessed from what each sentence says, not from the voices, and can be wrong. Tap
-        a label to flip it. A dotted word is a measured mishear of a Malay clinical word; tap the
-        suggestion after it to correct that word only. A sentence holding both speakers is best
-        fixed in the transcript box after applying. Plain text joins the turn above it until you
-        label it.
+        Labels are guessed from what each sentence says, not from the voices, and can be wrong.
       </p>
 
       <ul className="mt-3 flex max-h-80 flex-col gap-1 overflow-y-auto pr-1">
@@ -133,14 +153,16 @@ export function SpeakerAssign({
         <Button icon={<Check aria-hidden className="size-4" />} onClick={onApply}>
           Apply Labels to Transcript
         </Button>
-        <Button
-          variant="neutral"
-          size="sm"
-          icon={<Type aria-hidden className="size-3.5" />}
-          onClick={onInsertPlain}
-        >
-          Insert as Plain Text
-        </Button>
+        {canInsertPlain && (
+          <Button
+            variant="neutral"
+            size="sm"
+            icon={<Type aria-hidden className="size-3.5" />}
+            onClick={onInsertPlain}
+          >
+            Append as Plain Text
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/audio/draft-turns.test.ts
+++ b/frontend/src/audio/draft-turns.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { type DraftLine, draftToTurns, segmentsToDraft } from './draft-turns.js'
+import { type DraftLine, draftToTurns, proseToDraft, segmentsToDraft } from './draft-turns.js'
 import type { TranscriptSegment } from './protocol.js'
 
 /*
@@ -218,5 +218,50 @@ describe('draftToTurns', () => {
       { speaker: 'doctor', text: 'Morning.', offsetSeconds: 0 },
       { speaker: 'patient', text: 'Morning doctor.' },
     ])
+  })
+})
+
+/*
+ * The hosted path's floor.
+ *
+ * A relay returns prose and no segments, so when the server labelling pass
+ * does not come back, `segmentsToDraft` refuses and the doctor is left with a
+ * block that `parseTranscript` reads as zero turns. Start Consultation is
+ * disabled on exactly that, so the recording was billed and unusable.
+ */
+describe('proseToDraft', () => {
+  const CONSULT =
+    'Good morning, what brings you in today? I have had a cough for four days. Do you have a fever? A little last night.'
+
+  it('drafts a usable transcript from prose with no segments', () => {
+    const draft = proseToDraft(CONSULT)
+    expect(draft.length).toBeGreaterThan(1)
+    expect(draft.every((line) => line.text.trim() !== '')).toBe(true)
+  })
+
+  it('never invents a timestamp, because prose carries no timing', () => {
+    for (const line of proseToDraft(CONSULT)) {
+      expect(line.offsetSeconds).toBeUndefined()
+    }
+  })
+
+  it('keeps every word, so nothing the patient said is dropped', () => {
+    const words = (text: string) => text.split(/\s+/).filter(Boolean)
+    const drafted = proseToDraft(CONSULT).flatMap((line) => words(line.text))
+    expect(drafted).toEqual(words(CONSULT))
+  })
+
+  it('hands a question and its answer to different speakers', () => {
+    const draft = proseToDraft(CONSULT)
+    expect(new Set(draft.map((line) => line.speaker)).size).toBe(2)
+  })
+
+  it('returns nothing for empty or whitespace-only text', () => {
+    expect(proseToDraft('')).toEqual([])
+    expect(proseToDraft('   \n  ')).toEqual([])
+  })
+
+  it('carries an id namespace of its own, so appending cannot collide', () => {
+    expect(proseToDraft(CONSULT).every((line) => line.id.startsWith('prose-'))).toBe(true)
   })
 })

--- a/frontend/src/audio/draft-turns.ts
+++ b/frontend/src/audio/draft-turns.ts
@@ -131,6 +131,42 @@ function classify(
   return previous.speaker
 }
 
+/**
+ * The same rules applied to prose alone, for a transcript that arrives with no
+ * timing and no server-drafted labels.
+ *
+ * That is the hosted path whenever the labelling pass does not return: the
+ * relay sends no segments, so `segmentsToDraft` refuses at its first line, and
+ * the doctor was left holding an unlabelled block that `parseTranscript` reads
+ * as zero turns. Start Consultation is disabled on exactly that condition, so
+ * the documented "falls back to the unlabelled prose" was in practice a dead
+ * end: the recording succeeded, was billed, and could not be used.
+ *
+ * A guess the doctor corrects is the right floor here, because it is already
+ * what the labelled path produces. Both drafts land in the same review step
+ * with the same per-line flip and swap-all, and neither is a claim about who
+ * spoke until the doctor applies it.
+ *
+ * No offsets, ever. Prose carries no timing, and inventing one would assert a
+ * wrong time in the evidence trace, which is the rule the split-line branch of
+ * `segmentsToDraft` already follows.
+ */
+export function proseToDraft(fullText: string): DraftLine[] {
+  const text = normalise(fullText)
+  if (text === '') return []
+
+  const lines: DraftLine[] = []
+  let previous: { speaker: Speaker; text: string } | undefined
+  for (const sentence of splitSentences(text)) {
+    const speaker = classify(sentence, previous)
+    previous = { speaker, text: sentence }
+    const last = lines.at(-1)
+    if (last && last.speaker === speaker) last.text = `${last.text} ${sentence}`
+    else lines.push({ id: `prose-${lines.length}`, speaker, text: sentence })
+  }
+  return lines
+}
+
 export function segmentsToDraft(
   segments: readonly TranscriptSegment[],
   fullText: string,

--- a/frontend/src/routes/ConsultationNew.test.tsx
+++ b/frontend/src/routes/ConsultationNew.test.tsx
@@ -275,15 +275,37 @@ describe('hosted draft-turn labelling', () => {
     expect(textarea.value).toBe('Doctor: Any fever?\nPatient: Yesterday quite hot.')
   })
 
-  it('falls back to raw prose when a hosted result carries no drafted turns', () => {
+  /*
+   * The hosted labelling pass fails on a consultation-length transcript, and
+   * this is the path that leaves. Measured against production: 653 characters
+   * labelled in 19.5 s, 1,335 returned `draft_failed`, and a real recording is
+   * several thousand.
+   *
+   * This used to assert that the prose landed straight in the textarea, which
+   * described the behaviour accurately and hid that it was a dead end: a hosted
+   * recording carries no segments, so nothing drafted labels, `parseTranscript`
+   * read zero turns, and Start Consultation is disabled on exactly that. The
+   * relay had billed for a transcription the doctor could not use.
+   */
+  it('keeps a hosted recording usable when no drafted turns come back', () => {
     openRecordTab()
     fireEvent.click(screen.getByRole('button', { name: 'mock transcribe hosted raw' }))
 
-    // No draft pending: the text landed straight in the textarea rather than
-    // behind SpeakerAssign, unlike the drafted-turns path above.
-    expect(screen.queryByRole('button', { name: /apply labels/i })).toBeNull()
+    // Drafted locally instead of dumped as prose, so the doctor gets the same
+    // review step the labelled path reaches.
+    expect(screen.getByRole('button', { name: /apply labels/i })).toBeTruthy()
+    expect(screen.getByText(/Batuk sudah tiga hari\./)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /apply labels/i }))
+
     const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
-    expect(textarea.value).toBe('Batuk sudah tiga hari.')
+    expect(textarea.value).toMatch(/Batuk sudah tiga hari\./)
+    // The point of the fix: the transcript now parses to turns, so the button
+    // that was permanently disabled is reachable.
+    expect(screen.getByRole('button', { name: /start consultation/i })).not.toHaveProperty(
+      'disabled',
+      true,
+    )
   })
 
   it('corrects a measured mishear on tap and applies the corrected line', () => {

--- a/frontend/src/routes/ConsultationNew.tsx
+++ b/frontend/src/routes/ConsultationNew.tsx
@@ -4,7 +4,12 @@ import { FileUp, FolderOpen, Mic, Type } from 'lucide-react'
 import { type ChangeEvent, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { AudioCapture } from '../audio/AudioCapture.js'
-import { type DraftLine, draftToTurns, segmentsToDraft } from '../audio/draft-turns.js'
+import {
+  type DraftLine,
+  draftToTurns,
+  proseToDraft,
+  segmentsToDraft,
+} from '../audio/draft-turns.js'
 import { SpeakerAssign } from '../audio/SpeakerAssign.js'
 import { ApiError, api } from '../lib/api.js'
 import { cn } from '../lib/cn.js'
@@ -190,16 +195,29 @@ export function ConsultationNew() {
                 // segments (#189); `hosted-` ids are a namespace disjoint from
                 // the local `seg-` ones, and the turns carry no offsets, so a
                 // wrong timestamp can never be asserted for them.
+                //
+                // The third branch is the one that keeps this from being a
+                // dead end. A hosted recording carries no segments, so when the
+                // labelling pass does not return, the first two produce nothing
+                // and the doctor is left with a block of prose that parses to
+                // zero turns, which is exactly the condition Start Consultation
+                // is disabled on. `proseToDraft` applies the same rules to the
+                // text alone, so the recording stays usable and the labels stay
+                // the doctor's to confirm.
+                const hostedLines = (draftTurns ?? []).map(
+                  (turn, i): DraftLine => ({
+                    id: `hosted-${i}`,
+                    speaker: turn.speaker,
+                    text: turn.text,
+                  }),
+                )
+                const timedLines = segmentsToDraft(segments, transcribed, { withOffsets })
                 const lines =
-                  draftTurns && draftTurns.length > 0
-                    ? draftTurns.map(
-                        (turn, i): DraftLine => ({
-                          id: `hosted-${i}`,
-                          speaker: turn.speaker,
-                          text: turn.text,
-                        }),
-                      )
-                    : segmentsToDraft(segments, transcribed, { withOffsets })
+                  hostedLines.length > 0
+                    ? hostedLines
+                    : timedLines.length > 0
+                      ? timedLines
+                      : proseToDraft(transcribed)
                 if (lines.length > 0) {
                   setDraft((current) =>
                     current

--- a/frontend/src/routes/ConsultationNew.tsx
+++ b/frontend/src/routes/ConsultationNew.tsx
@@ -18,11 +18,19 @@ import { Button } from '../ui/Button.js'
 import { Card, Skeleton } from '../ui/Card.js'
 import { PageHeader } from '../ui/PageHeader.js'
 
+/*
+ * Ordered by how central each path is to the product, not by how it was built.
+ *
+ * `fixture` stays the opening tab even though it is last. A reviewer arriving
+ * with no microphone and no Malay recording still has to be able to run the
+ * pipeline in one click, and defaulting to Record would put an empty capture
+ * screen in front of them instead.
+ */
 const TABS = [
-  { id: 'fixture', label: 'Bundled Case', Icon: FolderOpen },
-  { id: 'paste', label: 'Paste', Icon: Type },
-  { id: 'upload', label: 'Upload', Icon: FileUp },
   { id: 'record', label: 'Record', Icon: Mic },
+  { id: 'upload', label: 'Upload', Icon: FileUp },
+  { id: 'paste', label: 'Paste', Icon: Type },
+  { id: 'fixture', label: 'Bundled Case', Icon: FolderOpen },
 ] as const
 
 export function ConsultationNew() {
@@ -274,6 +282,7 @@ export function ConsultationNew() {
                   appendText(serialiseTurns(draftToTurns(draft)))
                   setDraft(null)
                 }}
+                canInsertPlain={turns.length > 0}
                 onInsertPlain={() => {
                   if (!draft) return
                   appendText(draft.map((line) => line.text).join(' '))
@@ -301,7 +310,13 @@ export function ConsultationNew() {
         )}
       </div>
 
-      {(text || draft) && (
+      {/*
+        Gated on the same tab condition as the textarea above, because this card
+        reports on that textarea. On the Bundled Case tab there is no editing
+        surface on screen, so a parse count for text the doctor cannot see reads
+        as a stray leftover from the tab they came from.
+      */}
+      {tab !== 'fixture' && (text || draft) && (
         <Card className="mt-4 p-4">
           <p className="text-sm font-medium">
             {turns.length} turn{turns.length === 1 ? '' : 's'} parsed


### PR DESCRIPTION
Found during final testing before the demo recording: a hosted (ILMU) transcription came back as plain text with no speaker labels, and Start Consultation could not be pressed.

## Three Defects, One Symptom

| | Defect |
| --- | --- |
| **Dead end** | A hosted recording carries no segments, so with no labels nothing drafted, the prose parsed to zero turns, and Start Consultation is disabled on exactly that. The recording had left the device and been billed for, with no message saying why it could not be used. |
| **Labelling fails on real input** | Measured against production: 180 chars labelled in 16 s, 653 in 19.5 s, 1,335 returned `draft_failed`. A consultation is several thousand. |
| **No sign of life** | Both hosted phases showed a static sentence for 20 s or more, indistinguishable from a hang. |

## The Labelling Fix Is Granularity, Not A Weaker Guard

Word-for-word reconstruction is all-or-nothing across whatever was submitted, so one drifted word in four thousand discarded every label. Chunking shrinks the blast radius and leaves the guarantee untouched, because each chunk is still aligned and re-sliced in full.

- **`sliceDeidentified` cuts after the gate, never before it.** Detection is context-sensitive, so `Ahmad Ismail` is one PATIENT span only while adjacent; chunking before de-identification would let an identifier straddling a boundary through.
- **It lives in `deid/`** because that module owns the brand. It takes a `Deidentified` and returns `Deidentified[]`, so it cannot launder a raw string, and `assertNoIdentifiers` now runs per chunk rather than once.
- **Cuts land only on whitespace**, so a vault token cannot be split into pieces that stop matching.
- **Four in flight at most**, because the 30,000-char request cap would otherwise allow 50 concurrent provider calls for one request (OWASP LLM10).

**A rejected chunk fails the whole pass.** Keeping the survivors and giving the rejected one its neighbour's speaker was written first and removed: it fabricates attribution, presenting up to 600 characters of patient speech as the doctor's with nothing marking it invented, and it would flow into the note and the red-flag engine that way.

## Measured Before And After

Same 2,543-character unpunctuated Malay stream, against the real provider:

| | Before | After |
| --- | --- | --- |
| Result | `draft_failed` | 11 turns, both speakers |
| Verbatim | n/a | every word |
| Time | n/a | 37.9 s, against a 150 s deadline |

## Also In This PR

- **Append as Plain Text is hidden when it cannot work.** Unlabelled text is only ever a continuation, so on an empty transcript that button produced zero turns and disabled Start Consultation: the doctor blocking themselves with the control beside the one that works.
- **The parse-count card** is gated on the tab that owns it, so returning to Bundled Case no longer leaves a count for text that is not on screen.
- **Tabs run Record, Upload, Paste, Bundled Case.** Bundled Case stays the opening tab: a reviewer with no microphone still has to run the pipeline in one click.
- **The draft-label instructions move into a tip**, keeping visible the one sentence that changes behaviour, that the labels are guesses.

## Verification

- [x] `bun run typecheck`
- [x] `bun run test`, **974 pass** (48 shared, 708 backend, 206 frontend, 12 evals)
- [x] `npx impeccable detect frontend/src`, clean
- [x] Chunking verified against the real provider, not only mocks
- [x] Each new guard verified by reverting it and confirming the matching test fails

## Clinical-Safety Checklist

Touches `deid/` and the `lib/llm/` egress path, so the checklist is mandatory.

- [x] No un-de-identified text reaches a provider. Slicing happens strictly after `deidentify()`
- [x] No new provider SDK import, no new outbound call site
- [x] Deterministic red-flag hits untouched
- [x] Citations untouched
- [x] No new log or audit field; failures still carry a closed reason only
- [x] No fabricated speaker attribution reaches the note
- [x] Reviewed by `phi-boundary-auditor`, which confirmed ordering, brand handling and vault scoping, and found the fan-out and the fabricated attribution now fixed

**Open, recorded in docs/trd.md 20.6:** partial success. One rejected chunk still costs the transcript its server labels, where per-chunk reporting could keep the rest. That needs a contract field marking a turn as undrafted so the client renders it unlabelled rather than inheriting a guess.

https://claude.ai/code/session_01FS7ViinLwxy7QsBz2XJnLx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Large hosted transcripts are processed in smaller chunks for more reliable draft labelling.
  - Transcription screens show elapsed time during hosted processing.
  - Added prose-only transcript drafting when timestamps or hosted labels are unavailable.
  - Added an “Append as Plain Text” option when a parsed transcript exists.
  - Added guidance for draft labelling through an information tooltip.
  - Reordered intake options and improved fallback handling for recording results.

- **Bug Fixes**
  - Improved transcript usability when hosted labelling returns no turns.
  - Preserved complete words and speaker continuity across transcript chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->