### PR TITLE
fix(asr): let a rejected chunk cost its own labels and nothing else

### DIFF
--- a/backend/src/draft-turns/index.test.ts
+++ b/backend/src/draft-turns/index.test.ts
@@ -146,15 +146,34 @@ describe('draftTurns over a consultation-length transcript', () => {
   })
 
   /*
-   * A rejected chunk fails the whole pass, deliberately.
+   * A rejected chunk costs its own labels and nothing else.
    *
-   * Keeping the other chunks and giving the rejected one its neighbour's
-   * speaker was the tempting alternative, and it fabricates attribution: up to
-   * a chunk of patient speech presented as the doctor's, with nothing marking
-   * it invented. Failing is safe because the client's fallback drafts labels on
-   * the device and says on screen that they are guesses.
+   * Failing the whole pass was the previous behaviour and it did not hold up:
+   * measured in production, a 2,543-character transcript still returned
+   * `draft_failed` at ~28 s, because all five chunks had to land. The opposite,
+   * giving the rejected chunk its neighbour's speaker, fabricates attribution.
+   * The marker is what makes the third option honest.
    */
-  it('fails rather than inventing a speaker for a rejected chunk', async () => {
+  it('keeps the labels the other chunks earned, and marks the one that failed', async () => {
+    const { text: content } = deidentify(longStream)
+    let call = 0
+    stubClient(async (request) => {
+      const chunk = (request as unknown as { content: string }).content
+      call += 1
+      // A dropped word, which is exactly what reconstruction refuses.
+      if (call === 2) return { turns: [{ speaker: 'patient', text: 'not the input' }] }
+      return { turns: [{ speaker: 'doctor', text: chunk }] }
+    })
+
+    const turns = await draftTurns(content)
+
+    expect(turns.some((turn) => turn.undrafted === true)).toBe(true)
+    expect(turns.some((turn) => turn.undrafted === undefined)).toBe(true)
+    const words = (text: string) => text.split(/\s+/).filter(Boolean)
+    expect(words(turns.map((turn) => turn.text).join(' '))).toEqual(words(content))
+  })
+
+  it('never folds an unlabelled span into a labelled neighbour', async () => {
     const { text: content } = deidentify(longStream)
     let call = 0
     stubClient(async (request) => {
@@ -164,7 +183,34 @@ describe('draftTurns over a consultation-length transcript', () => {
       return { turns: [{ speaker: 'doctor', text: chunk }] }
     })
 
-    await expect(draftTurns(content)).rejects.toBeInstanceOf(DraftTurnsError)
+    const turns = await draftTurns(content)
+
+    // Every neighbouring pair differs in speaker or in drafted state, so an
+    // unlabelled span is never hidden inside a labelled turn.
+    for (const [index, turn] of turns.entries()) {
+      const next = turns[index + 1]
+      if (next === undefined) continue
+      expect(
+        turn.speaker !== next.speaker || Boolean(turn.undrafted) !== Boolean(next.undrafted),
+      ).toBe(true)
+    }
+  })
+
+  it('discards an undrafted flag the model tries to set', async () => {
+    const { text: content } = deidentify('doctor good morning patient i have a cough')
+    stubClient(async (request) => ({
+      turns: [
+        {
+          speaker: 'doctor',
+          text: (request as unknown as { content: string }).content,
+          undrafted: true,
+        },
+      ],
+    }))
+
+    const turns = await draftTurns(content)
+
+    expect(turns.every((turn) => turn.undrafted === undefined)).toBe(true)
   })
 
   it('never opens more than four provider calls at once', async () => {

--- a/backend/src/draft-turns/index.ts
+++ b/backend/src/draft-turns/index.ts
@@ -52,12 +52,18 @@ const CHUNK_CHARS = 600
  * comes back as two same-speaker turns. Merging keeps the review list showing
  * the speaker changes the doctor is there to check, rather than the places the
  * text happened to be cut.
+ *
+ * An undrafted span never merges into a drafted one, in either direction. The
+ * whole purpose of the marker is that the doctor can see which text nothing
+ * labelled, and folding it into a labelled neighbour would hide exactly that.
  */
 function mergeAdjacent(turns: readonly DraftTurn[]): DraftTurn[] {
   const merged: DraftTurn[] = []
   for (const turn of turns) {
     const last = merged.at(-1)
-    if (last && last.speaker === turn.speaker) last.text = `${last.text} ${turn.text}`
+    const joinable =
+      last !== undefined && last.speaker === turn.speaker && !last.undrafted && !turn.undrafted
+    if (joinable && last !== undefined) last.text = `${last.text} ${turn.text}`
     else merged.push({ ...turn })
   }
   return merged
@@ -71,29 +77,47 @@ export async function draftTurns(content: Deidentified): Promise<DraftTurn[]> {
    * gives this pass 150 s and the adapter allows 60 s plus one retry, so
    * sequential chunks would blow through both on any real consultation.
    *
-   * A rejected chunk keeps its text and loses only its labels, which is the
-   * point of chunking at all. The whole pass still fails if *every* chunk
-   * fails, so a broken model or a blocked egress is never dressed up as a
-   * successful draft.
-   */
-  /*
-   * A rejected chunk fails the whole pass rather than being papered over.
+   * **A rejected chunk costs its own labels and nothing else.** Measured in
+   * production, failing the whole pass on one rejection meant a 2,543-character
+   * transcript still returned `draft_failed` at ~28 s, because five chunks each
+   * had to land: chunking had shrunk the failure, not removed it.
    *
-   * The tempting alternative was to keep the other chunks' labels and give the
-   * rejected one its neighbour's speaker. That fabricates attribution: up to
-   * `CHUNK_CHARS` of patient speech is presented as the doctor's, nothing in
-   * the response marks it as invented, and it flows into the note and the
-   * red-flag engine that way. Doctor review does not redeem it, because what
-   * is being reviewed is an undisclosed guess.
-   *
-   * Failing is safe here precisely because the client's fallback is now a real
-   * one: it drafts labels on the device from the same prose and says on screen
-   * that they are guesses. An honest local guess beats a server guess wearing
-   * the model's authority.
+   * The chunk ships its text with `undrafted` set instead. It is the only
+   * option that neither throws away the labels the other chunks earned nor
+   * invents attribution for the one that failed, and the marker is what makes
+   * the difference: the span arrives declared as unlabelled rather than wearing
+   * a speaker nothing supports.
    */
-  const drafted = await mapWithLimit(chunks, MAX_CONCURRENT_CHUNKS, draftChunk)
+  const failures: DraftTurnsFailureReason[] = []
+  const drafted = await mapWithLimit(chunks, MAX_CONCURRENT_CHUNKS, async (chunk) => {
+    try {
+      return await draftChunk(chunk)
+    } catch (cause) {
+      // The egress guard fired before any provider call, so it is not a
+      // labelling outcome and must not be softened into one.
+      if (cause instanceof DeidentificationError) throw cause
+      failures.push(cause instanceof DraftTurnsError ? cause.reason : 'llm_failed')
+      return null
+    }
+  })
 
-  return mergeAdjacent(drafted.flat())
+  // Every chunk failing is a broken pass, not a draft with no labels: a model
+  // outage or a systematically rejected echo must still surface as a failure
+  // rather than as a transcript the doctor has to label from scratch.
+  if (drafted.every((result) => result === null)) {
+    throw new DraftTurnsError(failures[0] ?? 'llm_failed')
+  }
+
+  const labelled: DraftTurn[] = drafted.flatMap((result, index) => {
+    if (result !== null) return result
+    const text = chunks[index]?.trim()
+    if (text === undefined || text === '') return []
+    // `speaker` is required by the contract and is a placeholder here, which is
+    // precisely what `undrafted` tells the client not to trust.
+    return [{ speaker: 'doctor' as const, text, undrafted: true }]
+  })
+
+  return mergeAdjacent(labelled)
 }
 
 /**

--- a/docs/trd.md
+++ b/docs/trd.md
@@ -1833,7 +1833,16 @@ A real consultation is several thousand characters, so the pass failed on exactl
 
 Measured after, same 2,543-character unpunctuated Malay stream: **11 turns, both speakers, every word verbatim, 37.9 s**, against a 150 s client deadline.
 
-**Open:** partial success is not available. One rejected chunk still costs the transcript its server labels, where per-chunk reporting could keep the rest. That needs a contract field marking a turn as undrafted so the client can render it unlabelled rather than inheriting a guess, and is deliberately not bundled here.
+**A rejected chunk costs its own labels and nothing else.** Failing the whole pass was tried first and did not hold up: measured in production, a 2,543-character transcript still returned `draft_failed` at ~28 s, because all five chunks had to land. Chunking had shrunk the failure rather than removed it.
+
+The span now ships with its text intact and `undrafted` set on the turn:
+
+- **The marker is server-set only.** `reconstructTurns` builds every returned turn from scratch, so a model emitting `undrafted` is ignored; pinned by a test.
+- **`speaker` is a placeholder on those turns**, which is exactly what the marker tells the client not to trust. It is never merged into a labelled neighbour, because hiding it inside one would defeat the point.
+- **The client renders it as needing a label**, not as a drafted one, and names the count above the list. Resolving it is the doctor's tap.
+- **Every chunk failing is still a failure**, so a model outage or a systematically rejected echo surfaces as `draft_failed` rather than as a transcript with no labels.
+
+Verified against the real provider on the same 2,543-character stream, in a run where one chunk was genuinely rejected: **6 turns, both speakers, 1 marked undrafted, every word verbatim, 39.5 s**. The same run under the previous rule returned `draft_failed`.
 
 #### Failure Taxonomy And Fallback
 

--- a/frontend/src/audio/SpeakerAssign.test.tsx
+++ b/frontend/src/audio/SpeakerAssign.test.tsx
@@ -94,3 +94,42 @@ describe('the plain-text control', () => {
     expect(screen.getByRole('button', { name: /plain text/i })).toBeTruthy()
   })
 })
+
+/*
+ * A span the server could not label arrives with a placeholder speaker and
+ * `undrafted` set. Rendering it as Doctor or Patient would be exactly the
+ * fabricated attribution the server refuses to send.
+ */
+describe('an unlabelled span', () => {
+  const MIXED: DraftLine[] = [
+    { id: 'a', speaker: 'doctor', text: 'What brings you in?' },
+    { id: 'b', speaker: 'doctor', text: 'batuk sudah tiga hari', undrafted: true },
+  ]
+
+  it('is not shown as a drafted label', () => {
+    setup(MIXED)
+    expect(screen.getByRole('button', { name: /needs a label/i })).toBeTruthy()
+  })
+
+  it('says how many lines still need a speaker', () => {
+    setup(MIXED)
+    expect(screen.getByText(/1 line could not be labelled/i)).toBeTruthy()
+  })
+
+  it('still shows the text, so no speech is hidden behind the marker', () => {
+    setup(MIXED)
+    expect(screen.getByText(/batuk sudah tiga hari/)).toBeTruthy()
+  })
+
+  it('reports the tap so the caller can resolve it', () => {
+    const handlers = setup(MIXED)
+    fireEvent.click(screen.getByRole('button', { name: /needs a label/i }))
+    expect(handlers.onToggle).toHaveBeenCalledWith('b')
+  })
+
+  it('says nothing about unlabelled lines when every line is drafted', () => {
+    setup([{ id: 'a', speaker: 'doctor', text: 'What brings you in?' }])
+    expect(screen.queryByText(/could not be labelled/i)).toBeNull()
+    expect(screen.queryByRole('button', { name: /needs a label/i })).toBeNull()
+  })
+})

--- a/frontend/src/audio/SpeakerAssign.tsx
+++ b/frontend/src/audio/SpeakerAssign.tsx
@@ -86,6 +86,8 @@ export function SpeakerAssign({
    */
   canInsertPlain: boolean
 }) {
+  const undraftedCount = draft.filter((line) => line.undrafted).length
+
   return (
     <div className="mt-4 border-t border-line pt-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -118,24 +120,47 @@ export function SpeakerAssign({
       <p className="mt-1 text-xs text-ink-muted">
         Labels are guessed from what each sentence says, not from the voices, and can be wrong.
       </p>
+      {/*
+        Named rather than left to be discovered by scrolling. These are the
+        lines nothing labelled, and the count is the difference between the
+        doctor knowing to look for them and applying a placeholder unread.
+      */}
+      {undraftedCount > 0 && (
+        <p className="mt-1 text-xs font-medium text-urgent">
+          {undraftedCount} line{undraftedCount === 1 ? '' : 's'} could not be labelled and need
+          {undraftedCount === 1 ? 's' : ''} a speaker.
+        </p>
+      )}
 
       <ul className="mt-3 flex max-h-80 flex-col gap-1 overflow-y-auto pr-1">
         {draft.map((line) => (
           <li key={line.id} className="flex items-start gap-2 text-sm">
+            {/*
+              An undrafted line reads as a question, not as an answer. Nothing
+              labelled this span, so showing it as Doctor or Patient would be
+              the fabricated attribution the server refuses to send: the control
+              says so, and picking either side resolves it.
+            */}
             <button
               type="button"
               onClick={() => onToggle(line.id)}
-              aria-label={`${line.speaker === 'doctor' ? 'Doctor' : 'Patient'}, switch to ${
-                line.speaker === 'doctor' ? 'Patient' : 'Doctor'
-              }`}
+              aria-label={
+                line.undrafted
+                  ? `Needs a label, set to ${line.speaker === 'doctor' ? 'Doctor' : 'Patient'}`
+                  : `${line.speaker === 'doctor' ? 'Doctor' : 'Patient'}, switch to ${
+                      line.speaker === 'doctor' ? 'Patient' : 'Doctor'
+                    }`
+              }
               className={cn(
                 'inline-flex h-8 w-18 shrink-0 items-center justify-center rounded-control border text-xs font-semibold transition-colors',
-                line.speaker === 'doctor'
-                  ? 'border-accent/40 bg-accent-soft text-accent hover:bg-accent-soft-hover'
-                  : 'border-line bg-sunken text-ink-muted hover:bg-line/60',
+                line.undrafted
+                  ? 'border-dashed border-urgent/50 bg-urgent/10 text-urgent hover:bg-urgent/20'
+                  : line.speaker === 'doctor'
+                    ? 'border-accent/40 bg-accent-soft text-accent hover:bg-accent-soft-hover'
+                    : 'border-line bg-sunken text-ink-muted hover:bg-line/60',
               )}
             >
-              {line.speaker === 'doctor' ? 'Doctor' : 'Patient'}
+              {line.undrafted ? 'Set' : line.speaker === 'doctor' ? 'Doctor' : 'Patient'}
             </button>
             <p className="min-w-0 pt-1.5 leading-relaxed">
               {line.offsetSeconds !== undefined && (

--- a/frontend/src/audio/draft-turns.ts
+++ b/frontend/src/audio/draft-turns.ts
@@ -31,6 +31,12 @@ export type DraftLine = {
   speaker: TranscriptTurn['speaker']
   text: string
   offsetSeconds?: number
+  /**
+   * Set when the server labelled the rest of the transcript but not this span,
+   * so `speaker` is a placeholder rather than a guess with anything behind it.
+   * The review list marks these instead of showing them as drafted.
+   */
+  undrafted?: boolean
 }
 
 type Speaker = TranscriptTurn['speaker']

--- a/frontend/src/routes/ConsultationNew.test.tsx
+++ b/frontend/src/routes/ConsultationNew.test.tsx
@@ -140,6 +140,24 @@ function MockAudioCapture({
       >
         mock transcribe hosted misheard
       </button>
+      {/* A hosted draft where one chunk came back unlabelled, so the server
+          marked it rather than inventing a speaker for it. */}
+      <button
+        type="button"
+        onClick={() =>
+          onTranscript({
+            text: 'What brings you in? batuk sudah tiga hari',
+            segments: [],
+            source: 'asr_hosted',
+            draftTurns: [
+              { speaker: 'doctor', text: 'What brings you in?' },
+              { speaker: 'doctor', text: 'batuk sudah tiga hari', undrafted: true },
+            ],
+          })
+        }
+      >
+        mock transcribe hosted partial
+      </button>
     </>
   )
 }
@@ -339,6 +357,40 @@ describe('hosted draft-turn labelling', () => {
       'Doctor: Any fever?\nPatient: Yesterday quite hot.\n' +
         'Patient: Any fever?\nPatient: Yesterday quite hot.',
     )
+  })
+  /*
+   * The labelling pass runs in chunks and a rejected chunk ships its text with
+   * `undrafted` set. The placeholder speaker is not a guess with anything behind
+   * it, so the doctor resolving it is what turns it into a label.
+   */
+  describe('an unlabelled span from a partial draft', () => {
+    it('is marked in the review list rather than shown as drafted', () => {
+      openRecordTab()
+      fireEvent.click(screen.getByRole('button', { name: 'mock transcribe hosted partial' }))
+
+      expect(screen.getByRole('button', { name: /needs a label/i })).toBeTruthy()
+      expect(screen.getByText(/1 line could not be labelled/i)).toBeTruthy()
+    })
+
+    it('stops being marked once the doctor sets it', () => {
+      openRecordTab()
+      fireEvent.click(screen.getByRole('button', { name: 'mock transcribe hosted partial' }))
+      fireEvent.click(screen.getByRole('button', { name: /needs a label/i }))
+
+      expect(screen.queryByRole('button', { name: /needs a label/i })).toBeNull()
+      expect(screen.queryByText(/could not be labelled/i)).toBeNull()
+    })
+
+    it('applies with every line carrying a speaker the doctor accepted', () => {
+      openRecordTab()
+      fireEvent.click(screen.getByRole('button', { name: 'mock transcribe hosted partial' }))
+      fireEvent.click(screen.getByRole('button', { name: /needs a label/i }))
+      fireEvent.click(screen.getByRole('button', { name: /apply labels/i }))
+
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+      expect(textarea.value).toMatch(/batuk sudah tiga hari/)
+      expect(textarea.value).not.toMatch(/undrafted/)
+    })
   })
 })
 

--- a/frontend/src/routes/ConsultationNew.tsx
+++ b/frontend/src/routes/ConsultationNew.tsx
@@ -62,10 +62,22 @@ export function ConsultationNew() {
   const appendText = (addition: string) =>
     setText((current) => (current ? `${current.trimEnd()}\n${addition}` : addition))
 
-  const flip = (line: DraftLine): DraftLine => ({
-    ...line,
-    speaker: line.speaker === 'doctor' ? 'patient' : 'doctor',
-  })
+  /*
+   * Flipping an undrafted line also resolves it. Its speaker was a placeholder
+   * the server declared it did not stand behind; once the doctor has picked a
+   * side it is theirs, so it stops being marked as needing one.
+   *
+   * The first tap on an undrafted line keeps the speaker shown and only clears
+   * the mark, so choosing the side already displayed takes one tap rather than
+   * two.
+   */
+  const flip = (line: DraftLine): DraftLine => {
+    if (line.undrafted) {
+      const { undrafted: _resolved, ...rest } = line
+      return rest
+    }
+    return { ...line, speaker: line.speaker === 'doctor' ? 'patient' : 'doctor' }
+  }
 
   const onUpload = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
@@ -217,6 +229,10 @@ export function ConsultationNew() {
                     id: `hosted-${i}`,
                     speaker: turn.speaker,
                     text: turn.text,
+                    // Carried through rather than dropped: a chunk the server
+                    // could not label arrives with a placeholder speaker, and
+                    // the review list has to say so.
+                    ...(turn.undrafted === true ? { undrafted: true } : {}),
                   }),
                 )
                 const timedLines = segmentsToDraft(segments, transcribed, { withOffsets })

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -101,6 +101,22 @@ export const HostedAsrResultSchema = z.object({
 export const DraftTurnSchema = z.object({
   speaker: SpeakerSchema,
   text: z.string().min(1).max(MAX_TURN_CHARACTERS),
+  /**
+   * Set when no label was drafted for this span and `speaker` is a placeholder.
+   *
+   * The labelling pass runs in chunks, and a chunk whose echo fails the
+   * verbatim reconstruction has no labels to give. The two alternatives were
+   * both wrong: failing the whole request threw away the labels every other
+   * chunk produced, and quietly giving the span its neighbour's speaker
+   * presents unlabelled patient speech as the doctor's with nothing marking it
+   * invented.
+   *
+   * So the span ships with its text intact and its uncertainty declared, and
+   * the client renders it as needing a label rather than as a drafted one.
+   * **Server-set only.** The model may emit this field and it is discarded:
+   * `reconstructTurns` builds each returned turn from scratch.
+   */
+  undrafted: z.boolean().optional(),
 })
 
 /**


### PR DESCRIPTION
Chunking shrank the labelling failure without removing it. Measured in production after it shipped, a 2,543-character transcript still returned `draft_failed` at ~28 s, because any rejected chunk failed the whole pass and all five had to land.

## Both Obvious Options Are Wrong

| Option | Why not |
| --- | --- |
| Fail everything | Throws away the labels every other chunk earned. This is what production was doing. |
| Give the chunk its neighbour's speaker | Presents unlabelled patient speech as the doctor's, with nothing marking it invented, and it flows into the note and the red-flag engine that way. |

The third option is to ship the span with its text intact and its uncertainty declared. `DraftTurn.undrafted` says the speaker on that turn is a placeholder, not a guess with anything behind it.

- **Server-set only.** `reconstructTurns` builds every returned turn from scratch, so a model emitting `undrafted` is discarded. Pinned by a test.
- **Never merged into a labelled neighbour**, in either direction. The marker exists so the doctor can see which text nothing labelled; folding it into a labelled turn would hide exactly that.
- **Every chunk failing is still a failure**, so a model outage surfaces as `draft_failed` rather than as a transcript with no labels.

## On Screen

The span renders as needing a label rather than as a drafted one: a dashed control reading **Set** instead of a speaker, and a count above the list naming how many are outstanding. The first tap accepts the speaker shown rather than flipping it, so choosing the displayed side costs one tap rather than two.

## Measured Against The Real Provider

Same 2,543-character unpunctuated Malay stream, in a run where one chunk was genuinely rejected:

| | Before | After |
| --- | --- | --- |
| Result | `draft_failed` | 6 turns, both speakers |
| Unlabelled spans | n/a | 1, marked |
| Verbatim | n/a | every word |
| Time | ~28 s to fail | 39.5 s |

## Verification

- [x] `bun run typecheck`
- [x] `bun run test`, **984 pass** (48 shared, 710 backend, 214 frontend, 12 evals)
- [x] `npx impeccable detect frontend/src`, clean
- [x] Verified against the real provider in a run that actually hit the failure path, not only mocks

## Clinical-Safety Checklist

Touches the `lib/llm/` egress path.

- [x] No un-de-identified text reaches a provider; slicing still happens strictly after `deidentify()`
- [x] No new provider SDK import, no new outbound call site
- [x] Deterministic red-flag hits untouched
- [x] Citations untouched
- [x] No new log or audit field
- [x] **No fabricated speaker attribution reaches the note.** This PR exists to remove the last path that could produce one
- [x] The doctor still applies every label explicitly; the review gate is unchanged

https://claude.ai/code/session_01FS7ViinLwxy7QsBz2XJnLx