### PR TITLE
fix(ui): open the intake screen on Record

### DIFF
--- a/frontend/src/demo/DemoTour.tsx
+++ b/frontend/src/demo/DemoTour.tsx
@@ -83,7 +83,7 @@ export const TOUR_STEPS: TourStep[] = [
     label: 'Intake',
     route: '/consultations/new',
     target: '[data-tour="intake"]',
-    hint: 'A consultation starts as a transcript. Load a bundled case, paste one, or upload a file. All three feed one parser.',
+    hint: 'A consultation starts as a transcript. Record it, upload or paste one, or load a bundled case. All four feed one parser.',
   },
   {
     label: 'Transcript',

--- a/frontend/src/routes/ConsultationNew.tsx
+++ b/frontend/src/routes/ConsultationNew.tsx
@@ -19,12 +19,11 @@ import { Card, Skeleton } from '../ui/Card.js'
 import { PageHeader } from '../ui/PageHeader.js'
 
 /*
- * Ordered by how central each path is to the product, not by how it was built.
+ * Ordered by how central each path is to the product, not by how it was built,
+ * and the first tab is the one that opens.
  *
- * `fixture` stays the opening tab even though it is last. A reviewer arriving
- * with no microphone and no Malay recording still has to be able to run the
- * pipeline in one click, and defaulting to Record would put an empty capture
- * screen in front of them instead.
+ * A reviewer with no microphone is one tab away from the bundled cases, which
+ * is the right cost to put on the path that is not the product. Recording is.
  */
 const TABS = [
   { id: 'record', label: 'Record', Icon: Mic },
@@ -35,7 +34,7 @@ const TABS = [
 
 export function ConsultationNew() {
   const navigate = useNavigate()
-  const [tab, setTab] = useState<(typeof TABS)[number]['id']>('fixture')
+  const [tab, setTab] = useState<(typeof TABS)[number]['id']>(TABS[0].id)
   const [text, setText] = useState('')
   const [source, setSource] = useState<TranscriptSource>('fixture')
   /*


### PR DESCRIPTION
Record is the product; the bundled cases are the way to try it without a microphone. The screen opened on the cases, so the path that matters was one the doctor had to go and find.

The tab order already put Record first, which left the last tab selected and reading as an accident. The opening tab is now `TABS[0].id` rather than a second constant that can drift from the order.

The tour hint named three intake paths and omitted the one now in front of the viewer, so it names four.

## Verification

- [x] `bun run --cwd frontend typecheck`
- [x] `bun run --cwd frontend test`, 214 pass
- [x] `npx impeccable detect frontend/src`, clean
- [x] Mounting the Record tab does not prewarm the speech model; that is posted at record start, so opening the page downloads nothing

## Clinical-Safety Checklist

Not applicable by diff: no `deid/`, `lib/llm/`, `lib/asr/`, `redflags/`, `guidelines/` or logging path is touched.

https://claude.ai/code/session_01FS7ViinLwxy7QsBz2XJnLx